### PR TITLE
Add cleanup code for submodule react-native-aztec

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "prettier": "prettier-eslint --write $npm_package_config_jsfiles $npm_package_config_scssfiles",
     "clean": "yarn clean:node; yarn clean:aztec; yarn clean:runtime;",
     "clean:runtime": "yarn cache clean; yarn test --clearCache; watchman watch-del-all; rm -rf $TMPDIR/react-*; rm -rf $TMPDIR/metro-cache-*; rm -rf $TMPDIR/jest_*",
-    "clean:aztec": "pushd react-native-aztec && (yarn clean; pushd example && yarn clean; popd; popd;)",
+    "clean:aztec": "pushd react-native-aztec && (yarn clean; pushd example && (yarn clean; popd); popd)",
     "clean:node": "rm -rf node_modules",
     "clean:install": "yarn clean; yarn",
     "lint": "eslint $npm_package_config_jsfiles",

--- a/package.json
+++ b/package.json
@@ -53,9 +53,10 @@
     "test:debug": "yarn pre-build && cross-env NODE_ENV=test node --inspect-brk node_modules/jest/bin/jest.js --runInBand --verbose --config jest.config.js",
     "flow": "flow",
     "prettier": "prettier-eslint --write $npm_package_config_jsfiles $npm_package_config_scssfiles",
-    "clean": "yarn clean:setup; yarn clean:runtime",
+    "clean": "yarn clean:node; yarn clean:aztec; yarn clean:runtime;",
     "clean:runtime": "yarn cache clean; yarn test --clearCache; watchman watch-del-all; rm -rf $TMPDIR/react-*; rm -rf $TMPDIR/metro-cache-*; rm -rf $TMPDIR/jest_*",
-    "clean:setup": "rm -rf node_modules",
+    "clean:aztec": "pushd react-native-aztec && (yarn clean; pushd example && yarn clean; popd; popd;)",
+    "clean:node": "rm -rf node_modules",
     "clean:install": "yarn clean; yarn",
     "lint": "eslint $npm_package_config_jsfiles",
     "lint:fix": "eslint $npm_package_config_jsfiles --fix"


### PR DESCRIPTION
As we go back and forth from testing the[ `AztecRN wrapper`](https://github.com/wordpress-mobile/react-native-aztec) and gutenberg-mobile, it's been tedious to know and make sure things are clean and can be run seamlessly.

Adding a step here to clean RN installed in `/example` and `./` folders of `react-native-aztec` subtree, and updating the subtree commit to latest master in `react-native-aztec`.

**Test steps:**

Run Aztec demo app first so RN gets installed locally there, and then run Gutenberg.
1. ```cd gutenberg-mobile/react-native-aztec/example```
2. ```yarn clean:install```
3. ```yarn start --reset-cache```
4. on another window: ```yarn android``` or ```yarn iOS```

Once you confirm the Aztec demo app works alright, proceed to try running the Gutenberg mobile demo app:

1. ```cd gutenberg-mobile/```
2. ```yarn clean:install```
3. ```yarn start --reset-cache```
4. on another window: ```yarn android``` or ```yarn iOS```

Make sure the GB mobile demo app works alright.

