### PR TITLE
iOS: Aztec fully wired (v1).

### DIFF
--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -77,16 +77,18 @@ export default class BlockHolder extends React.Component<PropsType, StateType> {
 						styles[ 'aztec-editor' ],
 						{ minHeight: Math.max( _minHeight, this.state.aztecHeight ) },
 					] }
-					text={ { text: this.props.attributes.content, eventCount: this.props.attributes.eventCount } }
+					text={ { text: this.props.attributes.content, eventCount: this.state.eventCount } }
 					onContentSizeChange={ ( event ) => {
 						this.setState( { ...this.state, aztecHeight: event.nativeEvent.contentSize.height } );
 					} }
 					onChange={ ( event ) => {
 						console.log(event.nativeEvent.text),
+
+						this.setState( { ...this.state, eventCount: event.nativeEvent.eventCount } )
+
 						this.props.onChange( this.props.uid, {
 							...this.props.attributes,
 							content: event.nativeEvent.text,
-							eventCount: event.nativeEvent.eventCount,
 						} );
 					} }
 					color={ 'black' }

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -83,9 +83,7 @@ export default class BlockHolder extends React.Component<PropsType, StateType> {
 						this.setState( { ...this.state, aztecHeight: event.nativeEvent.contentSize.height } );
 					} }
 					onChange={ ( event ) => {
-						console.log(event.nativeEvent.text),
-
-						this.setState( { ...this.state, eventCount: event.nativeEvent.eventCount } )
+						this.setState( { ...this.state, eventCount: event.nativeEvent.eventCount } );
 
 						this.props.onChange( this.props.uid, {
 							...this.props.attributes,

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -82,6 +82,7 @@ export default class BlockHolder extends React.Component<PropsType, StateType> {
 						this.setState( { ...this.state, aztecHeight: event.nativeEvent.contentSize.height } );
 					} }
 					onChange={ ( event ) => {
+						console.log(event.nativeEvent.text),
 						this.props.onChange( this.props.uid, {
 							...this.props.attributes,
 							content: event.nativeEvent.text,

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -24,7 +24,7 @@ type StateType = {
 	selected: boolean,
 	focused: boolean,
 	aztecHeight: number,
-	eventCount: number,
+	eventCount?: number,
 };
 
 const _minHeight = 50;

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -24,6 +24,7 @@ type StateType = {
 	selected: boolean,
 	focused: boolean,
 	aztecHeight: number,
+	eventCount: number,
 };
 
 const _minHeight = 50;


### PR DESCRIPTION
This PR wraps up the initial wiring of Aztec to `gutenberg-mobile`.  It wires Aztec's content to our JavaScript state.

Closes #73.

### Details:

This PR also introduces some changes to how we store `eventCount` in our JS code.

According to https://facebook.github.io/react-native/docs/state:

```text
There are two types of data that control a component: props and state. props
are set by the parent and they are fixed throughout the lifetime of a
component. For data that is going to change, we have to use state.
```

Since `eventCount` was being changed throughout the lifetime of the Aztec TextView component, moving it to `state` made the most sense to adhere to the documentation cited above.

Storing it as a `prop` (that's what I understand we were doing before) was causing issues on iOS's side of the code.  When switching the editor to HTML mode and back, the `eventCount` was being persisted needlessly.  By removing it we were able to simplify the TextView refresh logic considerably.

### Testing:

- Make sure that you can type normally in the Aztec view.
- Switch to HTML and make sure the source code looks good.
- Switch back to visual and make sure the state wasn't lost.'

### Development tests:

✅ Tested in iOS
✅ Tested in Android (had some trouble initially to get the app running, but it was solved by resetting the cache).