### PR TITLE
Stops deleting yarn.lock on clean.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "prettier": "prettier-eslint --write $npm_package_config_jsfiles $npm_package_config_scssfiles",
     "clean": "yarn clean:setup; yarn clean:runtime",
     "clean:runtime": "yarn cache clean; yarn test --clearCache; watchman watch-del-all; rm -rf $TMPDIR/react-*; rm -rf $TMPDIR/metro-cache-*; rm -rf $TMPDIR/jest_*",
-    "clean:setup": "rm -rf node_modules; rm -f yarn.lock",
+    "clean:setup": "rm -rf node_modules",
     "clean:install": "yarn clean; yarn",
     "lint": "eslint $npm_package_config_jsfiles",
     "lint:fix": "eslint $npm_package_config_jsfiles --fix"


### PR DESCRIPTION
This PR is a tiny change that will prevent yarn.lock from being deleted when doing `yarn clean` or modified when doing `yarn install`.

This is actually a positive change for development, to avoid having all PRs updating `yarn.lock` continuously, which could introduce seemingly-random and actually-unrelated issues.

It will allow us to separate updates to that file into a task of its own.

Running `yarn install` will still make sure you have the required dependencies for the branch you're in, so this should not affect our ability to stay up to date when changing branches.

### Testing:

- Do `yarn clean` and make sure the `yarn.lock` isn't deleted.
- Do `yarn install` and make sure the `yarn.lock` isn't modified.
- Run the app and make sure there are no outstanding errors.