### PR TITLE
Remove the babel module resolver

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,21 +4,6 @@
   ],
   "plugins": [
     "react-require",
-    [
-      "module-resolver",
-      {
-        "cwd": "babelrc",
-        "alias": {          
-          "@gutenberg": "./gutenberg"
-        },
-        "extensions": [
-          ".js",
-          ".native.js",
-          ".ios.js",
-          ".android.js"
-        ]
-      }
-    ],
     "transform-async-to-generator",
     "transform-async-generator-functions",
     "react-native-classname-to-style",

--- a/.flowconfig
+++ b/.flowconfig
@@ -84,7 +84,7 @@ module.file_ext=.scss
 munge_underscores=true
 
 module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> 'RelativeImageStub'
-module.name_mapper='@gutenberg' -> '<PROJECT_ROOT>/gutenberg'
+module.name_mapper='@wordpress/block-library' -> '<PROJECT_ROOT>/gutenberg/packages/block-library/src'
 module.name_mapper='@wordpress/blocks' -> '<PROJECT_ROOT>/gutenberg/packages/blocks/src'
 module.name_mapper='@wordpress/element' -> '<PROJECT_ROOT>/gutenberg/packages/element/src'
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -32,7 +32,6 @@ module.exports = {
 	],
 	moduleNameMapper: {
 		'@wordpress\\/(blocks|data|element|deprecated|editor|redux-routine|block-library)$': '<rootDir>/gutenberg/packages/$1/src/index',
-		'@gutenberg': '<rootDir>/gutenberg',
 
 		// Mock the CSS modules. See https://facebook.github.io/jest/docs/en/webpack.html#handling-static-assets
 		'\\.(scss)$': '<rootDir>/__mocks__/styleMock.js',

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,7 @@ if ( process.env.TEST_RN_PLATFORM ) {
 }
 
 module.exports = {
+	verbose: true,
 	preset: 'jest-react-native',
 	testEnvironment: 'jsdom',
 	testPathIgnorePatterns: [ '/node_modules/', '/gutenberg/' ],

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "@wordpress/hooks": "^1.2.1",
     "@wordpress/i18n": "^1.1.0",
     "@wordpress/is-shallow-equal": "^1.0.1",
-    "babel-plugin-module-resolver": "^3.1.0",
     "babel-preset-es2015": "^6.24.1",
     "classnames": "^2.2.5",
     "dom-react": "^2.2.1",

--- a/src/parser/block-parser-code.test.js
+++ b/src/parser/block-parser-code.test.js
@@ -2,7 +2,7 @@
 
 import '../globals';
 
-import { registerCoreBlocks } from '@gutenberg/core-blocks';
+import { registerCoreBlocks } from '@wordpress/block-library';
 import { parse } from '@wordpress/blocks';
 
 registerCoreBlocks();

--- a/src/parser/block-parser-more.test.js
+++ b/src/parser/block-parser-more.test.js
@@ -2,7 +2,7 @@
 
 import '../globals';
 
-import { registerCoreBlocks } from '@gutenberg/core-blocks';
+import { registerCoreBlocks } from '@wordpress/block-library';
 import { parse } from '@wordpress/blocks';
 
 registerCoreBlocks();

--- a/src/parser/block-parser-paragraph.test.js
+++ b/src/parser/block-parser-paragraph.test.js
@@ -2,7 +2,7 @@
 
 import '../globals';
 
-import { registerCoreBlocks } from '@gutenberg/core-blocks';
+import { registerCoreBlocks } from '@wordpress/block-library';
 import { parse } from '@wordpress/blocks';
 
 registerCoreBlocks();

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,7 +4,7 @@
  */
 
 // Gutenberg imports
-import { registerCoreBlocks } from '@gutenberg/core-blocks';
+import { registerCoreBlocks } from '@wordpress/block-library';
 import { parse } from '@wordpress/blocks';
 
 import { createStore } from 'redux';

--- a/src/store/reducers/test.js
+++ b/src/store/reducers/test.js
@@ -4,7 +4,7 @@
 
 import { reducer } from './';
 import * as actions from '../actions/';
-import { registerCoreBlocks } from '@gutenberg/core-blocks';
+import { registerCoreBlocks } from '@wordpress/block-library';
 
 describe( 'Store', () => {
 	describe( 'reducer', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1149,16 +1149,6 @@ babel-plugin-jest-hoist@^22.4.4:
   version "22.4.4"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.4.tgz#b9851906eab34c7bf6f8c895a2b08bea1a844c0b"
 
-babel-plugin-module-resolver@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.1.1.tgz#881cf67e3d4b8400d5eaaefc1be44d2dc1fe404f"
-  dependencies:
-    find-babel-config "^1.1.0"
-    glob "^7.1.2"
-    pkg-up "^2.0.0"
-    reselect "^3.0.1"
-    resolve "^1.4.0"
-
 babel-plugin-react-native-classname-to-style@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-react-native-classname-to-style/-/babel-plugin-react-native-classname-to-style-1.2.1.tgz#364182bbc7d1929242a7a09598f873c5e97350dd"
@@ -3402,13 +3392,6 @@ finalhandler@1.1.0:
     parseurl "~1.3.2"
     statuses "~1.3.1"
     unpipe "~1.0.0"
-
-find-babel-config@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.1.0.tgz#acc01043a6749fec34429be6b64f542ebb5d6355"
-  dependencies:
-    json5 "^0.5.1"
-    path-exists "^3.0.0"
 
 find-cache-dir@^1.0.0:
   version "1.0.0"
@@ -5969,12 +5952,6 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-pkg-up@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
-  dependencies:
-    find-up "^2.1.0"
-
 plist@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/plist/-/plist-2.0.1.tgz#0a32ca9481b1c364e92e18dc55c876de9d01da8b"
@@ -6806,10 +6783,6 @@ requireindex@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
 
-reselect@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
-
 reserved-words@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/reserved-words/-/reserved-words-0.1.2.tgz#00a0940f98cd501aeaaac316411d9adc52b31ab1"
@@ -6836,7 +6809,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.3.2, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0:
+resolve@^1.3.2, resolve@^1.3.3, resolve@^1.5.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:


### PR DESCRIPTION
This PR:

* Fixes the `wp.coreBlocks.registerCoreBlocks is deprecated and will be removed in 3.8. Please use wp.blockLibrary.registerCoreBlocks instead.` warning by pointing to the `@wordpress/block-library` package
* Removes the `@gutenberg` alias from the Babel, Flow and Jest configurations
* Removed the `babel-plugin-module-resolver` mapping plugin as it's no longer needed 🎉

To test:

Run the app and tests and everything should work fine and without the warning about the `wp.coreBlocks.registerCoreBlocks` deprecation.