### PR TITLE
Update GB hash

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -32,7 +32,7 @@ module.exports = {
 		'node',
 	],
 	moduleNameMapper: {
-		'@wordpress\\/(blocks|data|element|deprecated|editor|redux-routine|block-library|components|keycodes|url|a11y|viewport|core-data|api-fetch|nux)$': '<rootDir>/gutenberg/packages/$1/src/index',
+		'@wordpress\\/(block-serialization-default-parser|blocks|data|element|deprecated|editor|redux-routine|block-library|components|keycodes|url|a11y|viewport|core-data|api-fetch|nux)$': '<rootDir>/gutenberg/packages/$1/src/index',
 
 		// Mock the CSS modules. See https://facebook.github.io/jest/docs/en/webpack.html#handling-static-assets
 		'\\.(scss)$': '<rootDir>/__mocks__/styleMock.js',


### PR DESCRIPTION
Update GB hash to get latest changes about eventCount hidden to components, and fixed crash on H3, H4 blocks.

cc @SergioEstevao 