### PR TITLE
Inserter - fix focus handling, awesomely spotted by @hypest

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -115,7 +115,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		// Update datasource UI
 		const index = this.getDataSourceIndexFromUid( clientId );
 		const dataSource = this.state.dataSource;
-		const block = dataSource.get( this.getDataSourceIndexFromUid( clientId ) );
+		const block = dataSource.get( index );
 		block.attributes = attributes;
 		// Update Redux store
 		this.props.onChange( clientId, attributes );

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -116,7 +116,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		const index = this.getDataSourceIndexFromUid( clientId );
 		const dataSource = this.state.dataSource;
 		const block = dataSource.get( this.getDataSourceIndexFromUid( clientId ) );
-		dataSource.set( index, { ...block, attributes: attributes } );
+		block.attributes = attributes;
 		// Update Redux store
 		this.props.onChange( clientId, attributes );
 	}


### PR DESCRIPTION
This fixes the problem with keeping up with `focused` state as described in https://github.com/wordpress-mobile/gutenberg-mobile/pull/88#issuecomment-411477900.
Fixed by @hypest, copying here the description of what this does:

> I think that happens there is that onChange breaks the “contract” where the block instances in the DataSource need to be the very same ones as in the props

This diff effectively makes sure to use the same block instance and update the instance `attributes`, then sending the updated changes to the redux store.

props to @hypest once more.