### PR TITLE
Feature/inserter modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "node-sass": "^4.8.3",
     "react": "16.3.1",
     "react-native": "0.55.4",
+    "react-native-modal": "^6.5.0",
     "react-native-recyclerview-list": "git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#bfccbaab6b5954e18f8b0ed441ba38275853b79c",
     "react-redux": "^5.0.7",
     "redux": "^3.7.2",

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -205,8 +205,8 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 				onDismiss={ () => {
 					this.showBlockTypePicker( false );
 				} }
-				onValueSelected={ ( itemValue, itemIndex ) => {
-					this.onBlockTypeSelected( itemValue, itemIndex );
+				onValueSelected={ ( itemValue ) => {
+					this.onBlockTypeSelected( itemValue );
 				} } />
 		);
 

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -200,16 +200,14 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		}
 
 		const blockTypePicker = (
-			<View>
-				<BlockPicker
-					visible={ this.state.blockTypePickerVisible }
-					onDismiss={ () => {
-						this.showBlockTypePicker( false );
-					} }
-					onValueSelected={ ( itemValue, itemIndex ) => {
-						this.onBlockTypeSelected( itemValue, itemIndex );
-					} } />
-			</View>
+			<BlockPicker
+				visible={ this.state.blockTypePickerVisible }
+				onDismiss={ () => {
+					this.showBlockTypePicker( false );
+				} }
+				onValueSelected={ ( itemValue, itemIndex ) => {
+					this.onBlockTypeSelected( itemValue, itemIndex );
+				} } />
 		);
 
 		return (

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { Platform, Switch, Text, View, FlatList, Picker, TextInput, KeyboardAvoidingView } from 'react-native';
+import { Platform, Switch, Text, View, FlatList, TextInput, KeyboardAvoidingView } from 'react-native';
 import RecyclerViewList, { DataSource } from 'react-native-recyclerview-list';
 import BlockHolder from './block-holder';
 import { ToolbarButton } from './constants';
@@ -38,7 +38,6 @@ type StateType = {
 
 export default class BlockManager extends React.Component<PropsType, StateType> {
 	_recycler = null;
-	blockTypePickerRef = null;
 	availableBlockTypes = getBlockTypes();
 
 	constructor( props: PropsType ) {
@@ -204,27 +203,13 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 			);
 		}
 
-		const blockTypePicker = (
-			<View>
-				<Picker
-					selectedValue={ this.state.selectedBlockType }
-					onValueChange={ ( itemValue ) => {
-						this.onBlockTypeSelected( itemValue );
-					} } >
-					{ this.availableBlockTypes.map( ( item, index ) => {
-						return ( <Picker.Item label={ item.title } value={ item.name } key={ index + 1 } /> );
-					} ) }
-				</Picker>
-			</View>
-		);
-
-		let blockTypePicker2 = (
+		let blockTypePicker = (
 			<View>
 				<BlockPicker 
 					visible={ this.state.blockTypePickerVisible }
 					onDismiss={ () => { this.showBlockTypePicker( false ) } }
-					onValueSelected={ ( itemValue ) => {
-						this.onBlockTypeSelected( itemValue );
+					onValueSelected={ ( itemValue, itemIndex ) => {
+						this.onBlockTypeSelected( itemValue, itemIndex );
 					} } />
 			</View>
 		);
@@ -243,8 +228,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 				</View>
 				{ this.state.showHtml && this.renderHTML() }
 				{ ! this.state.showHtml && list }
-				{/* { this.state.blockTypePickerVisible && blockTypePicker2 } */}
-				{ blockTypePicker2 }
+				{ blockTypePicker }
 			</View>
 		);
 	}

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -10,6 +10,7 @@ import BlockHolder from './block-holder';
 import { ToolbarButton } from './constants';
 import type { BlockType } from '../store/';
 import styles from './block-manager.scss';
+import BlockPicker from './block-picker';
 // Gutenberg imports
 import { getBlockType, getBlockTypes, serialize, createBlock } from '@wordpress/blocks';
 
@@ -37,6 +38,7 @@ type StateType = {
 
 export default class BlockManager extends React.Component<PropsType, StateType> {
 	_recycler = null;
+	blockTypePickerRef = null;
 	availableBlockTypes = getBlockTypes();
 
 	constructor( props: PropsType ) {
@@ -76,11 +78,11 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 
 	// TODO: in the near future this will likely be changed to onShowBlockTypePicker and bound to this.props
 	// once we move the action to the toolbar
-	showBlockTypePicker() {
-		this.setState( { ...this.state, blockTypePickerVisible: true } );
+	showBlockTypePicker( show: boolean ) {
+		this.setState( { ...this.state, blockTypePickerVisible: show } );
 	}
 
-	onBlockTypeSelected( itemValue: string ) {
+	onBlockTypeSelected( itemValue: string, itemIndex: number ) {
 		this.setState( { ...this.state, selectedBlockType: itemValue, blockTypePickerVisible: false } );
 
 		// find currently focused block
@@ -126,7 +128,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 				this.props.deleteBlockAction( clientId );
 				break;
 			case ToolbarButton.PLUS:
-				this.showBlockTypePicker();
+				this.showBlockTypePicker( true );
 				break;
 			case ToolbarButton.SETTINGS:
 				// TODO: implement settings
@@ -216,6 +218,17 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 			</View>
 		);
 
+		let blockTypePicker2 = (
+			<View>
+				<BlockPicker 
+					visible={ this.state.blockTypePickerVisible }
+					onDismiss={ () => { this.showBlockTypePicker( false ) } }
+					onValueSelected={ ( itemValue ) => {
+						this.onBlockTypeSelected( itemValue );
+					} } />
+			</View>
+		);
+
 		return (
 			<View style={ styles.container }>
 				<View style={ { height: 30 } } />
@@ -230,7 +243,8 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 				</View>
 				{ this.state.showHtml && this.renderHTML() }
 				{ ! this.state.showHtml && list }
-				{ this.state.blockTypePickerVisible && blockTypePicker }
+				{/* { this.state.blockTypePickerVisible && blockTypePicker2 } */}
+				{ blockTypePicker2 }
 			</View>
 		);
 	}

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -12,7 +12,7 @@ import type { BlockType } from '../store/';
 import styles from './block-manager.scss';
 import BlockPicker from './block-picker';
 // Gutenberg imports
-import { getBlockType, getBlockTypes, serialize, createBlock } from '@wordpress/blocks';
+import { getBlockType, serialize, createBlock } from '@wordpress/blocks';
 
 export type BlockListType = {
 	onChange: ( clientId: string, attributes: mixed ) => void,
@@ -38,7 +38,6 @@ type StateType = {
 
 export default class BlockManager extends React.Component<PropsType, StateType> {
 	_recycler = null;
-	availableBlockTypes = getBlockTypes();
 
 	constructor( props: PropsType ) {
 		super( props );
@@ -81,7 +80,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		this.setState( { ...this.state, blockTypePickerVisible: show } );
 	}
 
-	onBlockTypeSelected( itemValue: string, itemIndex: number ) {
+	onBlockTypeSelected( itemValue: string ) {
 		this.setState( { ...this.state, selectedBlockType: itemValue, blockTypePickerVisible: false } );
 
 		// find currently focused block
@@ -203,11 +202,13 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 			);
 		}
 
-		let blockTypePicker = (
+		const blockTypePicker = (
 			<View>
-				<BlockPicker 
+				<BlockPicker
 					visible={ this.state.blockTypePickerVisible }
-					onDismiss={ () => { this.showBlockTypePicker( false ) } }
+					onDismiss={ () => {
+						this.showBlockTypePicker( false );
+					} }
 					onValueSelected={ ( itemValue, itemIndex ) => {
 						this.onBlockTypeSelected( itemValue, itemIndex );
 					} } />

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -245,16 +245,27 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 	}
 
 	renderItem( value: { item: BlockType, clientId: string } ) {
+		const insertHere = (
+			<View style={ styles.containerStyleAddHere } >
+				<View style={ styles.lineStyleAddHere }></View>
+				<Text style={ styles.labelStyleAddHere } >ADD BLOCK HERE</Text>
+				<View style={ styles.lineStyleAddHere }></View>
+			</View>
+		);
+
 		return (
-			<BlockHolder
-				key={ value.clientId }
-				onToolbarButtonPressed={ this.onToolbarButtonPressed.bind( this ) }
-				onBlockHolderPressed={ this.onBlockHolderPressed.bind( this ) }
-				onChange={ this.onChange.bind( this ) }
-				focused={ value.item.focused }
-				clientId={ value.clientId }
-				{ ...value.item }
-			/>
+			<View>
+				<BlockHolder
+					key={ value.clientId }
+					onToolbarButtonPressed={ this.onToolbarButtonPressed.bind( this ) }
+					onBlockHolderPressed={ this.onBlockHolderPressed.bind( this ) }
+					onChange={ this.onChange.bind( this ) }
+					focused={ value.item.focused }
+					clientId={ value.clientId }
+					{ ...value.item }
+				/>
+				{ this.state.blockTypePickerVisible && value.item.focused && insertHere }
+			</View>
 		);
 	}
 

--- a/src/block-management/block-manager.scss
+++ b/src/block-management/block-manager.scss
@@ -27,3 +27,24 @@
 	flex-direction: row;
 	justify-content: flex-start;
 }
+
+.lineStyleAddHere {
+	flex: 1;
+	background-color: #0087be; // blue_wordpress
+	align-self: center;
+	height: 2px;
+}
+
+.labelStyleAddHere {
+	flex: 1;
+	text-align: center;
+	font-family: $default-monospace-font;
+	font-size: 12px;
+	font-weight: bold;
+}
+
+.containerStyleAddHere {
+	flex: 1;
+	flex-direction: row;
+	background-color: white;
+}

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -1,4 +1,4 @@
-	/**
+/**
  * @format
  * @flow
  */
@@ -40,7 +40,8 @@ export default class BlockPicker extends Component<PropsType, StateType> {
 				onSwipe={ this.props.onDismiss.bind( this ) }
 				swipeDirection="down"
 				style={ [ styles.bottomModal, this.props.style ] }
-				backdropColor={ 'grey' }
+				backdropColor={ 'lightgrey' }
+				backdropOpacity={ 0.4 }
 				onBackdropPress={ this.props.onDismiss.bind( this ) }>
 				<View style={ styles.modalContent }>
 					<View style={ styles.shortLineStyle } />
@@ -53,10 +54,10 @@ export default class BlockPicker extends Component<PropsType, StateType> {
 						data={ this.availableBlockTypes }
 						keyExtractor={ ( item ) => item.name }
 						renderItem={ ( { item } ) =>
-							<TouchableHighlight 
-								style= { styles.touchableArea }
-								underlayColor= { 'transparent' }
-								activeOpacity= { .5 }
+							<TouchableHighlight
+								style={ styles.touchableArea }
+								underlayColor={ 'transparent' }
+								activeOpacity={ .5 }
 								onPress={ this.props.onValueSelected.bind( this, item.name ) }>
 								<View style={ styles.modalItem }>
 									<View style={ styles.modalIcon }>

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -62,7 +62,7 @@ export default class BlockPicker extends Component<PropsType, StateType> {
 								<View style={ styles.modalItem }>
 									<View style={ styles.modalIcon }>
 										{ /* TODO: ICON IMAGE GOES HERE */ }
-										{/* <Text>{ item.icon.src }</Text> */}
+										{ /* <Text>{ item.icon.src }</Text> */ }
 										<Text>icon</Text>
 									</View>
 									<Text style={ styles.modalItemLabel }>{ item.title }</Text>

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -16,6 +16,7 @@ type PropsType = {
 	onDismiss: () => void,
 };
 
+// TODO: not used for now - will hold currently selected Block Type, probably makes sense for the inspector
 type StateType = {
 	selectedIndex: number,
 };

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -40,6 +40,7 @@ export default class BlockPicker extends Component<PropsType, StateType> {
 				onSwipe={ this.props.onDismiss.bind( this ) }
 				swipeDirection="down"
 				style={ [ styles.bottomModal, this.props.style ] }
+				backdropColor={ 'grey' }
 				onBackdropPress={ this.props.onDismiss.bind( this ) }>
 				<View style={ styles.modalContent }>
 					<View>

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -1,0 +1,66 @@
+/**
+ * @format
+ * @flow
+ */
+import React, {Component} from 'react';
+import {StyleSheet, Text, TouchableHighlight, View} from 'react-native';
+import Modal from 'react-native-modal';
+
+type PropsType =  {
+	uid: string,
+	onValueSelected: ( itemValue: string, itemIndex: number ) => void,
+	onDismiss: () => void,
+};
+
+type StateType = {
+	selectedIndex: number,
+};
+
+const style = StyleSheet.create({
+    bottomModal: {
+        justifyContent: "flex-end",
+        margin: 0
+      },
+  });
+
+ export default class BlockPicker extends Component<PropsType, StateType> {
+	constructor( props: PropsType ) {
+		super( props );
+		this.state = {
+            selectedIndex: 0,
+            //modalVisible: false,
+			//focused: false,
+		};
+	}
+    
+    // setModalVisible(visible) {
+    //     this.setState({modalVisible: visible});
+    // }
+
+   render() {
+    return (
+        <Modal
+          animationType="slide"
+          transparent={false}
+          isVisible={ this.props.visible }
+        //   onSwipe={() => this.setState({ modalVisible: null })}
+          onSwipe={ this.props.onDismiss.bind( this ) }
+          swipeDirection="down"
+          style={style.bottomModal}>
+          <View style={{marginTop: 22}}>
+            <View>
+              <Text>Hello World!</Text>
+               <TouchableHighlight
+				onPress={ this.props.onValueSelected.bind( this, 'core/paragraph', 1 ) }
+                // onPress={() => {
+                //   this.setModalVisible(!this.state.modalVisible);
+                // }}
+                >
+                <Text>Hide Modal</Text>
+              </TouchableHighlight>
+            </View>
+          </View>
+        </Modal>
+    );
+  }
+} 

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -20,13 +20,18 @@ type StateType = {
 
 const style = StyleSheet.create( {
 	bottomModal: {
-		justifyContent: 'flex-end',
-		backgroundColor: 'white',
-		padding: 22,
-		alignItems: 'center',
-		borderRadius: 4,
-		borderColor: 'rgba(0, 0, 0, 0.1)',
+		justifyContent: "flex-end",
+		margin: 0
 	},
+
+    modalContent: {
+        backgroundColor: "white",
+        padding: 22,
+        justifyContent: "center",
+        alignItems: "center",
+        borderRadius: 4,
+        borderColor: "rgba(0, 0, 0, 0.1)"
+    },
 } );
 
 export default class BlockPicker extends Component<PropsType, StateType> {
@@ -42,19 +47,20 @@ export default class BlockPicker extends Component<PropsType, StateType> {
 	render() {
 		return (
 			<Modal
-            animationType="slide"
-                transparent={false}
+                animationType="slide"
+                transparent={ true }
                 isVisible={ this.props.visible }
                 onSwipe={ this.props.onDismiss.bind( this ) }
                 swipeDirection="down"
-                style={style.bottomModal}>
-                <View style={{marginTop: 22}}>
+                style={[style.bottomModal, this.props.style]}
+                onBackdropPress={ this.props.onDismiss.bind( this ) }>
+                <View style={style.modalContent}>
                     <FlatList
                         data={ this.availableBlockTypes }
                         keyExtractor={ ( item ) => item.name }
                         renderItem={({item}) =>
                             <TouchableHighlight onPress={ this.props.onValueSelected.bind( this, item.name, 1 ) }>
-                                <View style={{backgroundColor: 'white'}}>
+                                <View style={ { backgroundColor: 'white' } }>
                                     <Text>{item.name}</Text>
                                 </View>
                             </TouchableHighlight>

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -10,8 +10,8 @@ import styles from './block-picker.scss';
 import { getBlockTypes } from '@wordpress/blocks';
 
 type PropsType = {
-    visible: boolean,
-    style?: StyleSheet,
+	visible: boolean,
+	style?: StyleSheet,
 	onValueSelected: ( itemValue: string, itemIndex: number ) => void,
 	onDismiss: () => void,
 };
@@ -33,27 +33,27 @@ export default class BlockPicker extends Component<PropsType, StateType> {
 	render() {
 		return (
 			<Modal
-                animationType="slide"
-                transparent={ true }
-                isVisible={ this.props.visible }
-                onSwipe={ this.props.onDismiss.bind( this ) }
-                swipeDirection="down"
-                style={[styles.bottomModal, this.props.style]}
-                onBackdropPress={ this.props.onDismiss.bind( this ) }>
-                <View style={styles.modalContent}>
-                    <FlatList
-                        data={ this.availableBlockTypes }
-                        keyExtractor={ ( item ) => item.name }
-                        renderItem={({item}) =>
-                            <TouchableHighlight onPress={ this.props.onValueSelected.bind( this, item.name, 1 ) }>
-                                <View style={ { backgroundColor: 'white' } }>
-                                    <Text>{item.name}</Text>
-                                </View>
-                            </TouchableHighlight>
-                        }
-                    />
-                </View>
-            </Modal>
-        );
-  }
-} 
+				animationType="slide"
+				transparent={ true }
+				isVisible={ this.props.visible }
+				onSwipe={ this.props.onDismiss.bind( this ) }
+				swipeDirection="down"
+				style={ [ styles.bottomModal, this.props.style ] }
+				onBackdropPress={ this.props.onDismiss.bind( this ) }>
+				<View style={ styles.modalContent }>
+					<FlatList
+						data={ this.availableBlockTypes }
+						keyExtractor={ ( item ) => item.name }
+						renderItem={ ( { item } ) =>
+							<TouchableHighlight onPress={ this.props.onValueSelected.bind( this, item.name, 1 ) }>
+								<View style={ { backgroundColor: 'white' } }>
+									<Text>{ item.name }</Text>
+								</View>
+							</TouchableHighlight>
+						}
+					/>
+				</View>
+			</Modal>
+		);
+	}
+}

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -52,7 +52,11 @@ export default class BlockPicker extends Component<PropsType, StateType> {
 						data={ this.availableBlockTypes }
 						keyExtractor={ ( item ) => item.name }
 						renderItem={ ( { item } ) =>
-							<TouchableHighlight onPress={ this.props.onValueSelected.bind( this, item.name ) }>
+							<TouchableHighlight 
+								style= { styles.touchableArea }
+								underlayColor= { 'transparent' }
+								activeOpacity= { .5 }
+								onPress={ this.props.onValueSelected.bind( this, item.name ) }>
 								<View style={ styles.modalItem }>
 									<View style={ styles.modalIcon }>
 										{ /* TODO: ICON IMAGE GOES HERE */ }

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -42,7 +42,12 @@ export default class BlockPicker extends Component<PropsType, StateType> {
 				style={ [ styles.bottomModal, this.props.style ] }
 				onBackdropPress={ this.props.onDismiss.bind( this ) }>
 				<View style={ styles.modalContent }>
+					<View>
+						<Text style={ styles.title }>ADD BLOCK</Text>
+					</View>
+					<View style={ styles.lineStyle }/>
 					<FlatList
+						numColumns={ 3 }
 						data={ this.availableBlockTypes }
 						keyExtractor={ ( item ) => item.name }
 						renderItem={ ( { item } ) =>

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -45,15 +45,18 @@ export default class BlockPicker extends Component<PropsType, StateType> {
 					<View>
 						<Text style={ styles.title }>ADD BLOCK</Text>
 					</View>
-					<View style={ styles.lineStyle }/>
+					<View style={ styles.lineStyle } />
 					<FlatList
 						numColumns={ 3 }
 						data={ this.availableBlockTypes }
 						keyExtractor={ ( item ) => item.name }
 						renderItem={ ( { item } ) =>
 							<TouchableHighlight onPress={ this.props.onValueSelected.bind( this, item.name ) }>
-								<View style={ { backgroundColor: 'white' } }>
-									<Text>{ item.title }</Text>
+								<View style={ styles.modalItem }>
+									<View style={ styles.modalIcon }>
+										{ /* TODO: ICON IMAGE GOES HERE */ }
+									</View>
+									<Text style={ styles.modalItemLabel }>{ item.title }</Text>
 								</View>
 							</TouchableHighlight>
 						}

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -62,6 +62,8 @@ export default class BlockPicker extends Component<PropsType, StateType> {
 								<View style={ styles.modalItem }>
 									<View style={ styles.modalIcon }>
 										{ /* TODO: ICON IMAGE GOES HERE */ }
+										{/* <Text>{ item.icon.src }</Text> */}
+										<Text>icon</Text>
 									</View>
 									<Text style={ styles.modalItemLabel }>{ item.title }</Text>
 								</View>

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -3,8 +3,9 @@
  * @flow
  */
 import React, { Component } from 'react';
-import { StyleSheet, FlatList, Text, TouchableHighlight, View } from 'react-native';
+import { FlatList, Text, TouchableHighlight, View } from 'react-native';
 import Modal from 'react-native-modal';
+import styles from './block-picker.scss';
 // Gutenberg imports
 import { getBlockTypes } from '@wordpress/blocks';
 
@@ -18,22 +19,6 @@ type PropsType = {
 type StateType = {
 	selectedIndex: number,
 };
-
-const style = StyleSheet.create( {
-	bottomModal: {
-		justifyContent: "flex-end",
-		margin: 0
-	},
-
-    modalContent: {
-        backgroundColor: "white",
-        padding: 22,
-        justifyContent: "center",
-        alignItems: "center",
-        borderRadius: 4,
-        borderColor: "rgba(0, 0, 0, 0.1)"
-    },
-} );
 
 export default class BlockPicker extends Component<PropsType, StateType> {
 	availableBlockTypes = getBlockTypes();
@@ -53,9 +38,9 @@ export default class BlockPicker extends Component<PropsType, StateType> {
                 isVisible={ this.props.visible }
                 onSwipe={ this.props.onDismiss.bind( this ) }
                 swipeDirection="down"
-                style={[style.bottomModal, this.props.style]}
+                style={[styles.bottomModal, this.props.style]}
                 onBackdropPress={ this.props.onDismiss.bind( this ) }>
-                <View style={style.modalContent}>
+                <View style={styles.modalContent}>
                     <FlatList
                         data={ this.availableBlockTypes }
                         keyExtractor={ ( item ) => item.name }

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -10,6 +10,7 @@ import { getBlockTypes } from '@wordpress/blocks';
 
 type PropsType = {
     visible: boolean,
+    style?: StyleSheet,
 	onValueSelected: ( itemValue: string, itemIndex: number ) => void,
 	onDismiss: () => void,
 };

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -2,12 +2,14 @@
  * @format
  * @flow
  */
-import React, {Component} from 'react';
-import {StyleSheet, Text, TouchableHighlight, View} from 'react-native';
+import React, { Component } from 'react';
+import { StyleSheet, FlatList, Text, TouchableHighlight, View } from 'react-native';
 import Modal from 'react-native-modal';
+// Gutenberg imports
+import { getBlockTypes } from '@wordpress/blocks';
 
-type PropsType =  {
-	uid: string,
+type PropsType = {
+    visible: boolean,
 	onValueSelected: ( itemValue: string, itemIndex: number ) => void,
 	onDismiss: () => void,
 };
@@ -16,51 +18,50 @@ type StateType = {
 	selectedIndex: number,
 };
 
-const style = StyleSheet.create({
-    bottomModal: {
-        justifyContent: "flex-end",
-        margin: 0
-      },
-  });
+const style = StyleSheet.create( {
+	bottomModal: {
+		justifyContent: 'flex-end',
+		backgroundColor: 'white',
+		padding: 22,
+		alignItems: 'center',
+		borderRadius: 4,
+		borderColor: 'rgba(0, 0, 0, 0.1)',
+	},
+} );
 
- export default class BlockPicker extends Component<PropsType, StateType> {
+export default class BlockPicker extends Component<PropsType, StateType> {
+	availableBlockTypes = getBlockTypes();
+
 	constructor( props: PropsType ) {
 		super( props );
 		this.state = {
-            selectedIndex: 0,
-            //modalVisible: false,
-			//focused: false,
+			selectedIndex: 0,
 		};
 	}
-    
-    // setModalVisible(visible) {
-    //     this.setState({modalVisible: visible});
-    // }
 
-   render() {
-    return (
-        <Modal
-          animationType="slide"
-          transparent={false}
-          isVisible={ this.props.visible }
-        //   onSwipe={() => this.setState({ modalVisible: null })}
-          onSwipe={ this.props.onDismiss.bind( this ) }
-          swipeDirection="down"
-          style={style.bottomModal}>
-          <View style={{marginTop: 22}}>
-            <View>
-              <Text>Hello World!</Text>
-               <TouchableHighlight
-				onPress={ this.props.onValueSelected.bind( this, 'core/paragraph', 1 ) }
-                // onPress={() => {
-                //   this.setModalVisible(!this.state.modalVisible);
-                // }}
-                >
-                <Text>Hide Modal</Text>
-              </TouchableHighlight>
-            </View>
-          </View>
-        </Modal>
-    );
+	render() {
+		return (
+			<Modal
+            animationType="slide"
+                transparent={false}
+                isVisible={ this.props.visible }
+                onSwipe={ this.props.onDismiss.bind( this ) }
+                swipeDirection="down"
+                style={style.bottomModal}>
+                <View style={{marginTop: 22}}>
+                    <FlatList
+                        data={ this.availableBlockTypes }
+                        keyExtractor={ ( item ) => item.name }
+                        renderItem={({item}) =>
+                            <TouchableHighlight onPress={ this.props.onValueSelected.bind( this, item.name, 1 ) }>
+                                <View style={{backgroundColor: 'white'}}>
+                                    <Text>{item.name}</Text>
+                                </View>
+                            </TouchableHighlight>
+                        }
+                    />
+                </View>
+            </Modal>
+        );
   }
 } 

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -1,4 +1,4 @@
-/**
+	/**
  * @format
  * @flow
  */
@@ -43,6 +43,7 @@ export default class BlockPicker extends Component<PropsType, StateType> {
 				backdropColor={ 'grey' }
 				onBackdropPress={ this.props.onDismiss.bind( this ) }>
 				<View style={ styles.modalContent }>
+					<View style={ styles.shortLineStyle } />
 					<View>
 						<Text style={ styles.title }>ADD BLOCK</Text>
 					</View>

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -46,9 +46,9 @@ export default class BlockPicker extends Component<PropsType, StateType> {
 						data={ this.availableBlockTypes }
 						keyExtractor={ ( item ) => item.name }
 						renderItem={ ( { item } ) =>
-							<TouchableHighlight onPress={ this.props.onValueSelected.bind( this, item.name, 1 ) }>
+							<TouchableHighlight onPress={ this.props.onValueSelected.bind( this, item.name ) }>
 								<View style={ { backgroundColor: 'white' } }>
-									<Text>{ item.name }</Text>
+									<Text>{ item.title }</Text>
 								</View>
 							</TouchableHighlight>
 						}

--- a/src/block-management/block-picker.scss
+++ b/src/block-management/block-picker.scss
@@ -26,13 +26,11 @@
 
 .modalContent {
 	background-color: white;
-	padding-left: 8;
-	padding-right: 8;
 	padding-top: 8;
 	padding-bottom: 8;
 	justify-content: center;
 	align-items: center;
-	border-radius: 4px 4px 0px 0px;
+	border-radius: 10px 10px 0px 0px;
 	border-color: grey;
 	border-width: 1px;
 }

--- a/src/block-management/block-picker.scss
+++ b/src/block-management/block-picker.scss
@@ -20,6 +20,10 @@
 	margin: 0px;
 }
 
+.touchableArea {
+	border-radius: 4px 4px 4px 4px;
+}
+
 .modalContent {
 	background-color: white;
 	padding-left: 8;

--- a/src/block-management/block-picker.scss
+++ b/src/block-management/block-picker.scss
@@ -2,9 +2,20 @@
 
 @import '../variables.scss';
 
+.title {
+	font-family: $default-monospace-font;
+	font-size: 16px;
+}
+
+.lineStyle {
+	border-bottom-color: lightgray;
+	border-bottom-width: 1px;
+	width: 100%;
+}
+
 .bottomModal {
 	justify-content: flex-end;
-	margin: 0;
+	margin: 0px;
 }
 
 .modalContent {
@@ -15,6 +26,6 @@
 	padding-bottom: 8;
 	justify-content: center;
 	align-items: center;
-	border-radius: 4px;
+	border-radius: 4px 4px 0px 0px;
 }
 

--- a/src/block-management/block-picker.scss
+++ b/src/block-management/block-picker.scss
@@ -15,6 +15,13 @@
 	width: 100%;
 }
 
+.shortLineStyle {
+	border-bottom-color: lightgray;
+	border-bottom-width: 2px;
+	margin-bottom: 8px;
+	width: 40px;
+}
+
 .bottomModal {
 	justify-content: flex-end;
 	margin: 0px;

--- a/src/block-management/block-picker.scss
+++ b/src/block-management/block-picker.scss
@@ -29,3 +29,35 @@
 	border-radius: 4px 4px 0px 0px;
 }
 
+.modalItem {	
+	flex: 1 1 auto;
+	margin: 5px;
+	width: 100px;
+	align-self: stretch;
+	justify-content: center;
+	align-items: center;
+}
+
+.modalIcon {
+	flex: 1 1 auto;
+	background-color: lightgray;
+	padding-left: 8;
+	padding-right: 8;
+	padding-top: 8;
+	padding-bottom: 8;
+	margin: 4px;
+	width: 72px;
+	height: 48px;
+	justify-content: center;
+	align-items: center;
+	border-radius: 4px 4px 4px 4px;
+}
+
+.modalItemLabel {
+	background-color: transparent;
+	padding-left: 2;
+	padding-right: 2;
+	padding-top: 2;
+	padding-bottom: 2;
+	justify-content: center;
+}

--- a/src/block-management/block-picker.scss
+++ b/src/block-management/block-picker.scss
@@ -1,0 +1,20 @@
+/** @format */
+
+@import '../variables.scss';
+
+.bottomModal {
+	justify-content: flex-end;
+	margin: 0;
+}
+
+.modalContent {
+	background-color: white;
+	padding-left: 8;
+	padding-right: 8;
+	padding-top: 8;
+	padding-bottom: 8;
+	justify-content: center;
+	align-items: center;
+	border-radius: 4px;
+}
+

--- a/src/block-management/block-picker.scss
+++ b/src/block-management/block-picker.scss
@@ -29,6 +29,8 @@
 	justify-content: center;
 	align-items: center;
 	border-radius: 4px 4px 0px 0px;
+	border-color: grey;
+	border-width: 1px;
 }
 
 .modalItem {	

--- a/src/block-management/block-picker.scss
+++ b/src/block-management/block-picker.scss
@@ -5,6 +5,8 @@
 .title {
 	font-family: $default-monospace-font;
 	font-size: 16px;
+	font-weight: bold;
+	margin-bottom: 8px;
 }
 
 .lineStyle {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6192,7 +6192,7 @@ promise@^7.0.3, promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2:
+prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
@@ -6312,6 +6312,12 @@ react-is@^16.3.1:
   version "16.4.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.2.tgz#84891b56c2b6d9efdee577cc83501dfc5ecead88"
 
+react-native-animatable@^1.2.4:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/react-native-animatable/-/react-native-animatable-1.3.0.tgz#b5c3940fc758cfd9b2fe54613a457c4b6962b46e"
+  dependencies:
+    prop-types "^15.5.10"
+
 react-native-crypto@^2.0.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/react-native-crypto/-/react-native-crypto-2.1.2.tgz#cfe68cad51cd1f73a4202b7ac164f96c1144cb2a"
@@ -6325,6 +6331,13 @@ react-native-crypto@^2.0.1:
     inherits "^2.0.1"
     pbkdf2 "3.0.8"
     public-encrypt "^4.0.0"
+
+react-native-modal@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/react-native-modal/-/react-native-modal-6.5.0.tgz#46220b2289a41597d344c1db17454611b426a758"
+  dependencies:
+    prop-types "^15.6.1"
+    react-native-animatable "^1.2.4"
 
 react-native-randombytes@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
**UPDATE:** this PR is ready for review now.

This PR adds a new `BlockPicker` component that shows the list of available (registered) blocks on a `FlatList` using the modal library [`react-native-modal`](https://github.com/react-native-community/react-native-modal).

- First blocks and action/props connectivity is in place
- worked a bit on styles, to make a better match (though not final) to what the designs show in #58 
- a new "ADD BLOCK HERE" label is shown when the picker is shown, to hint the user about where the block insertion is going to happen

![screenshot_1534964690 copy](https://user-images.githubusercontent.com/6597771/44485086-efaea100-a625-11e8-81e6-717bc2f825d2.png)


**ToDo**
- To be tackled separately: the rendering of the icon for each `BlockType` from `dashicons` will be done once https://github.com/WordPress/gutenberg/pull/9012 and https://github.com/wordpress-mobile/gutenberg-mobile/pull/117 get merged


**Updated gif**
![insertermodal3](https://user-images.githubusercontent.com/6597771/44485101-fccb9000-a625-11e8-9352-34a21a0e38ba.gif)
