### PR TITLE
Add option for Travis to run tests with GB as parent

### DIFF
--- a/.travis/travis-checks-js.sh
+++ b/.travis/travis-checks-js.sh
@@ -18,12 +18,18 @@ if [ "$CHECK_CORRECTNESS" = true ] ; then
   npm run lint || pFail
 fi
 
+if [ "$GUTENBERG_AS_PARENT" = true ] ; then
+  TEST_SCRIPT_NAME='test:inside-gb'
+else
+  TEST_SCRIPT_NAME='test'
+fi
+
 if [ "$CHECK_TESTS" = true ] ; then
   # we'll run the tests twich (once for each platform) if the platform env var is not set
   if [[ -z "${TEST_RN_PLATFORM}" ]] ; then
-    TEST_RN_PLATFORM=android npm test || pFail
-    TEST_RN_PLATFORM=ios npm test || pFail
+    TEST_RN_PLATFORM=android npm run ${TEST_SCRIPT_NAME} || pFail
+    TEST_RN_PLATFORM=ios npm run ${TEST_SCRIPT_NAME} || pFail
   else
-    npm test || pFail
+    npm run ${TEST_SCRIPT_NAME} || pFail
   fi
 fi


### PR DESCRIPTION
This PR adds an option to the Travis test script to specify whether to use the `test` yarn script or the `test:inside-gb` yarn script.

This will enable the nested-inside-Gutenberg setup to be used in Gutenberg's Travis flow as well.

To test A:

* Well, Travis should run on this and be green with all the tests running as before

To test B:
1. In a new fresh folder, clone the Gutenberg repo, change into it and checkout the `f8747043e` hash (it's the one this PR expects anyway)
2. Run `npm install` to install and compile packages
3. Change into the `gutenberg-mobile` subfolder
3. Run `GUTENBERG_AS_PARENT=true ./.travis/travis-checks-js.sh` and pay attention to the output. You should be able to find the `--config jest_gb.config.js` string somewhere, indicating that the mobile tests are using the "inside gutenberg" Jest configuration, which the the goal of this new parameter passed.