### PR TITLE
Inserter - have the RecyclerView update and re-draw item in onChange

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -117,6 +117,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		const dataSource = this.state.dataSource;
 		const block = dataSource.get( index );
 		block.attributes = attributes;
+		dataSource.set( index, block );
 		// Update Redux store
 		this.props.onChange( clientId, attributes );
 	}


### PR DESCRIPTION
After the change introduced in https://github.com/wordpress-mobile/gutenberg-mobile/pull/108, the first time the RecyclerView renders its items these will all have the same height, rendering some of the blocks "cut".

**BEFORE**
<img width="268" alt="screen shot 2018-08-14 at 11 21 29" src="https://user-images.githubusercontent.com/6597771/44097491-47110fe6-9fb4-11e8-899c-ad1f2bb8ba68.png">


**AFTER**
<img width="270" alt="screen shot 2018-08-14 at 11 22 09" src="https://user-images.githubusercontent.com/6597771/44097511-4fd7610c-9fb4-11e8-87c9-31bfc4a30f69.png">

This PR addresses this by making sure to set these items dirty, [signaling the RecyclerView to re-draw them](https://github.com/wordpress-mobile/react-native-recyclerview-list/blob/master/src/RecyclerViewList.js#L106) as `onChange` is received.