### PR TITLE
Implement heading block

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -41,6 +41,7 @@ const initialMoreBlockHtml = `
 <!-- /wp:more -->
 `;
 
+const initialHeadingBlockHtml = '<!-- wp:heading {"level": 2} --><h2>Welcome to Gutenberg</h2><!-- /wp:heading -->';
 const initialParagraphBlockHtml = '<!-- wp:paragraph --><p><b>Hello</b> World!</p><!-- /wp:paragraph -->';
 const initialParagraphBlockHtml2 = `<!-- wp:paragraph {"dropCap":true,"backgroundColor":"vivid-red","fontSize":"large","className":"custom-class-1 custom-class-2"} -->
 <p class="has-background has-drop-cap is-large-text has-vivid-red-background-color custom-class-1 custom-class-2">
@@ -48,6 +49,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer tempor tincidun
 
 const codeBlockInstance = parse( initialCodeBlockHtml )[ 0 ];
 const moreBlockInstance = parse( initialMoreBlockHtml )[ 0 ];
+const headingBlockInstance = parse( initialHeadingBlockHtml )[ 0 ];
 const paragraphBlockInstance = parse( initialParagraphBlockHtml )[ 0 ];
 const paragraphBlockInstance2 = parse( initialParagraphBlockHtml2 )[ 0 ];
 
@@ -65,6 +67,7 @@ const initialState: StateType = {
 			innerBlocks: [],
 			focused: false,
 		},
+		{ ...headingBlockInstance, focused: false },
 		{ ...paragraphBlockInstance, focused: false },
 		{ ...paragraphBlockInstance2, focused: false },
 		{ ...codeBlockInstance, focused: false },


### PR DESCRIPTION
This ports the heading block (without toolbar or settings) to gutenberg-mobile.
The bulk of the code is in TBD, this PR just adds a heading block to the initial list.

See #57 