### PR TITLE
Inserter - added direct insertion to block manager (take2)

### DIFF
--- a/src/app/AppContainer.js
+++ b/src/app/AppContainer.js
@@ -32,8 +32,8 @@ const mapDispatchToProps = ( dispatch, ownProps ) => {
 		deleteBlockAction: ( clientId ) => {
 			dispatch( deleteBlockAction( clientId ) );
 		},
-		createBlockAction: ( clientId, block ) => {
-			dispatch( createBlockAction( clientId, block ) );
+		createBlockAction: ( clientId, block, clientIdAbove ) => {
+			dispatch( createBlockAction( clientId, block, clientIdAbove ) );
 		},
 	};
 };

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -19,7 +19,7 @@ export type BlockListType = {
 	moveBlockUpAction: string => mixed,
 	moveBlockDownAction: string => mixed,
 	deleteBlockAction: string => mixed,
-	createBlockAction: ( string, BlockType ) => mixed,
+	createBlockAction: ( string, BlockType, string ) => mixed,
 	blocks: Array<BlockType>,
 	aztechtml: string,
 	refresh: boolean,
@@ -72,16 +72,11 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 				this.props.deleteBlockAction( clientId );
 				break;
 			case ToolbarButton.PLUS:
-				// TODO: direct access insertion: it would be nice to pass the dataSourceBlockIndex here,
-				// so in this way we know the new block should be inserted right after this one
-				// instead of being appended to the end.
-				// this.props.createBlockAction( uid, dataSourceBlockIndex );
-
 				// TODO: block type picker here instead of hardcoding a core/code block
 				const newBlock = createBlock( 'core/paragraph', { content: 'new test text for a core/paragraph block' } );
 				const newBlockWithFocusedState = { ...newBlock, focused: false };
-				this.state.dataSource.push( newBlockWithFocusedState );
-				this.props.createBlockAction( newBlockWithFocusedState.clientId, newBlockWithFocusedState );
+				this.state.dataSource.splice( dataSourceBlockIndex + 1, 0, newBlockWithFocusedState );
+				this.props.createBlockAction( newBlockWithFocusedState.clientId, newBlockWithFocusedState, clientId );
 				break;
 			case ToolbarButton.SETTINGS:
 				// TODO: implement settings

--- a/src/store/actions/index.js
+++ b/src/store/actions/index.js
@@ -4,10 +4,18 @@
  */
 
 import ActionTypes from './ActionTypes';
+import type { BlockType } from '../';
 
 export type BlockActionType = string => {
 	type: $Values<typeof ActionTypes.BLOCK>,
 	clientId: string,
+};
+
+export type CreateActionType = (string, BlockType, string) => {
+	type: $Values<typeof ActionTypes.BLOCK>,
+	clientId: string,
+	block: BlockType,
+	clientIdAbove: string,
 };
 
 export function updateBlockAttributes( clientId: string, attributes: mixed ) {
@@ -38,7 +46,7 @@ export const deleteBlockAction: BlockActionType = clientId => ( {
 	clientId,
 } );
 
-export const createBlockAction: BlockActionType = (clientId, block, clientIdAbove) => ( {
+export const createBlockAction: CreateActionType = (clientId, block, clientIdAbove) => ( {
 	type: ActionTypes.BLOCK.CREATE,
 	clientId,
 	block: block,

--- a/src/store/actions/index.js
+++ b/src/store/actions/index.js
@@ -11,7 +11,7 @@ export type BlockActionType = string => {
 	clientId: string,
 };
 
-export type CreateActionType = (string, BlockType, string) => {
+export type CreateActionType = ( string, BlockType, string ) => {
 	type: $Values<typeof ActionTypes.BLOCK>,
 	clientId: string,
 	block: BlockType,
@@ -46,9 +46,9 @@ export const deleteBlockAction: BlockActionType = clientId => ( {
 	clientId,
 } );
 
-export const createBlockAction: CreateActionType = (clientId, block, clientIdAbove) => ( {
+export const createBlockAction: CreateActionType = ( clientId, block, clientIdAbove ) => ( {
 	type: ActionTypes.BLOCK.CREATE,
 	clientId,
 	block: block,
-	clientIdAbove
+	clientIdAbove,
 } );

--- a/src/store/actions/index.js
+++ b/src/store/actions/index.js
@@ -40,7 +40,7 @@ export const deleteBlockAction: BlockActionType = clientId => ( {
 
 export const createBlockAction: BlockActionType = (clientId, block, clientIdAbove) => ( {
 	type: ActionTypes.BLOCK.CREATE,
-	block: block,
 	clientId,
+	block: block,
 	clientIdAbove
 } );

--- a/src/store/actions/index.js
+++ b/src/store/actions/index.js
@@ -38,8 +38,9 @@ export const deleteBlockAction: BlockActionType = clientId => ( {
 	clientId,
 } );
 
-export const createBlockAction: BlockActionType = (clientId, block) => ( {
+export const createBlockAction: BlockActionType = (clientId, block, clientIdAbove) => ( {
 	type: ActionTypes.BLOCK.CREATE,
 	block: block,
 	clientId,
+	clientIdAbove
 } );

--- a/src/store/actions/test.js
+++ b/src/store/actions/test.js
@@ -11,7 +11,7 @@ describe( 'Store', () => {
 		beforeAll( () => {
 			registerCoreBlocks();
 		} );
-	
+
 		it( 'should create an action to focus a block', () => {
 			const action = actions.focusBlockAction( '1' );
 			expect( action.type ).toBeDefined();
@@ -48,6 +48,5 @@ describe( 'Store', () => {
 			expect( action.block ).toEqual( newBlock );
 			expect( action.clientIdAbove ).toEqual( '0' );
 		} );
-
 	} );
 } );

--- a/src/store/actions/test.js
+++ b/src/store/actions/test.js
@@ -46,6 +46,7 @@ describe( 'Store', () => {
 			expect( action.type ).toEqual( ActionTypes.BLOCK.CREATE );
 			expect( action.clientId ).toEqual( '1' );
 			expect( action.block ).toEqual( newBlock );
+			expect( action.clientIdAbove ).toEqual( '0' );
 		} );
 
 	} );

--- a/src/store/actions/test.js
+++ b/src/store/actions/test.js
@@ -42,7 +42,7 @@ describe( 'Store', () => {
 
 		it( 'should create an action to create a block', () => {
 			const newBlock = createBlock( 'core/code', { content: 'new test text for a core/code block' } );
-			const action = actions.createBlockAction( '1', newBlock );
+			const action = actions.createBlockAction( '1', newBlock, '0' );
 			expect( action.type ).toEqual( ActionTypes.BLOCK.CREATE );
 			expect( action.clientId ).toEqual( '1' );
 			expect( action.block ).toEqual( newBlock );

--- a/src/store/reducers/index.js
+++ b/src/store/reducers/index.js
@@ -21,6 +21,21 @@ function findBlockIndex( blocks, clientId: string ) {
 	} );
 }
 
+/*
+ * insert block into blocks[], below / after block having clientIdAbove
+*/
+function insertBlock( blocks, block, clientIdAbove ) {
+	// TODO we need to set focused: true and search for the currently focused block and
+	// set that one to `focused: false`.
+	const insertionIndex = findBlockIndex( blocks, clientIdAbove );
+	if (insertionIndex === blocks.length - 1) {
+		// append new block to blocks list
+		blocks.push(block);
+	} else {
+		blocks.splice(insertionIndex + 1, 0, block);
+	}
+}
+
 export const reducer = (
 	state: StateType = { blocks: [], refresh: false },
 	action: BlockActionType
@@ -112,6 +127,7 @@ export const reducer = (
 			// TODO we need to set focused: true and search for the currently focused block and
 			// set that one to `focused: false`.
 			blocks.push(action.block);
+			insertBlock(blocks, action.block, action.clientIdAbove);
 			return { blocks: blocks, refresh: ! state.refresh };
 		}
 		default:

--- a/src/store/reducers/index.js
+++ b/src/store/reducers/index.js
@@ -126,7 +126,6 @@ export const reducer = (
 		case ActionTypes.BLOCK.CREATE: {
 			// TODO we need to set focused: true and search for the currently focused block and
 			// set that one to `focused: false`.
-			blocks.push(action.block);
 			insertBlock(blocks, action.block, action.clientIdAbove);
 			return { blocks: blocks, refresh: ! state.refresh };
 		}

--- a/src/store/reducers/index.js
+++ b/src/store/reducers/index.js
@@ -27,7 +27,7 @@ function findBlockIndex( blocks, clientId: string ) {
 function insertBlock( blocks, block, clientIdAbove ) {
 	// TODO we need to set focused: true and search for the currently focused block and
 	// set that one to `focused: false`.
-	blocks.splice( findBlockIndex( blocks, clientIdAbove ) + 1, 0, block);
+	blocks.splice( findBlockIndex( blocks, clientIdAbove ) + 1, 0, block );
 }
 
 export const reducer = (
@@ -120,7 +120,7 @@ export const reducer = (
 		case ActionTypes.BLOCK.CREATE: {
 			// TODO we need to set focused: true and search for the currently focused block and
 			// set that one to `focused: false`.
-			insertBlock(blocks, action.block, action.clientIdAbove);
+			insertBlock( blocks, action.block, action.clientIdAbove );
 			return { blocks: blocks, refresh: ! state.refresh };
 		}
 		default:

--- a/src/store/reducers/index.js
+++ b/src/store/reducers/index.js
@@ -27,13 +27,7 @@ function findBlockIndex( blocks, clientId: string ) {
 function insertBlock( blocks, block, clientIdAbove ) {
 	// TODO we need to set focused: true and search for the currently focused block and
 	// set that one to `focused: false`.
-	const insertionIndex = findBlockIndex( blocks, clientIdAbove );
-	if (insertionIndex === blocks.length - 1) {
-		// append new block to blocks list
-		blocks.push(block);
-	} else {
-		blocks.splice(insertionIndex + 1, 0, block);
-	}
+	blocks.splice( findBlockIndex( blocks, clientIdAbove ) + 1, 0, block);
 }
 
 export const reducer = (


### PR DESCRIPTION
_Closing #96 in favor of this one, as the base branch of #95 is not needed anymore, and avoid messing with commit history_

Adds direct insertion at a specific index in the list state. For the sake of the exercise in the GB mobile application for now we're inserting right below the tapped block.

Before, it would only _append_ new blocks to the list.

#### Android
![insertertake1direct](https://user-images.githubusercontent.com/6597771/43851449-210117e4-9b11-11e8-98d0-073644081d8b.gif)

#### iOS
![insertertake1direct_ios](https://user-images.githubusercontent.com/6597771/43851609-8508fc0c-9b11-11e8-8399-729732a9d7eb.gif)

