### PR TITLE
Inserter - added direct insertion to block manager

### DIFF
--- a/src/app/AppContainer.js
+++ b/src/app/AppContainer.js
@@ -32,8 +32,8 @@ const mapDispatchToProps = ( dispatch, ownProps ) => {
 		deleteBlockAction: ( uid ) => {
 			dispatch( deleteBlockAction( uid ) );
 		},
-		createBlockAction: ( uid, block ) => {
-			dispatch( createBlockAction( uid, block ) );
+		createBlockAction: ( uid, block, uidAbove ) => {
+			dispatch( createBlockAction( uid, block, uidAbove ) );
 		},
 	};
 };

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -19,7 +19,7 @@ export type BlockListType = {
 	moveBlockUpAction: string => mixed,
 	moveBlockDownAction: string => mixed,
 	deleteBlockAction: string => mixed,
-	createBlockAction: ( string, BlockType ) => mixed,
+	createBlockAction: ( string, BlockType, string ) => mixed,
 	blocks: Array<BlockType>,
 	aztechtml: string,
 	refresh: boolean,
@@ -97,8 +97,6 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 	}
 
 	onToolbarButtonPressed( button: number, uid: string ) {
-		// TODO: don't remove - to be used when working on direct insertion
-		// const dataSourceBlockIndex = this.getDataSourceIndexFromUid( uid );
 		switch ( button ) {
 			case ToolbarButton.UP:
 				this.props.moveBlockUpAction( uid );
@@ -110,15 +108,10 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 				this.props.deleteBlockAction( uid );
 				break;
 			case ToolbarButton.PLUS:
-				// TODO: direct access insertion: it would be nice to pass the dataSourceBlockIndex here,
-				// so in this way we know the new block should be inserted right after this one
-				// instead of being appended to the end.
-				// this.props.createBlockAction( uid, dataSourceBlockIndex );
-
 				// TODO: block type picker here instead of hardcoding a core/code block
 				const newBlock = createBlock( 'core/paragraph', { content: 'new test text for a core/paragraph block' } );
 				const newBlockWithFocusedState = { ...newBlock, focused: false };
-				this.props.createBlockAction( newBlockWithFocusedState.uid, newBlockWithFocusedState );
+				this.props.createBlockAction( newBlockWithFocusedState.uid, newBlockWithFocusedState, uid );
 				break;
 			case ToolbarButton.SETTINGS:
 				// TODO: implement settings

--- a/src/store/actions/index.js
+++ b/src/store/actions/index.js
@@ -38,8 +38,9 @@ export const deleteBlockAction: BlockActionType = uid => ( {
 	uid: uid,
 } );
 
-export const createBlockAction: BlockActionType = (uid, block) => ( {
+export const createBlockAction: BlockActionType = (uid, block, uidAbove) => ( {
 	type: ActionTypes.BLOCK.CREATE,
 	block: block,
 	uid: uid,
+	uidAbove: uidAbove,
 } );

--- a/src/store/actions/test.js
+++ b/src/store/actions/test.js
@@ -39,7 +39,7 @@ describe( 'Store', () => {
 		it( 'should create an action to create a block', () => {
 			registerCoreBlocks();
 			const newBlock = createBlock( 'core/code', { content: 'new test text for a core/code block' } );
-			const action = actions.createBlockAction( '1', newBlock );
+			const action = actions.createBlockAction( '1', newBlock, '0' );
 			expect( action.type ).toEqual( ActionTypes.BLOCK.CREATE );
 		} );
 

--- a/src/store/reducers/index.js
+++ b/src/store/reducers/index.js
@@ -21,6 +21,21 @@ function findBlockIndex( blocks, uid: string ) {
 	} );
 }
 
+/*
+ * insert block into blocks[], below / after block having uidAbove
+*/
+function insertBlock( blocks, block, uidAbove ) {
+	// TODO we need to set focused: true and search for the currently focused block and
+	// set that one to `focused: false`.
+	const insertionIndex = findBlockIndex( blocks, uidAbove );
+	if (insertionIndex === blocks.length - 1) {
+		// append new block to blocks list
+		blocks.push(block);
+	} else {
+		blocks.splice(insertionIndex + 1, 0, block);
+	}
+}
+
 export const reducer = (
 	state: StateType = { blocks: [], refresh: false },
 	action: BlockActionType
@@ -109,9 +124,7 @@ export const reducer = (
 			return { blocks: blocks, refresh: ! state.refresh };
 		}
 		case ActionTypes.BLOCK.CREATE: {
-			// TODO we need to set focused: true and search for the currently focused block and
-			// set that one to `focused: false`.
-			blocks.push(action.block);
+			insertBlock(blocks, action.block, action.uidAbove);
 			return { blocks: blocks, refresh: ! state.refresh };
 		}
 		default:


### PR DESCRIPTION
This PR builds on top of #95, and adds direct insertion at a specific index in the list state. For the sake of the exercise in the GB mobile application for now we're inserting right below the tapped block.

Before, it would only _append_ new blocks to the list.

#### Android
![insertertake1direct](https://user-images.githubusercontent.com/6597771/43851449-210117e4-9b11-11e8-98d0-073644081d8b.gif)

#### iOS
![insertertake1direct_ios](https://user-images.githubusercontent.com/6597771/43851609-8508fc0c-9b11-11e8-8399-729732a9d7eb.gif)

