### PR TITLE
Point to git@github.com url for Gutenberg's repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "gutenberg"]
 	path = gutenberg
-	url = https://github.com/wordpress/gutenberg
+	url = git@github.com:WordPress/gutenberg.git


### PR DESCRIPTION
To allow us to push to GB's repo using keys instead of http credentials.