### PR TITLE
Inserter - show Picker with registered blocks to choose from

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -43,7 +43,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 			dataSource: new DataSource( this.props.blocks, ( item: BlockType ) => item.clientId ),
 			showHtml: false,
 			blockTypePickerVisible: false,
-			selectedBlockType: 'core/paragraph'
+			selectedBlockType: 'core/paragraph',
 		};
 	}
 
@@ -114,11 +114,11 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		this.setState( { ...this.state, blockTypePickerVisible: true } );
 	}
 
-	onBlockTypeSelected( itemValue: string, itemIndex: number ) {
-		this.setState( {...this.state, selectedBlockType: itemValue, blockTypePickerVisible: false} );
+	onBlockTypeSelected( itemValue: string ) {
+		this.setState( { ...this.state, selectedBlockType: itemValue, blockTypePickerVisible: false } );
 
 		// find currently focused block
-		const clientIdFocused = this.state.dataSource.get(this.findDataSourceIndexForFocusedItem()).clientId;
+		const clientIdFocused = this.state.dataSource.get( this.findDataSourceIndexForFocusedItem() ).clientId;
 
 		// create an empty block of the selected type
 		const newBlock = createBlock( itemValue, { content: 'new test text for a ' + itemValue + ' block' } );
@@ -209,14 +209,16 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 			);
 		}
 
-		let blockTypePicker = (
+		const blockTypePicker = (
 			<View>
 				<Picker
-					selectedValue={this.state.selectedBlockType}
-					onValueChange= { (itemValue, itemIndex) => { this.onBlockTypeSelected(itemValue, itemIndex); } } >
-					{ this.availableBlockTypes.map((item, index) => {
-							return (<Picker.Item label={item.title} value={item.name} key={index+1}/>)
-						} ) }
+					selectedValue={ this.state.selectedBlockType }
+					onValueChange={ ( itemValue ) => {
+						this.onBlockTypeSelected( itemValue );
+					} } >
+					{ this.availableBlockTypes.map( ( item, index ) => {
+						return ( <Picker.Item label={ item.title } value={ item.name } key={ index + 1 } /> );
+					} ) }
 				</Picker>
 			</View>
 		);
@@ -236,7 +238,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 				{ this.state.showHtml && <Text style={ styles.htmlView }>{ this.serializeToHtml() }</Text> }
 				{ ! this.state.showHtml && list }
 				{ this.state.blockTypePickerVisible && blockTypePicker }
-				</View>
+			</View>
 		);
 	}
 


### PR DESCRIPTION
This completes a very draft, initial 1st iteration on implementing the inserter flow. With this, the flow goes roughly along the lines of the expected actions like this:

1. focusing on an item shows an item toolbar which for now currently includes the `+` button to insert a new item (this `+` trigger will be moved to the toolbar as per the designs https://github.com/wordpress-mobile/gutenberg-mobile/issues/58#issuecomment-409571383)
2. tapping on `+ ` makes a RN `Picker` show up
3. tap on the picker to choose the type of block you'd like to insert
4. a newly created block is inserted right below the block that was being focused on.

![inserter-picker](https://user-images.githubusercontent.com/6597771/44030938-b8cb4fde-9ed8-11e8-8b9d-ea09fe1c765e.gif)

Known issues:
- the [RN `Picker`](https://facebook.github.io/react-native/docs/picker) component, though easy to use, as far as I could check only reacts when an item other than the currently selected value is chosen, and has had variable behavior in the recent past:
https://github.com/facebook/react-native/issues/15556
https://github.com/facebook/react-native/issues/15672
https://github.com/facebook/react-native/issues/13204
https://stackoverflow.com/questions/48465288/detect-selecting-current-selectedvalue-with-react-native-picker
Kind of makes sense with the prop name `onValueChange`, (i.e. I think from the name itself it derive that if the value didn't change, it won't be triggered) although it's not exactly what can be expected of the control (even the docs describe the prop function as `Callback for when an item is selected.`)

For this I'm working on another implementation with a modal dialog and a flatlist, but wanted to continue to put this PR up and complete a first "working" flow at least.






