### PR TITLE
Reinstate clean:runtime script so start:reset works

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "flow": "flow",
     "prettier": "prettier-eslint --write $npm_package_config_jsfiles $npm_package_config_scssfiles",
     "clean": "yarn clean:aztec; yarn cache clean; yarn clean:haste; yarn clean:jest; yarn clean:metro; yarn clean:react; yarn clean:watchman; yarn clean:node;",
+    "clean:runtime": "yarn clean:haste; yarn clean:react; yarn clean:metro; yarn clean:jest; yarn clean:watchman",
     "clean:aztec": "pushd react-native-aztec && (yarn clean; pushd example && (yarn clean; popd); popd)",
     "clean:haste": "rm -rf /tmp/haste-map-react-native-packager-*",
     "clean:install": "yarn clean; yarn",


### PR DESCRIPTION
Reinstates the `clean:runtime` script that runs all the cleaning procedures needed after package installations and before Metro starts. This also fixes the broken `start:reset` script.

So, ideally, if the dependencies list hasn't changed (no new deps or upgraded deps or removed deps) than one just needs to `yarn start:reset` to clean-start Metro.

To test:
1. Run `yarn start:reset` to clean-start Metro and notice that it start correctly