### PR TITLE
Fix eslint missing src subdirs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+; ignore the submodules
+gutenberg
+react-native-aztec
+

--- a/.flowconfig
+++ b/.flowconfig
@@ -86,10 +86,7 @@ munge_underscores=true
 module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> 'RelativeImageStub'
 module.name_mapper='@gutenberg' -> '<PROJECT_ROOT>/gutenberg'
 module.name_mapper='@wordpress/blocks' -> '<PROJECT_ROOT>/gutenberg/packages/blocks/src'
-module.name_mapper='@wordpress/data' -> '<PROJECT_ROOT>/gutenberg/packages/data'
-module.name_mapper='@wordpress/element' -> '<PROJECT_ROOT>/gutenberg/packages/element'
-module.name_mapper='@wordpress/deprecated' -> '<PROJECT_ROOT>/gutenberg/packages/deprecated'
-module.name_mapper='@wordpress/redux-routine' -> '<PROJECT_ROOT>/gutenberg/packages/redux-routine'
+module.name_mapper='@wordpress/element' -> '<PROJECT_ROOT>/gutenberg/packages/element/src'
 
 ; mock/ignore style files
 module.name_mapper='.*\(.scss\)' -> 'empty/object'

--- a/__mocks__/nodejsMock.js
+++ b/__mocks__/nodejsMock.js
@@ -1,3 +1,4 @@
-/** @format */
+/** @flow
+ * @format */
 
 module.exports = {};

--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -1,3 +1,4 @@
-/** @format */
+/** @flow
+ * @format */
 
 module.exports = {};

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-/** @format */
+/** @flow
+ * @format */
 
 import { AppRegistry } from 'react-native';
 import App from './src/app/App';

--- a/jest.config.js
+++ b/jest.config.js
@@ -30,7 +30,8 @@ module.exports = {
 		'node',
 	],
 	moduleNameMapper: {
-		'@wordpress\\/(blocks|data|element|deprecated|editor|redux-routine)$': '<rootDir>/gutenberg/packages/$1/src/index',
+		'@wordpress\\/(blocks|data|element|deprecated|editor|redux-routine)$':
+			'<rootDir>/gutenberg/packages/$1/src/index',
 		'@gutenberg': '<rootDir>/gutenberg',
 
 		// Mock the CSS modules. See https://facebook.github.io/jest/docs/en/webpack.html#handling-static-assets

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
-/** @format */
+/** @flow
+ * @format */
 
 const defaultPlatform = 'android';
 const rnPlatform = process.env.TEST_RN_PLATFORM || defaultPlatform;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "config": {
-    "jsfiles": "./*.js src/*.js src/**/*.js",
+    "jsfiles": "./*.js src/*.js src/**/*.js src/**/**/*.js",
     "scssfiles": "src/*.scss src/**/*.scss"
   },
   "devDependencies": {
@@ -32,6 +32,8 @@
     "jest": "^22.4.3",
     "jest-react-native": "^18.0.0",
     "prettier": "git+https://github.com/Automattic/calypso-prettier.git#calypso-1.9",
+    "prettier-eslint": "^8.8.2",
+    "prettier-eslint-cli": "^4.7.1",
     "react-dom": "^16.2.0",
     "react-native-sass-transformer": "^1.1.1",
     "react-test-renderer": "16.2.0",
@@ -88,7 +90,6 @@
     "memize": "^1.0.5",
     "node-libs-react-native": "^1.0.2",
     "node-sass": "^4.8.3",
-    "prettier-eslint": "^8.8.1",
     "react": "16.3.1",
     "react-native": "0.55.4",
     "react-native-recyclerview-list": "git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#bfccbaab6b5954e18f8b0ed441ba38275853b79c",

--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
     "clean:react": "rm -rf $TMPDIR/react-*",
     "clean:node": "rm -rf node_modules",
     "clean:watchman": "watchman watch-del-all",
-    "lint": "eslint $npm_package_config_jsfiles",
-    "lint:fix": "eslint $npm_package_config_jsfiles --fix"
+    "lint": "eslint . --ext .js",
+    "lint:fix": "yarn lint --fix"
   },
   "dependencies": {
     "@wordpress/autop": "^1.0.6",

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -1,7 +1,9 @@
-/** @format */
+/** @flow
+ * @format */
 
 import '../globals';
 
+import React from 'react';
 import { Provider } from 'react-redux';
 import { setupStore } from '../store';
 import AppContainer from './AppContainer';

--- a/src/app/AppContainer.js
+++ b/src/app/AppContainer.js
@@ -1,4 +1,6 @@
-/** @format */
+/** @flow
+ * @format */
+
 import { connect } from 'react-redux';
 import {
 	updateBlockAttributes,

--- a/src/app/MainApp.js
+++ b/src/app/MainApp.js
@@ -1,6 +1,5 @@
-/** @format */
-
-// @flow
+/** @flow
+ * @format */
 
 import React from 'react';
 

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -36,7 +36,10 @@ export default class BlockHolder extends React.Component<PropsType, StateType> {
 	renderToolbarIfBlockFocused() {
 		if ( this.props.focused ) {
 			return (
-				<Toolbar clientId={ this.props.clientId } onButtonPressed={ this.props.onToolbarButtonPressed } />
+				<Toolbar
+					clientId={ this.props.clientId }
+					onButtonPressed={ this.props.onToolbarButtonPressed }
+				/>
 			);
 		}
 
@@ -61,7 +64,9 @@ export default class BlockHolder extends React.Component<PropsType, StateType> {
 				<Block
 					attributes={ { ...this.props.attributes } }
 					// pass a curried version of onChanged with just one argument
-					setAttributes={ ( attrs ) => this.props.onChange( this.props.clientId, { ...this.props.attributes, ...attrs } ) }
+					setAttributes={ ( attrs ) =>
+						this.props.onChange( this.props.clientId, { ...this.props.attributes, ...attrs } )
+					}
 					isSelected={ this.props.focused }
 					style={ style }
 				/>

--- a/src/block-management/toolbar.js
+++ b/src/block-management/toolbar.js
@@ -17,7 +17,11 @@ export default class Toolbar extends React.Component<PropsType> {
 		return (
 			<View style={ styles.toolbar }>
 				<TouchableOpacity
-					onPress={ this.props.onButtonPressed.bind( this, ToolbarButton.PLUS, this.props.clientId ) }
+					onPress={ this.props.onButtonPressed.bind(
+						this,
+						ToolbarButton.PLUS,
+						this.props.clientId
+					) }
 				>
 					<View style={ styles.toolbarButton }>
 						<Text>+</Text>
@@ -33,7 +37,11 @@ export default class Toolbar extends React.Component<PropsType> {
 				</TouchableOpacity>
 				<View style={ styles.buttonSeparator } />
 				<TouchableOpacity
-					onPress={ this.props.onButtonPressed.bind( this, ToolbarButton.DOWN, this.props.clientId ) }
+					onPress={ this.props.onButtonPressed.bind(
+						this,
+						ToolbarButton.DOWN,
+						this.props.clientId
+					) }
 				>
 					<View style={ styles.toolbarButton }>
 						<Text>▼</Text>
@@ -54,7 +62,11 @@ export default class Toolbar extends React.Component<PropsType> {
 				</TouchableOpacity>
 				<View style={ styles.buttonSeparator } />
 				<TouchableOpacity
-					onPress={ this.props.onButtonPressed.bind( this, ToolbarButton.DELETE, this.props.clientId ) }
+					onPress={ this.props.onButtonPressed.bind(
+						this,
+						ToolbarButton.DELETE,
+						this.props.clientId
+					) }
 				>
 					<View style={ styles.toolbarButton }>
 						<Text>🗑</Text>

--- a/src/globals.js
+++ b/src/globals.js
@@ -1,4 +1,5 @@
-/** @format */
+/** @flow
+ * @format */
 
 import { createElement } from '@wordpress/element';
 import jsdom from 'jsdom-jscore';

--- a/src/store/actions/index.js
+++ b/src/store/actions/index.js
@@ -18,22 +18,22 @@ export function updateBlockAttributes( clientId: string, attributes: mixed ) {
 	};
 }
 
-export const focusBlockAction: BlockActionType = clientId => ( {
+export const focusBlockAction: BlockActionType = ( clientId ) => ( {
 	type: ActionTypes.BLOCK.FOCUS,
 	clientId,
 } );
 
-export const moveBlockUpAction: BlockActionType = clientId => ( {
+export const moveBlockUpAction: BlockActionType = ( clientId ) => ( {
 	type: ActionTypes.BLOCK.MOVE_UP,
 	clientId,
 } );
 
-export const moveBlockDownAction: BlockActionType = clientId => ( {
+export const moveBlockDownAction: BlockActionType = ( clientId ) => ( {
 	type: ActionTypes.BLOCK.MOVE_DOWN,
 	clientId,
 } );
 
-export const deleteBlockAction: BlockActionType = clientId => ( {
+export const deleteBlockAction: BlockActionType = ( clientId ) => ( {
 	type: ActionTypes.BLOCK.DELETE,
 	clientId,
 } );

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -41,8 +41,10 @@ const initialMoreBlockHtml = `
 <!-- /wp:more -->
 `;
 
-const initialHeadingBlockHtml = '<!-- wp:heading {"level": 2} --><h2>Welcome to Gutenberg</h2><!-- /wp:heading -->';
-const initialParagraphBlockHtml = '<!-- wp:paragraph --><p><b>Hello</b> World!</p><!-- /wp:paragraph -->';
+const initialHeadingBlockHtml =
+	'<!-- wp:heading {"level": 2} --><h2>Welcome to Gutenberg</h2><!-- /wp:heading -->';
+const initialParagraphBlockHtml =
+	'<!-- wp:paragraph --><p><b>Hello</b> World!</p><!-- /wp:paragraph -->';
 const initialParagraphBlockHtml2 = `<!-- wp:paragraph {"dropCap":true,"backgroundColor":"vivid-red","fontSize":"large","className":"custom-class-1 custom-class-2"} -->
 <p class="has-background has-drop-cap has-large-font-size has-vivid-red-background-color custom-class-1 custom-class-2">
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer tempor tincidunt sapien, quis dictum orci sollicitudin quis. Proin sed elit id est pulvinar feugiat vitae eget dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><!-- /wp:paragraph -->`;
@@ -89,7 +91,7 @@ const initialState: StateType = {
 
 const devToolsEnhancer =
 	// ( 'development' === process.env.NODE_ENV && require( 'remote-redux-devtools' ).default ) ||
-	( () => {} );
+	() => {};
 
 export function setupStore( state: StateType = initialState ) {
 	const store = createStore( reducer, state, devToolsEnhancer() );

--- a/src/store/reducers/index.js
+++ b/src/store/reducers/index.js
@@ -10,13 +10,13 @@ import type { StateType } from '../';
 import type { BlockActionType } from '../actions';
 
 function findBlock( blocks, clientId: string ) {
-	return find( blocks, obj => {
+	return find( blocks, ( obj ) => {
 		return obj.clientId === clientId;
 	} );
 }
 
 function findBlockIndex( blocks, clientId: string ) {
-	return findIndex( blocks, obj => {
+	return findIndex( blocks, ( obj ) => {
 		return obj.clientId === clientId;
 	} );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1898,6 +1898,10 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
 
+boolify@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/boolify/-/boolify-1.0.1.tgz#b5c09e17cacd113d11b7bb3ed384cc012994d86b"
+
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
@@ -2096,6 +2100,14 @@ camelcase-keys@^2.0.0:
     camelcase "^2.0.0"
     map-obj "^1.0.0"
 
+camelcase-keys@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-4.2.0.tgz#a2aa5fb1af688758259c32c141426d78923b9b77"
+  dependencies:
+    camelcase "^4.1.0"
+    map-obj "^2.0.0"
+    quick-lru "^1.0.0"
+
 camelcase@4.1.0, camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
@@ -2136,6 +2148,14 @@ center-align@^0.1.1:
 chalk@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
+chalk@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
   dependencies:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
@@ -3023,7 +3043,7 @@ eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
-eslint@^4.0.0, eslint@^4.19.1:
+eslint@^4.0.0, eslint@^4.19.1, eslint@^4.5.0:
   version "4.19.1"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.19.1.tgz#32d1d653e1d90408854bfb296f076ec7e186a300"
   dependencies:
@@ -3563,6 +3583,10 @@ get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
 
+get-stdin@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
+
 get-stream@3.0.0, get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
@@ -3625,6 +3649,17 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@~7.1.1:
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@~7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.6.tgz#211bafaf49e525b8cd93260d14ab136152b3f57a"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.2"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -3912,7 +3947,7 @@ ignore@3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
-ignore@^3.3.3, ignore@^3.3.6:
+ignore@^3.2.7, ignore@^3.3.3, ignore@^3.3.6:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
 
@@ -3945,7 +3980,7 @@ indent-string@^2.1.0:
   dependencies:
     repeating "^2.0.0"
 
-indent-string@^3.2.0:
+indent-string@^3.1.0, indent-string@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
 
@@ -4911,6 +4946,10 @@ lodash.clonedeep@^4.3.2:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
 
+lodash.memoize@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+
 lodash.merge@^4.6.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
@@ -5002,6 +5041,12 @@ make-dir@^1.0.0:
   dependencies:
     pify "^3.0.0"
 
+make-plural@^4.1.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/make-plural/-/make-plural-4.2.0.tgz#03edfc34a2aee630a57e209369ef26ee3ca69590"
+  optionalDependencies:
+    minimist "^1.2.0"
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -5015,6 +5060,10 @@ map-cache@^0.2.2:
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
+
+map-obj@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-2.0.0.tgz#a65cd29087a92598b8791257a523e021222ac1f9"
 
 map-visit@^1.0.0:
   version "1.0.0"
@@ -5071,6 +5120,20 @@ merge-stream@^1.0.1:
 merge@^1.2.0, merge@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
+
+messageformat-parser@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/messageformat-parser/-/messageformat-parser-1.1.0.tgz#13ba2250a76bbde8e0fca0dbb3475f95c594a90a"
+
+messageformat@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/messageformat/-/messageformat-1.1.1.tgz#ceaa2e6c86929d4807058275a7372b1bd963bdf6"
+  dependencies:
+    glob "~7.0.6"
+    make-plural "^4.1.1"
+    messageformat-parser "^1.1.0"
+    nopt "~3.0.6"
+    reserved-words "^0.1.2"
 
 metro-babylon7@0.30.2:
   version "0.30.2"
@@ -5500,7 +5563,7 @@ node-sass@^4.8.3:
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
 
-"nopt@2 || 3", nopt@~3.0.1:
+"nopt@2 || 3", nopt@~3.0.1, nopt@~3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
   dependencies:
@@ -6012,7 +6075,30 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier-eslint@^8.8.1:
+prettier-eslint-cli@^4.7.1:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/prettier-eslint-cli/-/prettier-eslint-cli-4.7.1.tgz#3d103c494baa4e80b99ad53e2b9db7620101859f"
+  dependencies:
+    arrify "^1.0.1"
+    babel-runtime "^6.23.0"
+    boolify "^1.0.0"
+    camelcase-keys "^4.1.0"
+    chalk "2.3.0"
+    common-tags "^1.4.0"
+    eslint "^4.5.0"
+    find-up "^2.1.0"
+    get-stdin "^5.0.1"
+    glob "^7.1.1"
+    ignore "^3.2.7"
+    indent-string "^3.1.0"
+    lodash.memoize "^4.1.2"
+    loglevel-colored-level-prefix "^1.0.0"
+    messageformat "^1.0.2"
+    prettier-eslint "^8.5.0"
+    rxjs "^5.3.0"
+    yargs "10.0.3"
+
+prettier-eslint@^8.5.0, prettier-eslint@^8.8.2:
   version "8.8.2"
   resolved "https://registry.yarnpkg.com/prettier-eslint/-/prettier-eslint-8.8.2.tgz#fcb29a48ab4524e234680797fe70e9d136ccaf0b"
   dependencies:
@@ -6189,6 +6275,10 @@ querystring-es3@^0.2.0:
 querystring@0.2.0, querystring@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+
+quick-lru@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
 
 randomatic@^3.0.0:
   version "3.0.0"
@@ -6720,6 +6810,10 @@ reselect@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
 
+reserved-words@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/reserved-words/-/reserved-words-0.1.2.tgz#00a0940f98cd501aeaaac316411d9adc52b31ab1"
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
@@ -6805,6 +6899,12 @@ rx-lite-aggregates@^4.0.8:
 rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
+
+rxjs@^5.3.0:
+  version "5.5.11"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.11.tgz#f733027ca43e3bec6b994473be4ab98ad43ced87"
+  dependencies:
+    symbol-observable "1.0.1"
 
 safe-buffer@5.1.1:
   version "5.1.1"
@@ -7327,6 +7427,10 @@ supports-color@^5.3.0, supports-color@^5.4.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
   dependencies:
     has-flag "^3.0.0"
+
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
 
 symbol-observable@^1.0.2, symbol-observable@^1.0.3:
   version "1.2.0"
@@ -7978,11 +8082,28 @@ yargs-parser@^7.0.0:
   dependencies:
     camelcase "^4.1.0"
 
-yargs-parser@^8.1.0:
+yargs-parser@^8.0.0, yargs-parser@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"
   dependencies:
     camelcase "^4.1.0"
+
+yargs@10.0.3:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.0.3.tgz#6542debd9080ad517ec5048fb454efe9e4d4aaae"
+  dependencies:
+    cliui "^3.2.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^8.0.0"
 
 yargs@^10.0.3:
   version "10.1.2"


### PR DESCRIPTION
The params passed to eslint command line specifying which source files to check were missing the subdirectories inside the `src` directory. See [this comment](https://github.com/wordpress-mobile/gutenberg-mobile/pull/88#discussion_r209577525) for example. This PR replaces the glob definition with the all-catching `.`.

The submodules are left out of the list though (see `.eslintignore` file) since those are checked in their respective repositories.

Also in this PR:
* Fix for the `yarn prettier` command to use `prettier-eslint-cli`
* Apply the `@flow` pragma to more source files so Flow should check those too

To test:
* compile and run the app; everything should run just fine
* run the linter (`yarn lint`) and tests (`yarn test`); all should run fine as well
* run the Flow checker (`yarn flow`); no warnings/errors should be emitted
* run Prettier (`yarn prettier`) which also should run fine and introduce no changes to the code files
* run the linter in fix mode (`yarn lint:fix`) which also should run fine and introduce no changes to the code files