### PR TITLE
Auto import React, don't import it in GB code

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,7 @@
     "babel-preset-react-native-stage-0/decorator-support"
   ],
   "plugins": [
+    "react-require",
     [
       "module-resolver",
       {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "devDependencies": {
     "@wordpress/babel-preset-default": "^1.1.2",
+    "babel-plugin-react-require": "^3.0.0",
     "babel-plugin-transform-async-generator-functions": "^6.24.1",
     "babel-preset-react-native-stage-0": "^1.0.1",
     "cross-env": "^5.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -517,6 +517,10 @@ babel-plugin-module-resolver@^3.1.0:
     reselect "^3.0.1"
     resolve "^1.4.0"
 
+babel-plugin-react-require@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-react-require/-/babel-plugin-react-require-3.0.0.tgz#2e4e7b4496b93a654a1c80042276de4e4eeb20e3"
+
 babel-plugin-react-transform@2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-react-transform/-/babel-plugin-react-transform-2.0.2.tgz#515bbfa996893981142d90b1f9b1635de2995109"


### PR DESCRIPTION
When imported directly in GB code, GB's eslint errors out because it
finds React as an unused import. So, leaving it out and auto-importing
it in the RN project.

To test:
* Make sure you've run `git submodule update` to get the latest of the GB branch
* run `npm run lint` inside the `gutenberg` subdir and notice no error occurs