### PR TITLE
Update to latest GB master

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,7 +10,6 @@
         "cwd": "babelrc",
         "alias": {
           "react-native-aztec": "./react-native-aztec",
-          "@wordpress/blocks": "./blocks",
           "@wordpress/editor": "./editor",
           "@gutenberg": "./gutenberg"
         },

--- a/.flowconfig
+++ b/.flowconfig
@@ -85,6 +85,7 @@ munge_underscores=true
 
 module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> 'RelativeImageStub'
 module.name_mapper='@gutenberg' -> '<PROJECT_ROOT>/gutenberg'
+module.name_mapper='@wordpress/blocks' -> '<PROJECT_ROOT>/gutenberg/packages/blocks/src'
 module.name_mapper='@wordpress/data' -> '<PROJECT_ROOT>/gutenberg/packages/data'
 module.name_mapper='@wordpress/element' -> '<PROJECT_ROOT>/gutenberg/packages/element'
 module.name_mapper='@wordpress/deprecated' -> '<PROJECT_ROOT>/gutenberg/packages/deprecated'

--- a/jest.config.js
+++ b/jest.config.js
@@ -30,8 +30,8 @@ module.exports = {
 		'node',
 	],
 	moduleNameMapper: {
-		'@wordpress\\/(blocks|editor)$': '<rootDir>/gutenberg/$1',
-		'@wordpress\\/(data|element|deprecated)$': '<rootDir>/gutenberg/packages/$1/src/index',
+		'@wordpress\\/(editor)$': '<rootDir>/gutenberg/$1',
+		'@wordpress\\/(blocks|data|element|deprecated)$': '<rootDir>/gutenberg/packages/$1/src/index',
 		'@gutenberg': '<rootDir>/gutenberg',
 
 		// Mock the CSS modules. See https://facebook.github.io/jest/docs/en/webpack.html#handling-static-assets

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "@wordpress/babel-preset-default": "^1.1.2",
+    "@wordpress/block-serialization-spec-parser": "^1.0.0",
     "babel-eslint": "^8.2.2",
     "babel-plugin-react-native-classname-to-style": "^1.2.1",
     "babel-plugin-react-native-platform-specific-extensions": "^1.0.1",
@@ -61,6 +62,7 @@
   },
   "dependencies": {
     "@wordpress/autop": "^1.0.6",
+    "@wordpress/compose": "^1.0.1",
     "@wordpress/deprecated": "^1.0.0-alpha.2",
     "@wordpress/hooks": "^1.2.1",
     "@wordpress/i18n": "^1.1.0",

--- a/rn-cli.config.js
+++ b/rn-cli.config.js
@@ -13,7 +13,7 @@ module.exports = {
 		// On the other hand, GB packages that are loaded from the source tree directly
 		// are automagically resolved by Metro so, there is no list of them anywhere.
 		return blacklist( [
-			/gutenberg\/packages\/(autop|deprecated|hooks|i18n|is-shallow-equal)\/.*/,
+			/gutenberg\/packages\/(autop|compose|deprecated|hooks|i18n|is-shallow-equal)\/.*/,
 		] );
 	},
 	getTransformModulePath() {

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -13,7 +13,7 @@ import type { BlockType } from '../store/';
 import styles from './block-holder.scss';
 
 // Gutenberg imports
-import { getBlockType } from '@gutenberg/blocks/api';
+import { getBlockType } from '@wordpress/blocks';
 
 type PropsType = BlockType & {
 	onChange: ( uid: string, attributes: mixed ) => void,

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -14,7 +14,7 @@ import type { BlockType } from '../store/';
 import styles from './block-manager.scss';
 
 // Gutenberg imports
-import { getBlockType, serialize } from '@gutenberg/blocks/api';
+import { getBlockType, serialize } from '@wordpress/blocks';
 
 export type BlockListType = {
 	onChange: ( uid: string, attributes: mixed ) => void,

--- a/src/globals.js
+++ b/src/globals.js
@@ -2,6 +2,7 @@
 
 import { createElement } from '@wordpress/element';
 import jsdom from 'jsdom-jscore';
+import jsdomLevel1Core from 'jsdom-jscore/lib/jsdom/level1/core';
 
 global.wp = {
 	element: {
@@ -18,3 +19,7 @@ doc.implementation.createHTMLDocument = function( html ) {
 
 // `hpq` depends on `document` be available globally
 global.document = doc;
+
+if ( ! global.window.Node ) {
+	global.window.Node = jsdomLevel1Core.dom.level1.core.Node;
+}

--- a/src/parser/block-parser-code.test.js
+++ b/src/parser/block-parser-code.test.js
@@ -3,7 +3,7 @@
 import '../globals';
 
 import { registerCoreBlocks } from '@gutenberg/core-blocks';
-import { parse } from '@gutenberg/blocks';
+import { parse } from '@wordpress/blocks';
 
 registerCoreBlocks();
 
@@ -14,7 +14,7 @@ describe( 'Parser', () => {
 		else:
 			return "Hello Pony"`;
 
-	const originalCodeBlockHtml = `<pre><code>${ codeContent }</code></pre>`;
+	const originalCodeBlockHtml = `<pre class="wp-block-code"><code>${ codeContent }</code></pre>`;
 
 	const gbCodeBlockHtml = `
 		<!-- wp:code -->

--- a/src/parser/block-parser-more.test.js
+++ b/src/parser/block-parser-more.test.js
@@ -3,7 +3,7 @@
 import '../globals';
 
 import { registerCoreBlocks } from '@gutenberg/core-blocks';
-import { parse } from '@gutenberg/blocks';
+import { parse } from '@wordpress/blocks';
 
 registerCoreBlocks();
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -5,7 +5,7 @@
 
 // Gutenberg imports
 import { registerCoreBlocks } from '@gutenberg/core-blocks';
-import { parse } from '@gutenberg/blocks';
+import { parse } from '@wordpress/blocks';
 
 import { createStore } from 'redux';
 import { reducer } from './reducers';
@@ -28,7 +28,7 @@ registerCoreBlocks();
 
 const initialCodeBlockHtml = `
 <!-- wp:code -->
-<pre><code>if name == "World":
+<pre class="wp-block-code"><code>if name == "World":
     return "Hello World"
 else:
     return "Hello Pony"</code></pre>

--- a/yarn.lock
+++ b/yarn.lock
@@ -536,15 +536,39 @@
     babel-plugin-transform-runtime "^6.23.0"
     babel-preset-env "^1.6.1"
 
+"@wordpress/block-serialization-spec-parser@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/block-serialization-spec-parser/-/block-serialization-spec-parser-1.0.0.tgz#a51a9276421629d4be398dfcc9bab52e303c3403"
+
 "@wordpress/browserslist-config@^2.1.4":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@wordpress/browserslist-config/-/browserslist-config-2.2.0.tgz#7fcc77db40d4d846dbb158e485a6badc143c76d2"
 
-"@wordpress/deprecated@^1.0.0-alpha.2":
+"@wordpress/compose@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/compose/-/compose-1.0.1.tgz#fdfb24b27390ca97db432108c47188b4fc96dea8"
+  dependencies:
+    "@babel/runtime" "^7.0.0-beta.52"
+    "@wordpress/element" "^1.0.1"
+    "@wordpress/is-shallow-equal" "^1.1.1"
+    lodash "^4.17.10"
+
+"@wordpress/deprecated@^1.0.0-alpha.2", "@wordpress/deprecated@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@wordpress/deprecated/-/deprecated-1.0.1.tgz#8769d791b228022caef156dbbff0f21eb2b21f3e"
   dependencies:
     "@babel/runtime" "^7.0.0-beta.52"
+
+"@wordpress/element@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-1.0.1.tgz#d9e31e437793655556816e6328bc67bfbecc4a27"
+  dependencies:
+    "@babel/runtime" "^7.0.0-beta.52"
+    "@wordpress/deprecated" "^1.0.1"
+    "@wordpress/is-shallow-equal" "^1.1.1"
+    lodash "^4.17.10"
+    react "^16.4.1"
+    react-dom "^16.4.1"
 
 "@wordpress/hooks@^1.2.1":
   version "1.3.1"
@@ -562,7 +586,7 @@
     lodash "^4.17.10"
     memize "^1.0.5"
 
-"@wordpress/is-shallow-equal@^1.0.1":
+"@wordpress/is-shallow-equal@^1.0.1", "@wordpress/is-shallow-equal@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@wordpress/is-shallow-equal/-/is-shallow-equal-1.1.1.tgz#377db18206afe2a6e787862106c3ff5c27d65e36"
   dependencies:
@@ -6208,7 +6232,7 @@ react-devtools-core@3.1.0:
     shell-quote "^1.6.1"
     ws "^2.0.3"
 
-react-dom@^16.2.0:
+react-dom@^16.2.0, react-dom@^16.4.1:
   version "16.4.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.1.tgz#7f8b0223b3a5fbe205116c56deb85de32685dad6"
   dependencies:
@@ -6368,6 +6392,15 @@ react@^0.14.0:
   dependencies:
     envify "^3.0.0"
     fbjs "^0.6.1"
+
+react@^16.4.1:
+  version "16.4.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.4.1.tgz#de51ba5764b5dbcd1f9079037b862bd26b82fe32"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Update to the currently latest Gutenberg master branch.

Changes:
* Using the @wordpress/blocks packages now, and directly from src
* For some reason, Flow doesn't like pointing to the root of the blocks
package (while it's not complaining for the same reason for the
`element` package). Having the flow config pointing inside the `src` dir
of the package now.
* Need to expose `window.Node` for a couple of its constants. Using
jsdom's definitions for that.
* Code block needs a css class defined (wp-block-code) in the innerHTML
for validation to succeed