### PR TITLE
Image Block: Adding example block with image.

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -39,6 +39,10 @@ const initialHtml = `
 <figure class="wp-block-image"><img alt=""/></figure>
 <!-- /wp:image -->
 
+<!-- wp:image -->
+<figure class="wp-block-image"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
+<!-- /wp:image -->
+
 <!-- wp:title -->
 Hello World
 <!-- /wp:title -->


### PR DESCRIPTION
This PR implements the[ changes on the `Gutenberg` project ](https://github.com/WordPress/gutenberg/pull/9888)to display the content of an image block, or the empty block UI. 

To be able to test them, this PR also adds an extra example block with an image to be displayed.

The buttons to add images do nothing. That's fine for now :) 

![image_block_with_image](https://user-images.githubusercontent.com/9772967/45521527-bb498300-b794-11e8-9a60-8856587b4a75.jpg)

To test:
- Be sure that the Gutenberg submodule point to `06793a`.
- Run the project.
- Check that the UI looks like in the screenshot.
- Add a new image block.
- Check that the empty image block was added.