### PR TITLE
Inserter - fix block manager state handling

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -56,19 +56,23 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		return -1;
 	}
 
+	componentWillReceiveProps(newProps) {
+		this.setState( {
+			...this.state,
+			dataSource: new DataSource( newProps.blocks, ( item: BlockType ) => item.uid ),
+		})
+	}
+
 	onToolbarButtonPressed( button: number, uid: string ) {
 		const dataSourceBlockIndex = this.getDataSourceIndexFromUid( uid );
 		switch ( button ) {
 			case ToolbarButton.UP:
-				this.state.dataSource.moveUp( dataSourceBlockIndex );
 				this.props.moveBlockUpAction( uid );
 				break;
 			case ToolbarButton.DOWN:
-				this.state.dataSource.moveDown( dataSourceBlockIndex );
 				this.props.moveBlockDownAction( uid );
 				break;
 			case ToolbarButton.DELETE:
-				this.state.dataSource.splice( dataSourceBlockIndex, 1 );
 				this.props.deleteBlockAction( uid );
 				break;
 			case ToolbarButton.PLUS:
@@ -80,7 +84,6 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 				// TODO: block type picker here instead of hardcoding a core/code block
 				const newBlock = createBlock( 'core/paragraph', { content: 'new test text for a core/paragraph block' } );
 				const newBlockWithFocusedState = { ...newBlock, focused: false };
-				this.state.dataSource.push( newBlockWithFocusedState );
 				this.props.createBlockAction( newBlockWithFocusedState.uid, newBlockWithFocusedState );
 				break;
 			case ToolbarButton.SETTINGS:

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -56,11 +56,41 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		return -1;
 	}
 
-	componentWillReceiveProps(newProps) {
-		this.setState( {
-			...this.state,
-			dataSource: new DataSource( newProps.blocks, ( item: BlockType ) => item.uid ),
-		})
+	isAdditionOrDeletion( newProps ) {
+		// there's been an addition / deletion
+		if (this.state.dataSource.size() != newProps.blocks.length) {
+			return true;
+		}
+	}
+
+	// returns true if focus, content, or position changes
+	isFocusContentPositionChange( newProps ) {
+		// checks whether there's been a `focused` flag change in the props
+		for ( let i = 0; i < this.state.dataSource.size(); ++i ) {
+			const block = this.state.dataSource.get( i );
+			const blockUpdate = newProps.blocks[ i ];
+			if ( block.uid === blockUpdate.uid ) {
+				if ( block.focused != blockUpdate.focused ) {
+					return true;
+				}
+				if ( block.attributes.content != blockUpdate.attributes.content ) {
+					return true;
+				}
+			} else {
+				// same array position and different uid, this means a move up/down of a block happened
+				return true;
+			}
+		}
+		return false;
+	}
+
+	componentWillReceiveProps( newProps ) {
+		if ((this.isAdditionOrDeletion(newProps) === true) || (this.isFocusContentPositionChange(newProps) === true)) {
+			this.setState( {
+				...this.state,
+				dataSource: new DataSource( newProps.blocks, ( item: BlockType ) => item.uid ),
+			})
+		}
 	}
 
 	onToolbarButtonPressed( button: number, uid: string ) {

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -46,7 +46,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		this.props.focusBlockAction( clientId );
 	}
 
-	getDataSourceIndexFromUid( clientId: string ) {
+	getDataSourceIndexFromClientId( clientId: string ) {
 		for ( let i = 0; i < this.state.dataSource.size(); ++i ) {
 			const block = this.state.dataSource.get( i );
 			if ( block.clientId === clientId ) {
@@ -95,7 +95,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 
 	onToolbarButtonPressed( button: number, clientId: string ) {
 		// TODO: don't remove - to be used when working on direct insertion
-		// const dataSourceBlockIndex = this.getDataSourceIndexFromUid( uid );
+		// const dataSourceBlockIndex = this.getDataSourceIndexFromClientId( clientId );
 		switch ( button ) {
 			case ToolbarButton.UP:
 				this.props.moveBlockUpAction( clientId );
@@ -110,7 +110,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 				// TODO: direct access insertion: it would be nice to pass the dataSourceBlockIndex here,
 				// so in this way we know the new block should be inserted right after this one
 				// instead of being appended to the end.
-				// this.props.createBlockAction( uid, dataSourceBlockIndex );
+				// this.props.createBlockAction( clientId, dataSourceBlockIndex );
 
 				// TODO: block type picker here instead of hardcoding a core/code block
 				const newBlock = createBlock( 'core/paragraph', { content: 'new test text for a core/paragraph block' } );
@@ -147,9 +147,9 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 
 	onChange( clientId: string, attributes: mixed ) {
 		// Update datasource UI
-		const index = this.getDataSourceIndexFromUid( clientId );
+		const index = this.getDataSourceIndexFromClientId( clientId );
 		const dataSource = this.state.dataSource;
-		const block = dataSource.get( this.getDataSourceIndexFromUid( clientId ) );
+		const block = dataSource.get( this.getDataSourceIndexFromClientId( clientId ) );
 		dataSource.set( index, { ...block, attributes: attributes } );
 		// Update Redux store
 		this.props.onChange( clientId, attributes );

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -57,10 +57,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 	}
 
 	static isAdditionOrDeletion( newProps: PropsType, currState: StateType ) {
-		// there's been an addition / deletion
-		if ( currState.dataSource.size() !== newProps.blocks.length ) {
-			return true;
-		}
+		return currState.dataSource.size() !== newProps.blocks.length;
 	}
 
 	// returns true if focus, content, or position change

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -97,7 +97,8 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 	}
 
 	onToolbarButtonPressed( button: number, uid: string ) {
-		const dataSourceBlockIndex = this.getDataSourceIndexFromUid( uid );
+		// TODO: don't remove - to be used when working on direct insertion
+		// const dataSourceBlockIndex = this.getDataSourceIndexFromUid( uid );
 		switch ( button ) {
 			case ToolbarButton.UP:
 				this.props.moveBlockUpAction( uid );

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -58,7 +58,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 
 	static isAdditionOrDeletion( newProps: PropsType, currState: StateType ) {
 		// there's been an addition / deletion
-		if (currState.dataSource.size() != newProps.blocks.length) {
+		if ( currState.dataSource.size() !== newProps.blocks.length ) {
 			return true;
 		}
 	}
@@ -70,10 +70,10 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 			const block = currState.dataSource.get( i );
 			const blockUpdate = newProps.blocks[ i ];
 			if ( block.uid === blockUpdate.uid ) {
-				if ( block.focused != blockUpdate.focused ) {
+				if ( block.focused !== blockUpdate.focused ) {
 					return true;
 				}
-				if ( block.attributes.content != blockUpdate.attributes.content ) {
+				if ( block.attributes.content !== blockUpdate.attributes.content ) {
 					return true;
 				}
 			} else {
@@ -85,9 +85,8 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 	}
 
 	static getDerivedStateFromProps( props: PropsType, state: StateType ) {
-		debugger;
-		if ((BlockManager.isAdditionOrDeletion(props, state) === true) 
-				|| (BlockManager.isFocusContentPositionChange(props, state) === true)) {
+		if ( ( BlockManager.isAdditionOrDeletion( props, state ) === true ) ||
+					( BlockManager.isFocusContentPositionChange( props, state ) === true ) ) {
 			return {
 				...state,
 				dataSource: new DataSource( props.blocks, ( item: BlockType ) => item.uid ),

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -56,7 +56,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		return -1;
 	}
 
-	static isAdditionOrDeletion( newProps, currState ) {
+	static isAdditionOrDeletion( newProps: PropsType, currState: StateType ) {
 		// there's been an addition / deletion
 		if (currState.dataSource.size() != newProps.blocks.length) {
 			return true;
@@ -64,7 +64,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 	}
 
 	// returns true if focus, content, or position change
-	static isFocusContentPositionChange( newProps, currState ) {
+	static isFocusContentPositionChange( newProps: PropsType, currState: StateType ) {
 		// checks whether there's been a `focused` flag change in the props
 		for ( let i = 0; i < currState.dataSource.size(); ++i ) {
 			const block = currState.dataSource.get( i );
@@ -84,7 +84,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		return false;
 	}
 
-	static getDerivedStateFromProps(props, state) {
+	static getDerivedStateFromProps( props: PropsType, state: StateType ) {
 		debugger;
 		if ((BlockManager.isAdditionOrDeletion(props, state) === true) 
 				|| (BlockManager.isFocusContentPositionChange(props, state) === true)) {

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -56,18 +56,18 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		return -1;
 	}
 
-	isAdditionOrDeletion( newProps ) {
+	static isAdditionOrDeletion( newProps, currState ) {
 		// there's been an addition / deletion
-		if (this.state.dataSource.size() != newProps.blocks.length) {
+		if (currState.dataSource.size() != newProps.blocks.length) {
 			return true;
 		}
 	}
 
-	// returns true if focus, content, or position changes
-	isFocusContentPositionChange( newProps ) {
+	// returns true if focus, content, or position change
+	static isFocusContentPositionChange( newProps, currState ) {
 		// checks whether there's been a `focused` flag change in the props
-		for ( let i = 0; i < this.state.dataSource.size(); ++i ) {
-			const block = this.state.dataSource.get( i );
+		for ( let i = 0; i < currState.dataSource.size(); ++i ) {
+			const block = currState.dataSource.get( i );
 			const blockUpdate = newProps.blocks[ i ];
 			if ( block.uid === blockUpdate.uid ) {
 				if ( block.focused != blockUpdate.focused ) {
@@ -84,13 +84,17 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		return false;
 	}
 
-	componentWillReceiveProps( newProps ) {
-		if ((this.isAdditionOrDeletion(newProps) === true) || (this.isFocusContentPositionChange(newProps) === true)) {
-			this.setState( {
-				...this.state,
-				dataSource: new DataSource( newProps.blocks, ( item: BlockType ) => item.uid ),
-			})
+	static getDerivedStateFromProps(props, state) {
+		debugger;
+		if ((BlockManager.isAdditionOrDeletion(props, state) === true) 
+				|| (BlockManager.isFocusContentPositionChange(props, state) === true)) {
+			return {
+				...state,
+				dataSource: new DataSource( props.blocks, ( item: BlockType ) => item.uid ),
+			};
 		}
+		// no state change necessary
+		return null;
 	}
 
 	onToolbarButtonPressed( button: number, uid: string ) {


### PR DESCRIPTION
This PR brings the ability to focus/move/delete/create blocks back to #88 by making sure the datasource used for the RecyclerView gets re-built and set through the Block Manager component `state`  lifecycle rather than operating on the List's `datasource` in a direct way, which I believe was an early optimization done to explore the ability for the RecyclerView list RN  wrapper to support animations (i.e. make blocks change positions animatedly while on another level reflecting the changes to the model). IIRC these explorations were done before the Redux connection was implemented.

#### Before
![insertertake1fixbefore](https://user-images.githubusercontent.com/6597771/43833687-026cc82a-9ae2-11e8-89fd-779ad5fac993.gif)
(note how tapping on one of the newly created blocks at the bottom of the list does not make the toolbar appear - that's an indication the `focused` prop is `false`)

#### After
![insertertake1fix](https://user-images.githubusercontent.com/6597771/43815528-7bd779d0-9aa6-11e8-8703-038e57687319.gif)
(note how tapping on any block makes it be focused, making the toolbar appear)

The flow / lifecycle in this PR - instead of setting the items in the datasource directly, it only modifies the component's `props` on each action (move up/down, delete and create), which then makes it to the redux store and finally then receives the new information through ~`componentWillReceiveProps` ~in commit a12f5ac first, but then moved to the new [`static getDerivedStateFromProps()` ](https://reactjs.org/docs/react-component.html#static-getderivedstatefromprops) in 5a5a2ccf056e73ce739bd30b2f4266176f3c63ab  and finally sets the new state there, effectively creating a new dataset for our forked RN RecyclerView.

In order to conveniently choose whether deriving and setting a new state is appropriate or not, there are 2 new specific methods `isAdditionOrDeletion` which checks whether there's a new block created or a block has been deleted, and `isFocusContentPositionChange` which checks whether a change happened in `focus`, `content`, or the position of any block.


### Description / Background / Path to solution

Since the merge of https://github.com/wordpress-mobile/gutenberg-mobile/pull/81 in commit f47cc5dfd907922d71731ff400b545fb240f1c47, I observed an issue only when adding new blocks in PR #88 and when these blocks are implemented by the `<Rich>` component, which in native is in turn implemented by the AztecRN wrapper.

1 - blocks generated in the initial state can handle get/lose `focused` state just fine
2 - how new blocks were generated made no difference - tried to generate blocks with `parse()`, `createBlock` and manually hardcoding the values, all work well with initial state but don't work well when inserted to the datasource on the fly 
3 - this started to fail only when I merged back the new Aztec based `Rich` component implementation (PR #81)
4 - the insertion and state keeping work alright when we use a plain object instead of the Rich component, i.e. by setting this line here to `if (false)` https://github.com/wordpress-mobile/gutenberg-mobile/blob/try/inserter-take1/src/block-management/block-holder.js#L49

As per my tests, the problem only appeared under these conditions:

- the list works in a way that it makes it easier to set and keep its own datasource on each action, effectively keeping a copy of the status in its datasource.
- the problem with focus only appears with our Android list, and only with the Aztec wrapper. It doesn't appear on iOS or when we have a plain View instead of Aztec wrapper.
- what happens is that when creating a new block and appending to the list, then tapping on it, it will generate the right `focused` prop change that will hit redux, but 
when the list is re-rendered the change is not made visible, and by observation it turns out that's because the prop there will still be `focused=false`.  Why is it `false`? I couldn't understand why.

Looking into all corners of the code I suspected the problem is manipulation of state in two places: locally on the List's state `datasource` to produce the UI changes, and on the props and signaling the redux store, not really then making good use of the lifecycle.
For example, this was being done on `DELETE` action:
```
              case ToolbarButton.DELETE:
				this.state.dataSource.splice( dataSourceBlockIndex, 1 );
				this.props.deleteBlockAction( uid );
```
.

Making sure the datasource was not directly accessed / modified was a first step (eliminating line 1 within the case handler above), and then making sure the state was then set after props changed made sense as part of [the component's lifecycle](https://reactjs.org/docs/react-component.html#the-component-lifecycle).


### Possible next steps

In the near future we might want to check how to bring some optimization back into the List (if more than say 100 or 200 blocks ever exist into a single Post), and animations can be looked into later as well. I think the way we were handling things was not being done properly. The obvious thing is, we are indeed producing a new `datasource` instead of only changing the items that need be changed but that's how React should work - down the line the proper `Components`(items in the list) should decide wether to update themselves or not within the List, but the whole state needs to be a new object each time as per how React works.

Other resources to have in mind as we discover and adapt our block manager to further uses:

https://facebook.github.io/react-native/docs/direct-manipulation
https://reactjs.org/docs/react-component.html#shouldcomponentupdate
https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#recommendation-fully-controlled-component
https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#new-lifecycle-getderivedstatefromprops
https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props

#### Further notes
Just adding many reviewers so to get a few of your eyes on this - it seems important and would like to get the team aware and get as many comments as possible :) 🙇 