### PR TITLE
Updates gitignore. Adds vscode settings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,8 @@ DerivedData
 *.xcuserstatee
 
 # VSCode local config dir
-.vscode/
-
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+    	"flowtype.flow-for-vscode",
+        "ms-vscode.js-atom-grammar"
+    ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
     "recommendations": [
-    	"flowtype.flow-for-vscode",
-        "ms-vscode.js-atom-grammar"
+    	"gcazaciuc.vscode-flow-ide"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "flow.useNPMPackagedFlow": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "flow.useNPMPackagedFlow": true
+    "javascript.validate.enable": false
 }


### PR DESCRIPTION
### Description:

This PR updates the .gitignore file with the [latest GitHub settings for vscode](https://github.com/github/gitignore/blob/master/Global/VisualStudioCode.gitignore).

It also adds the default settings for vscode, and the recommended extensions.

### Testing

Before starting, make sure you uninstall the "Flow Language Support" and "JavaScript Atom Grammar" extensions from VS Code.

1. Make a fresh clone of this repository.
2. Launch VisualStudioCode.app and open the fresh clone of `mobile-gutenberg`.
3. Make sure you see the following recommendation in the bottom-left corner:

<img width="459" alt="screen shot 2018-04-05 at 12 15 39" src="https://user-images.githubusercontent.com/1836005/38375485-ba516a36-38cc-11e8-8d30-2c3373b5bca7.png">

4. Tap on "Show Recommendations" and make sure you see this addon

<img width="356" alt="screen shot 2018-04-05 at 14 04 30" src="https://user-images.githubusercontent.com/1836005/38380507-56aed9d8-38da-11e8-9381-71973e9252c1.png">

5. Press `CMD ,`.  Select the "Workspace Settings" tab and make sure you see `"javascript.validate.enable": false`