### PR TITLE
Add `textAlignVertical` to html text input.

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -201,12 +201,12 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		return (
 			<KeyboardAvoidingView style={ { flex: 1 } } behavior={ behavior }>
 				<TextInput
+					textAlignVertical='top'
 					multiline
 					numberOfLines={ 0 }
 					style={ styles.htmlView }
 					value={ this.state.html }
 					onChangeText={ this.handleHTMLUpdate }>
-
 				</TextInput>
 			</KeyboardAvoidingView>
 		);


### PR DESCRIPTION
This is a first small step on improving the html text input UX.

This PR fixes the input view on Android when it is empty. Now the cursor goes to the top instead of the middle of the screen.

![cursor](https://user-images.githubusercontent.com/9772967/44103332-28938bee-9fa9-11e8-815c-15a22c8c1580.png)

**To test:**
- Run the project on Android.
- Switch to HTML view.
- Remove all the text.
- Check that the cursor is at the top.