### PR TITLE
Preserve existing attributes in setAttributes

### DIFF
--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -61,7 +61,7 @@ export default class BlockHolder extends React.Component<PropsType, StateType> {
 				<Block
 					attributes={ { ...this.props.attributes } }
 					// pass a curried version of onChanged with just one argument
-					setAttributes={ ( attrs ) => this.props.onChange( this.props.uid, attrs ) }
+					setAttributes={ ( attrs ) => this.props.onChange( this.props.uid, {...this.props.attributes, ...attrs} ) }
 					isSelected={ this.props.focused }
 					style={ style }
 				/>

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -61,7 +61,7 @@ export default class BlockHolder extends React.Component<PropsType, StateType> {
 				<Block
 					attributes={ { ...this.props.attributes } }
 					// pass a curried version of onChanged with just one argument
-					setAttributes={ ( attrs ) => this.props.onChange( this.props.uid, {...this.props.attributes, ...attrs} ) }
+					setAttributes={ ( attrs ) => this.props.onChange( this.props.uid, { ...this.props.attributes, ...attrs } ) }
 					isSelected={ this.props.focused }
 					style={ style }
 				/>


### PR DESCRIPTION
This brings the implementation closer to the web by only changing the specified attributes instead of replacing everything with the passed attributes.

This means that callers don't need to be aware and prepend `...this.props.attributes` and can just worry about specifying the change they want, for instance:

```js
setAttributes( { dropCap: ! attributes.dropCap } );
```

This was added so that our `onChange` and `onContentSizeChange` methods don't need to have access to `this.props`, but also to match how the web behaves.