### PR TITLE
Inserter - show Picker with registered blocks to choose from

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -86,14 +86,14 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 
 		// create an empty block of the selected type
 		const newBlock = createBlock( itemValue, { content: 'new test text for a ' + itemValue + ' block' } );
-		const newBlockWithFocusedState = { ...newBlock, focused: false };
+		newBlock.focused = false;
 
 		// set it into the datasource, and use the same object instance to send it to props/redux
-		this.state.dataSource.splice( focusedItemIndex + 1, 0, newBlockWithFocusedState );
-		this.props.createBlockAction( newBlockWithFocusedState.clientId, newBlockWithFocusedState, clientIdFocused );
+		this.state.dataSource.splice( focusedItemIndex + 1, 0, newBlock );
+		this.props.createBlockAction( newBlock.clientId, newBlock, clientIdFocused );
 
 		// now set the focus
-		this.props.focusBlockAction( newBlockWithFocusedState.clientId );
+		this.props.focusBlockAction( newBlock.clientId );
 	}
 
 	onToolbarButtonPressed( button: number, clientId: string ) {

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -4,14 +4,14 @@
  */
 
 import React from 'react';
-import { Platform, Switch, Text, View, FlatList } from 'react-native';
+import { Platform, Switch, Text, View, FlatList, Picker } from 'react-native';
 import RecyclerViewList, { DataSource } from 'react-native-recyclerview-list';
 import BlockHolder from './block-holder';
 import { ToolbarButton } from './constants';
 import type { BlockType } from '../store/';
 import styles from './block-manager.scss';
 // Gutenberg imports
-import { getBlockType, serialize, createBlock } from '@wordpress/blocks';
+import { getBlockType, getBlockTypes, serialize, createBlock } from '@wordpress/blocks';
 
 export type BlockListType = {
 	onChange: ( clientId: string, attributes: mixed ) => void,
@@ -29,16 +29,21 @@ type PropsType = BlockListType;
 type StateType = {
 	dataSource: DataSource,
 	showHtml: boolean,
+	blockTypePickerVisible: boolean,
+	selectedBlockType: string,
 };
 
 export default class BlockManager extends React.Component<PropsType, StateType> {
 	_recycler = null;
+	availableBlockTypes = getBlockTypes();
 
 	constructor( props: PropsType ) {
 		super( props );
 		this.state = {
 			dataSource: new DataSource( this.props.blocks, ( item: BlockType ) => item.clientId ),
 			showHtml: false,
+			blockTypePickerVisible: false,
+			selectedBlockType: 'core/paragraph', // just any valid type to start from
 		};
 	}
 
@@ -54,6 +59,41 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 			}
 		}
 		return -1;
+	}
+
+	findDataSourceIndexForFocusedItem() {
+		for ( let i = 0; i < this.state.dataSource.size(); ++i ) {
+			const block = this.state.dataSource.get( i );
+			if ( block.focused === true ) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	// TODO: in the near future this will likely be changed to onShowBlockTypePicker and bound to this.props
+	// once we move the action to the toolbar
+	showBlockTypePicker() {
+		this.setState( { ...this.state, blockTypePickerVisible: true } );
+	}
+
+	onBlockTypeSelected( itemValue: string ) {
+		this.setState( { ...this.state, selectedBlockType: itemValue, blockTypePickerVisible: false } );
+
+		// find currently focused block
+		const focusedItemIndex = this.findDataSourceIndexForFocusedItem();
+		const clientIdFocused = this.state.dataSource.get( focusedItemIndex ).clientId;
+
+		// create an empty block of the selected type
+		const newBlock = createBlock( itemValue, { content: 'new test text for a ' + itemValue + ' block' } );
+		const newBlockWithFocusedState = { ...newBlock, focused: false };
+
+		// set it into the datasource, and use the same object instance to send it to props/redux
+		this.state.dataSource.splice( focusedItemIndex + 1, 0, newBlockWithFocusedState );
+		this.props.createBlockAction( newBlockWithFocusedState.clientId, newBlockWithFocusedState, clientIdFocused );
+
+		// now set the focus
+		this.props.focusBlockAction( newBlockWithFocusedState.clientId );
 	}
 
 	onToolbarButtonPressed( button: number, clientId: string ) {
@@ -72,11 +112,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 				this.props.deleteBlockAction( clientId );
 				break;
 			case ToolbarButton.PLUS:
-				// TODO: block type picker here instead of hardcoding a core/code block
-				const newBlock = createBlock( 'core/paragraph', { content: 'new test text for a core/paragraph block' } );
-				const newBlockWithFocusedState = { ...newBlock, focused: false };
-				this.state.dataSource.splice( dataSourceBlockIndex + 1, 0, newBlockWithFocusedState );
-				this.props.createBlockAction( newBlockWithFocusedState.clientId, newBlockWithFocusedState, clientId );
+				this.showBlockTypePicker();
 				break;
 			case ToolbarButton.SETTINGS:
 				// TODO: implement settings
@@ -145,6 +181,20 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 			);
 		}
 
+		const blockTypePicker = (
+			<View>
+				<Picker
+					selectedValue={ this.state.selectedBlockType }
+					onValueChange={ ( itemValue ) => {
+						this.onBlockTypeSelected( itemValue );
+					} } >
+					{ this.availableBlockTypes.map( ( item, index ) => {
+						return ( <Picker.Item label={ item.title } value={ item.name } key={ index + 1 } /> );
+					} ) }
+				</Picker>
+			</View>
+		);
+
 		return (
 			<View style={ styles.container }>
 				<View style={ { height: 30 } } />
@@ -159,6 +209,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 				</View>
 				{ this.state.showHtml && <Text style={ styles.htmlView }>{ this.serializeToHtml() }</Text> }
 				{ ! this.state.showHtml && list }
+				{ this.state.blockTypePickerVisible && blockTypePicker }
 			</View>
 		);
 	}


### PR DESCRIPTION
_Supersedes already reviewed/approved #105 to clean commit history_

This completes a very draft, initial 1st iteration on implementing the inserter flow. With this, the flow goes roughly along the lines of the expected actions like this:

1. focusing on an item shows an item toolbar which for now currently includes the `+` button to insert a new item (this `+` trigger will be moved to the toolbar as per the designs https://github.com/wordpress-mobile/gutenberg-mobile/issues/58#issuecomment-409571383)
2. tapping on `+ ` makes a RN `Picker` show up
3. tap on the picker to choose the type of block you'd like to insert
4. a newly created block is inserted right below the block that was being focused on.

![inserter-picker](https://user-images.githubusercontent.com/6597771/44030938-b8cb4fde-9ed8-11e8-8b9d-ea09fe1c765e.gif)

Known issues:
- the [RN `Picker`](https://facebook.github.io/react-native/docs/picker) component, though easy to use, as far as I could check only reacts when an item other than the currently selected value is chosen, and has had variable behavior in the recent past:
https://github.com/facebook/react-native/issues/15556
https://github.com/facebook/react-native/issues/15672
https://github.com/facebook/react-native/issues/13204
https://stackoverflow.com/questions/48465288/detect-selecting-current-selectedvalue-with-react-native-picker
Kind of makes sense with the prop name `onValueChange`, (i.e. I think from the name itself it derive that if the value didn't change, it won't be triggered) although it's not exactly what can be expected of the control (even the docs describe the prop function as `Callback for when an item is selected.`)

For this I'm working on another implementation with a modal dialog and a flatlist, but wanted to continue to put this PR up and complete a first "working" flow at least.
