### PR TITLE
HTML parser - restart datasource after full parse of html

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -61,6 +61,17 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		return -1;
 	}
 
+	static getDerivedStateFromProps( props: PropsType, state: StateType ) {
+		if ( props.fullparse === true ) {
+			return {
+				...state,
+				dataSource: new DataSource( props.blocks, ( item: BlockType ) => item.clientId ),
+			};
+		}
+		// no state change necessary
+		return null;
+	}
+
 	onToolbarButtonPressed( button: number, clientId: string ) {
 		const dataSourceBlockIndex = this.getDataSourceIndexFromUid( clientId );
 		switch ( button ) {
@@ -115,7 +126,8 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		const index = this.getDataSourceIndexFromUid( clientId );
 		const dataSource = this.state.dataSource;
 		const block = dataSource.get( this.getDataSourceIndexFromUid( clientId ) );
-		dataSource.set( index, { ...block, attributes: attributes } );
+		block.attributes = attributes;
+		dataSource.set( index, block );
 		// Update Redux store
 		this.props.onChange( clientId, attributes );
 	}

--- a/src/store/reducers/index.js
+++ b/src/store/reducers/index.js
@@ -111,7 +111,7 @@ export const reducer = (
 		}
 		case ActionTypes.BLOCK.PARSE: {
 			const parsed = parse(action.html)
-			return { blocks: parsed, refresh: state.refresh };
+			return { blocks: parsed, refresh: ! state.refresh, fullparse: true };
 		}
 		default:
 			return state;


### PR DESCRIPTION
This PR performs a `dataSource` re-init (by recreating the object in the `state`) when a full `parse` has taken place. While we've avoided re-creating the list's `dataSource` in other cases, I think it makes sense to do so after an html-to-blocks conversion has taken place. 

This makes sure the state of `dataSource`, and `props` are aligned, and fixes the detail described in #100 here:

> On Android, this currently won't work, but this issue was taken care of by #95. [...]

To test (on Android):
1. start the demo app
2. edit one of the known blocks such as paragraph or heading
3. wait a bit so Aztec makes the change signaling happen (at least 500 miliseconds ;) ) _this is something we'll probably need to take a look into at some point_
3. switch to HTML view
4. observe the html contents show the entered text in the edited blocks
5. edit such blocks again (without breaking the delimiters)
6. switch back from html
7. observe the new text is in place, in the visual mode.


Idea to make this better at some point in the future: only pass the `fullparse: true` value when no edits have been in place (maybe at least check the length?)
