### PR TITLE
Editable html view

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { Platform, Switch, Text, View, FlatList } from 'react-native';
+import { Platform, Switch, Text, View, FlatList, TextInput, KeyboardAvoidingView } from 'react-native';
 import RecyclerViewList, { DataSource } from 'react-native-recyclerview-list';
 import BlockHolder from './block-holder';
 import { ToolbarButton } from './constants';
@@ -152,7 +152,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 						onValueChange={ ( value ) => this.setState( { showHtml: value } ) }
 					/>
 				</View>
-				{ this.state.showHtml && <Text style={ styles.htmlView }>{ this.serializeToHtml() }</Text> }
+				{ this.state.showHtml && this.renderHTML() }
 				{ ! this.state.showHtml && list }
 			</View>
 		);
@@ -168,6 +168,14 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 				uid={ value.uid }
 				{ ...value.item }
 			/>
+		);
+	}
+
+	renderHTML() {
+		return (
+			<KeyboardAvoidingView style={ styles.container } behavior="padding" enabled>
+				<TextInput multiline numberOfLines={ 0 } style={ styles.htmlView }>{ this.serializeToHtml() }</TextInput>
+			</KeyboardAvoidingView>
 		);
 	}
 }

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -172,9 +172,15 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 	}
 
 	renderHTML() {
+		const behavior = Platform.OS === 'ios' ? 'padding' : null;
 		return (
-			<KeyboardAvoidingView style={ styles.container } behavior="padding" enabled>
-				<TextInput multiline numberOfLines={ 0 } style={ styles.htmlView }>{ this.serializeToHtml() }</TextInput>
+			<KeyboardAvoidingView style={ { flex: 1 } } behavior={ behavior }>
+				<TextInput
+					multiline
+					numberOfLines={ 0 }
+					style={ styles.htmlView }>
+					{ this.serializeToHtml() }
+				</TextInput>
 			</KeyboardAvoidingView>
 		);
 	}


### PR DESCRIPTION
This is a small PR that makes the text view that shows the HTML code editable.

There are a couple of "known issues" on **Android** that I'd prefer to fix later on, to not make this PR too big:
- The TextInput view appears scrolled to the bottom.
- Anywhere I tap to start typing, the cursor will appear at the bottom.

**Note**: Any change made will be lost when returning to the blocks view.