### PR TITLE
Register and load Code block

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,18 @@
 {
   "presets": ["babel-preset-expo"],
+  "plugins": [
+    [
+      "module-resolver",
+      {
+        "alias": {
+          "@wordpress/hooks": "./wordpress/hooks",
+          "@wordpress/i18n": "./gutenberg/i18n",
+          "@gutenberg": "./gutenberg"
+        },
+        "extensions": [".js", ".ios.js", ".android.js"]
+      }
+    ]
+  ],
   "env": {
     "development": {
       "plugins": ["transform-react-jsx-source"]

--- a/.flowconfig
+++ b/.flowconfig
@@ -70,6 +70,7 @@ module.file_ext=.ios.js
 munge_underscores=true
 
 module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> 'RelativeImageStub'
+module.name_mapper='@gutenberg' -> '<PROJECT_ROOT>/gutenberg'
 
 suppress_type=$FlowIssue
 suppress_type=$FlowFixMe

--- a/block-management/block-holder.js
+++ b/block-management/block-holder.js
@@ -34,7 +34,7 @@ export default class BlockHolder extends React.Component<PropsType, StateType> {
 
 	getBlockForType() {
 		if ( this.props.blockType === 'code' ) {
-			const blockType = getBlockType('core/code');
+			const blockType = getBlockType( 'core/code' );
 			const Code = blockType.edit;
 			// TODO: input text needs to be kept by updating the attributes
 			return (

--- a/block-management/block-holder.js
+++ b/block-management/block-holder.js
@@ -8,7 +8,7 @@ import { StyleSheet, View, Text, TouchableWithoutFeedback } from 'react-native';
 import Toolbar from './toolbar';
 
 // Gutenberg imports
-import { settings as codeBlock } from '../gutenberg/blocks/library/code';
+import { getBlockType } from '@gutenberg/blocks/api';
 
 type PropsType = {
 	index: number,
@@ -34,7 +34,8 @@ export default class BlockHolder extends React.Component<PropsType, StateType> {
 
 	getBlockForType() {
 		if ( this.props.blockType === 'code' ) {
-			const Code = codeBlock.edit;
+			const blockType = getBlockType('core/code');
+			const Code = blockType.edit;
 			// TODO: input text needs to be kept by updating the attributes
 			return (
 				<Code

--- a/block-management/block-holder.js
+++ b/block-management/block-holder.js
@@ -33,8 +33,8 @@ export default class BlockHolder extends React.Component<PropsType, StateType> {
 	}
 
 	getBlockForType() {
-		if ( this.props.blockType === 'code' ) {
-			const blockType = getBlockType( 'core/code' );
+		const blockType = getBlockType( this.props.blockType );
+		if ( blockType ) {
 			const Code = blockType.edit;
 			// TODO: input text needs to be kept by updating the attributes
 			return (

--- a/block-management/block-holder.js
+++ b/block-management/block-holder.js
@@ -35,11 +35,11 @@ export default class BlockHolder extends React.Component<PropsType, StateType> {
 	getBlockForType() {
 		const blockType = getBlockType( this.props.blockType );
 		if ( blockType ) {
-			const Code = blockType.edit;
-			// TODO: input text needs to be kept by updating the attributes
+			const Block = blockType.edit;
+			// TODO: setAttributes needs to change the state/attributes
 			return (
-				<Code
-					attributes={ { content: this.props.content } }
+				<Block
+					attributes={ { ...this.props } }
 					setAttributes={ attrs => console.log( { attrs } ) }
 				/>
 			);

--- a/block-management/block-manager.js
+++ b/block-management/block-manager.js
@@ -8,6 +8,8 @@ import { StyleSheet, Text, View, FlatList, TextInput } from 'react-native';
 import BlockHolder from './block-holder';
 import { ToolbarButton } from './constants';
 
+import { registerCoreBlocks } from '@gutenberg/blocks/library';
+
 type PropsType = {};
 type StateType = {
 	refresh: boolean,
@@ -17,6 +19,9 @@ type StateType = {
 export default class BlockManager extends React.Component<PropsType, StateType> {
 	constructor( props: PropsType ) {
 		super( props );
+
+		registerCoreBlocks();
+
 		// TODO: block state should be externalized (shared with Gutenberg at some point?).
 		// If not it should be created from a string parsing (commented HTML to json).
 		this.state = {

--- a/block-management/block-manager.js
+++ b/block-management/block-manager.js
@@ -49,7 +49,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 				},
 				{
 					key: '3',
-					blockType: 'code',
+					blockType: 'core/code',
 					content: 'if name == "World":\n    return "Hello World"\nelse:\n    return "Hello Pony"',
 					focused: false,
 				},

--- a/package.json
+++ b/package.json
@@ -24,7 +24,12 @@
     "prettier-check": "prettier -l *.js *block-management/*.js"
   },
   "jest": {
-    "preset": "jest-expo"
+    "preset": "jest-expo",
+    "moduleNameMapper": {
+      "@wordpress/hooks": "<rootDir>/wordpress/hooks",
+      "@wordpress/i18n": "<rootDir>/gutenberg/i18n",
+      "@gutenberg": "<rootDir>/gutenberg"
+    }
   },
   "dependencies": {
     "babel-plugin-module-resolver": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "preset": "jest-expo"
   },
   "dependencies": {
+    "babel-plugin-module-resolver": "^3.1.0",
     "classnames": "^2.2.5",
     "expo": "^25.0.0",
     "jed": "^1.1.1",

--- a/wordpress/hooks.js
+++ b/wordpress/hooks.js
@@ -1,0 +1,9 @@
+/** @format */
+
+export function hasFilter() {
+	return false;
+}
+
+export function applyFilters( filter, props, blockType, attributes ) {
+	return props;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -682,6 +682,16 @@ babel-plugin-module-resolver@^2.7.1:
     glob "^7.1.1"
     resolve "^1.2.0"
 
+babel-plugin-module-resolver@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.1.0.tgz#cf7868bd2c1818f855aede16141009b87dd1f95b"
+  dependencies:
+    find-babel-config "^1.1.0"
+    glob "^7.1.2"
+    pkg-up "^2.0.0"
+    reselect "^3.0.1"
+    resolve "^1.4.0"
+
 babel-plugin-react-transform@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-react-transform/-/babel-plugin-react-transform-3.0.0.tgz#402f25137b7bb66e9b54ead75557dfbc7ecaaa74"
@@ -2702,7 +2712,7 @@ finalhandler@1.1.1:
     statuses "~1.4.0"
     unpipe "~1.0.0"
 
-find-babel-config@^1.0.1:
+find-babel-config@^1.0.1, find-babel-config@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.1.0.tgz#acc01043a6749fec34429be6b64f542ebb5d6355"
   dependencies:
@@ -5359,6 +5369,12 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
+  dependencies:
+    find-up "^2.1.0"
+
 plist@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/plist/-/plist-2.0.1.tgz#0a32ca9481b1c364e92e18dc55c876de9d01da8b"
@@ -6140,6 +6156,10 @@ reqwest@2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/reqwest/-/reqwest-2.0.5.tgz#00fb15ac4918c419ca82b43f24c78882e66039a1"
 
+reselect@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
@@ -6158,7 +6178,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.2.0:
+resolve@^1.2.0, resolve@^1.4.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.6.0.tgz#0fbd21278b27b4004481c395349e7aba60a9ff5c"
   dependencies:


### PR DESCRIPTION
Uses GB code to register and retrieve the `Code` block.

Note: Needs updating the submodule

Note 2: currently tests give out console error (`Block "core/code" is already registered.`) because the registration happens twice (2 tests in `App.test.js`). We need to figure out a better way to handle the registration lifecycle.