### PR TITLE
Makes sure carthage dependencies are installed when running gutenberg…

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "start:reset": "yarn clean:runtime && yarn start --reset-cache",
     "start:debug": "yarn pre-build && node --inspect-brk node_modules/.bin/react-native start",
     "android": "react-native run-android",
+    "preios": "yarn preios:carthage",
+    "preios:carthage": "pushd react-native-aztec && (yarn install-aztec-ios; popd)",
     "ios": "react-native run-ios",
     "test": "yarn test:pre-build && cross-env NODE_ENV=test node node_modules/jest/bin/jest.js --verbose --config jest.config.js",
     "test:debug": "yarn pre-build && cross-env NODE_ENV=test node --inspect-brk node_modules/jest/bin/jest.js --runInBand --verbose --config jest.config.js",


### PR DESCRIPTION
This PR simply makes sure iOS dependencies for `RNAztecView` are properly installed when running `gutenberg-mobile`.