### PR TITLE
Load the data package from local GB source tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
   },
   "dependencies": {
     "@wordpress/autop": "^1.0.6",
-    "@wordpress/data": "^1.0.0-alpha.2",
     "@wordpress/deprecated": "^1.0.0-alpha.2",
     "@wordpress/hooks": "^1.2.0",
     "@wordpress/i18n": "^1.1.0",

--- a/rn-cli.config.js
+++ b/rn-cli.config.js
@@ -13,7 +13,7 @@ module.exports = {
 		// On the other hand, GB packages that are loaded from the source tree directly
 		// are automagically resolved by Metro so, there is no list of them anywhere.
 		return blacklist( [
-			/gutenberg\/packages\/(autop|data|deprecated|hooks|i18n|is-shallow-equal)\/.*/,
+			/gutenberg\/packages\/(autop|deprecated|hooks|i18n|is-shallow-equal)\/.*/,
 		] );
 	},
 	getTransformModulePath() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -533,30 +533,9 @@
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@wordpress/browserslist-config/-/browserslist-config-2.1.4.tgz#2297713d53424dec835eed4895abd4ceb3cac297"
 
-"@wordpress/data@^1.0.0-alpha.2":
-  version "1.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@wordpress/data/-/data-1.0.0-alpha.2.tgz#71370eac999836694f06b959c6cbcaa5f8481b2d"
-  dependencies:
-    "@wordpress/deprecated" "^1.0.0-alpha.2"
-    "@wordpress/element" "^1.0.0-alpha.2"
-    "@wordpress/is-shallow-equal" "1.0.2"
-    equivalent-key-map "0.2.0"
-    lodash "4.17.5"
-    redux "3.7.2"
-
 "@wordpress/deprecated@^1.0.0-alpha.2":
   version "1.0.0-alpha.2"
   resolved "https://registry.yarnpkg.com/@wordpress/deprecated/-/deprecated-1.0.0-alpha.2.tgz#3af32f454e302c95910381157093df9c0f9ed753"
-
-"@wordpress/element@^1.0.0-alpha.2":
-  version "1.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-1.0.0-alpha.2.tgz#33059ebaa2680e572783841c86b0aceeb1cb977a"
-  dependencies:
-    "@wordpress/deprecated" "^1.0.0-alpha.2"
-    "@wordpress/is-shallow-equal" "1.0.2"
-    lodash "4.17.5"
-    react "16.4.1"
-    react-dom "16.4.1"
 
 "@wordpress/hooks@^1.2.0":
   version "1.2.0"
@@ -571,7 +550,7 @@
     lodash "^4.17.5"
     memize "^1.0.5"
 
-"@wordpress/is-shallow-equal@1.0.2", "@wordpress/is-shallow-equal@^1.0.1":
+"@wordpress/is-shallow-equal@^1.0.1":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@wordpress/is-shallow-equal/-/is-shallow-equal-1.0.2.tgz#9368bedc69d5ec08f46ff7b188a0d48c6499818c"
 
@@ -1963,12 +1942,13 @@ browserify-cipher@^1.0.0:
     evp_bytestokey "^1.0.0"
 
 browserify-des@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/browserify-des/-/browserify-des-1.0.1.tgz#3343124db6d7ad53e26a8826318712bdc8450f9c"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/browserify-des/-/browserify-des-1.0.2.tgz#3af4f1f59839403572f1c66204375f7a7f703e9c"
   dependencies:
     cipher-base "^1.0.1"
     des.js "^1.0.0"
     inherits "^2.0.1"
+    safe-buffer "^5.1.2"
 
 browserify-rsa@^4.0.0:
   version "4.0.1"
@@ -2095,8 +2075,8 @@ camelcase@^3.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
 
 caniuse-lite@^1.0.30000844:
-  version "1.0.30000864"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000864.tgz#7a08c78da670f23c06f11aa918831b8f2dd60ddc"
+  version "1.0.30000865"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000865.tgz#70026616e8afe6e1442f8bb4e1092987d81a2f25"
 
 capture-exit@^1.2.0:
   version "1.2.0"
@@ -2851,7 +2831,7 @@ envinfo@^3.0.0:
     os-name "^2.0.1"
     which "^1.2.14"
 
-equivalent-key-map@0.2.0, equivalent-key-map@^0.2.0:
+equivalent-key-map@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/equivalent-key-map/-/equivalent-key-map-0.2.0.tgz#10acd3f327a1a07ff3eba39e40887ef9aad01004"
 
@@ -3760,11 +3740,11 @@ hash-base@^3.0.0:
     safe-buffer "^5.0.1"
 
 hash.js@^1.0.0, hash.js@^1.0.3:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.4.tgz#8b50e1f35d51bd01e5ed9ece4dbe3549ccfa0a3c"
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.5.tgz#e38ab4b85dfb1e0c40fe9265c0e9b54854c23812"
   dependencies:
     inherits "^2.0.3"
-    minimalistic-assert "^1.0.0"
+    minimalistic-assert "^1.0.1"
 
 hawk@~3.1.3:
   version "3.1.3"
@@ -4643,6 +4623,10 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+
 js-yaml@^3.7.0, js-yaml@^3.9.0, js-yaml@^3.9.1:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
@@ -4914,10 +4898,6 @@ lodash.unescape@4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
 
-lodash@4.17.5:
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
-
 lodash@^3.5.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
@@ -4942,10 +4922,10 @@ longest@^1.0.1:
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
-    js-tokens "^3.0.0"
+    js-tokens "^3.0.0 || ^4.0.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -5258,7 +5238,7 @@ min-document@^2.19.0:
   dependencies:
     dom-walk "^0.1.0"
 
-minimalistic-assert@^1.0.0:
+minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
 
@@ -6211,7 +6191,7 @@ react-devtools-core@3.1.0:
     shell-quote "^1.6.1"
     ws "^2.0.3"
 
-react-dom@16.4.1, react-dom@^16.2.0:
+react-dom@^16.2.0:
   version "16.4.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.1.tgz#7f8b0223b3a5fbe205116c56deb85de32685dad6"
   dependencies:
@@ -6365,15 +6345,6 @@ react@16.3.1:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react@16.4.1:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.4.1.tgz#de51ba5764b5dbcd1f9079037b862bd26b82fe32"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
-
 react@^0.14.0:
   version "0.14.9"
   resolved "https://registry.yarnpkg.com/react/-/react-0.14.9.tgz#9110a6497c49d44ba1c0edd317aec29c2e0d91d1"
@@ -6452,7 +6423,7 @@ redux-devtools-instrument@^1.3.3:
     lodash "^4.2.0"
     symbol-observable "^1.0.2"
 
-redux@3.7.2, redux@^3.7.2:
+redux@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
   dependencies:
@@ -6970,8 +6941,8 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
 
 shortid@^2.2.6:
-  version "2.2.10"
-  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.10.tgz#3d296472434d5c73d31310225e6a6b2a70984495"
+  version "2.2.11"
+  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.11.tgz#a77896f086b0dae7fce1237e29232d2aeef5738e"
   dependencies:
     nanoid "^1.0.7"
 


### PR DESCRIPTION
## Fixes #67 

With #66, the `@wordpress/data` package is pulled from NPM while the `@wordpress/element` from local GB source. Thing is, `data` tries to pull in the `element` package as well and that gets resolved from NPM. Apparently this ends up messing up with the locally loaded `element` package too. So, even though the `data` package doesn't contain any mobile native code (and thus we could just pull it from NPM) we seem forced to load it from local too.

This PR let's `@wordpress/data` be resolved from the local GB source tree.

### To test

1. Delete the local `node_modules` folder
2. Install the packages: `yarn install`
3. Clean-Start the bundler: `yarn start:reset`
4. In a separate terminal window build/install the app: `yarn android` or `yarn ios`
5. Notice the app launching normally
