### PR TITLE
Most basic image block

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "dependencies": {
     "@wordpress/autop": "^1.0.6",
+    "@wordpress/blob": "^2.0.0",
     "@wordpress/compose": "^1.0.1",
     "@wordpress/deprecated": "^1.0.0-alpha.2",
     "@wordpress/element": "^1.0.2",

--- a/rn-cli.config.js
+++ b/rn-cli.config.js
@@ -13,7 +13,7 @@ module.exports = {
 		// On the other hand, GB packages that are loaded from the source tree directly
 		// are automagically resolved by Metro so, there is no list of them anywhere.
 		return blacklist( [
-			/gutenberg\/packages\/(autop|compose|deprecated|hooks|i18n|is-shallow-equal)\/.*/,
+			/gutenberg\/packages\/(autop|compose|deprecated|hooks|i18n|is-shallow-equal|blob)\/.*/,
 		] );
 	},
 	getTransformModulePath() {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -35,6 +35,10 @@ registerBlockType( UnsupportedBlock.name, UnsupportedBlock.settings );
 setUnknownTypeHandlerName( UnsupportedBlock.name );
 
 const initialHtml = `
+<!-- wp:image -->
+<figure class="wp-block-image"><img alt=""/></figure>
+<!-- /wp:image -->
+
 <!-- wp:title -->
 Hello World
 <!-- /wp:title -->

--- a/yarn.lock
+++ b/yarn.lock
@@ -445,6 +445,12 @@
     pirates "^4.0.0"
     source-map-support "^0.4.2"
 
+"@babel/runtime@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0.tgz#adeb78fedfc855aa05bc041640f3f6f98e85424c"
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/runtime@^7.0.0-beta.52":
   version "7.0.0-beta.54"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.54.tgz#39ebb42723fe7ca4b3e1b00e967e80138d47cadf"
@@ -535,6 +541,12 @@
     babel-plugin-transform-react-jsx "^6.24.1"
     babel-plugin-transform-runtime "^6.23.0"
     babel-preset-env "^1.6.1"
+
+"@wordpress/blob@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/blob/-/blob-2.0.0.tgz#b310674a93f7484c0b4492e6698aba55a1e04f48"
+  dependencies:
+    "@babel/runtime" "^7.0.0"
 
 "@wordpress/block-serialization-spec-parser@^1.0.0":
   version "1.0.0"


### PR DESCRIPTION
Parts of #140 . 
This PR implements the [changes on Gutenberg](https://github.com/WordPress/gutenberg/pull/9850) to recognize the image block.

![image-block](https://user-images.githubusercontent.com/9772967/45454263-9fbd7a00-b6b9-11e8-9082-31b10327dbe9.png)

To test:
- Update the Gutenberg submodule (should be pointing to `fc16864 `)
- `yarn clean`
- `yarn install`
- Check that the image placeholder is shown.