### PR TITLE
Use the .native.js file extension

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,7 +9,7 @@
           "@wordpress/i18n": "./gutenberg/i18n",
           "@gutenberg": "./gutenberg"
         },
-        "extensions": [".js", ".ios.js", ".android.js"]
+        "extensions": [".js", ".native.js", ".ios.js", ".android.js"]
       }
     ]
   ],


### PR DESCRIPTION
The GB has been updated to use single `.native.js` files for platform specific code instead of the dual `.android.js`+`.ios.js`.