### PR TITLE
Adding HTMLTextInput component

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -11,6 +11,7 @@ import { ToolbarButton } from './constants';
 import type { BlockType } from '../store/';
 import styles from './block-manager.scss';
 import BlockPicker from './block-picker';
+import HTMLTextInput from '../components/html-text-input'
 
 // Gutenberg imports
 import {
@@ -29,6 +30,8 @@ export type BlockListType = {
 	blocks: Array<BlockType>,
 	aztechtml: string,
 	refresh: boolean,
+	showBlocks: void => void,
+	showHtml: void => void,
 };
 
 type PropsType = BlockListType;
@@ -42,7 +45,6 @@ type StateType = {
 };
 
 export default class BlockManager extends React.Component<PropsType, StateType> {
-	_htmlTextInput: TextInput = null;
 
 	constructor( props: PropsType ) {
 		super( props );
@@ -52,7 +54,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 			inspectBlocks: false,
 			blockTypePickerVisible: false,
 			selectedBlockType: 'core/paragraph', // just any valid type to start from
-			html: '', // This is used to hold the Android html text input state.
+			html: '',
 		};
 	}
 
@@ -154,9 +156,9 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 			}, '' );
 	}
 
-	parseHTML( html: string ) {
+	parseHTML() {
 		const { parseBlocksAction } = this.props;
-		parseBlocksAction( html );
+		parseBlocksAction( this.state.html );
 	}
 
 	componentDidUpdate() {
@@ -251,12 +253,17 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 	}
 
 	handleSwitchEditor = ( showHtml: boolean ) => {
-		if ( ! showHtml ) {
-			const html = this._htmlTextInput._lastNativeText;
-			this.parseHTML( html );
-		}
+		showHtml ? this.showHtml() : this.showBlocks()
+	}
+
+	showBlocks() {
+		this.parseHTML();
+		this.setState( { showHtml: false } );
+	}
+
+	showHtml() {
 		const html = this.serializeToHtml();
-		this.setState( { showHtml, html } );
+		this.setState( { showHtml: true, html } );
 	}
 
 	handleInspectBlocksChanged = ( inspectBlocks: boolean ) => {
@@ -290,27 +297,15 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 	}
 
 	onChangeHTML = ( html: string ) => {
-		if ( Platform.OS === 'android' ) {
-			this.setState( { html } );
-		}
+		this.setState( { html } );
 	}
 
 	renderHTML() {
-		const behavior = Platform.OS === 'ios' ? 'padding' : null;
-		const htmlInputRef = ( el ) => this._htmlTextInput = el;
-
 		return (
-			<KeyboardAvoidingView style={ { flex: 1 } } behavior={ behavior }>
-				<TextInput
-					textAlignVertical="top"
-					multiline
-					ref={ htmlInputRef }
-					numberOfLines={ 0 }
-					style={ styles.htmlView }
-					value={ this.state.html }
-					onChangeText={ ( html ) => this.onChangeHTML( html ) }
-				/>
-			</KeyboardAvoidingView>
+			<HTMLTextInput
+				value={ this.state.html }
+				onChange={ this.onChangeHTML }
+			/>
 		);
 	}
 }

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -4,14 +4,14 @@
  */
 
 import React from 'react';
-import { Platform, Switch, Text, View, FlatList, TextInput, KeyboardAvoidingView } from 'react-native';
+import { Platform, Switch, Text, View, FlatList, KeyboardAvoidingView } from 'react-native';
 import RecyclerViewList, { DataSource } from 'react-native-recyclerview-list';
 import BlockHolder from './block-holder';
 import { ToolbarButton } from './constants';
 import type { BlockType } from '../store/';
 import styles from './block-manager.scss';
 import BlockPicker from './block-picker';
-import HTMLTextInput from '../components/html-text-input'
+import HTMLTextInput from '../components/html-text-input';
 
 // Gutenberg imports
 import {
@@ -31,7 +31,7 @@ export type BlockListType = {
 	aztechtml: string,
 	refresh: boolean,
 	showBlocks: void => void,
-	showHtml: void => void,
+	showHTML: void => void,
 };
 
 type PropsType = BlockListType;
@@ -45,7 +45,6 @@ type StateType = {
 };
 
 export default class BlockManager extends React.Component<PropsType, StateType> {
-
 	constructor( props: PropsType ) {
 		super( props );
 		this.state = {
@@ -253,7 +252,11 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 	}
 
 	handleSwitchEditor = ( showHtml: boolean ) => {
-		showHtml ? this.showHtml() : this.showBlocks()
+		if ( showHtml ) {
+			this.showHTML();
+		} else {
+			this.showBlocks();
+		}
 	}
 
 	showBlocks() {
@@ -261,7 +264,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		this.setState( { showHtml: false } );
 	}
 
-	showHtml() {
+	showHTML() {
 		const html = this.serializeToHtml();
 		this.setState( { showHtml: true, html } );
 	}

--- a/src/block-management/block-manager.scss
+++ b/src/block-management/block-manager.scss
@@ -13,16 +13,6 @@
 	flex: 1;
 }
 
-.htmlView {
-	font-family: $default-monospace-font;
-	flex: 1;
-	background-color: #eee;
-	padding-left: 8;
-	padding-right: 8;
-	padding-top: 8;
-	padding-bottom: 8;
-}
-
 .switch {
 	flex-direction: row;
 	justify-content: flex-start;

--- a/src/components/html-text-input.js
+++ b/src/components/html-text-input.js
@@ -1,39 +1,34 @@
+/**
+ * @format
+ * @flow
+ */
 
 import React from 'react';
-import { Platform, Switch, Text, View, FlatList, TextInput, KeyboardAvoidingView } from 'react-native';
+import { Platform, TextInput, KeyboardAvoidingView } from 'react-native';
 import styles from './html-text-input.scss';
 
-type BlockListType = {
+type PropsType = {
 	onChange: ( html: string ) => void,
 	value: string,
 };
 
-export default class HTMLInputView extends React.Component<BlockListType> {
-	_htmlTextInput: TextInput = null;
-
-	constructor( props: PropsType ) {
-		super( props );
-	}
-
+export default class HTMLInputView extends React.Component<PropsType> {
 	shouldComponentUpdate() {
 		return Platform.OS === 'android';
 	}
 
 	render() {
-		console.log("Rendering text");
 		const behavior = Platform.OS === 'ios' ? 'padding' : null;
-		const htmlInputRef = ( el ) => this._htmlTextInput = el;
 
 		return (
 			<KeyboardAvoidingView style={ { flex: 1 } } behavior={ behavior }>
 				<TextInput
 					textAlignVertical="top"
 					multiline
-					ref={ htmlInputRef }
 					numberOfLines={ 0 }
 					style={ styles.htmlView }
 					value={ this.props.value }
-					onChangeText={ this.props.onChange } 
+					onChangeText={ this.props.onChange }
 				/>
 			</KeyboardAvoidingView>
 		);

--- a/src/components/html-text-input.js
+++ b/src/components/html-text-input.js
@@ -1,0 +1,41 @@
+
+import React from 'react';
+import { Platform, Switch, Text, View, FlatList, TextInput, KeyboardAvoidingView } from 'react-native';
+import styles from './html-text-input.scss';
+
+type BlockListType = {
+	onChange: ( html: string ) => void,
+	value: string,
+};
+
+export default class HTMLInputView extends React.Component<BlockListType> {
+	_htmlTextInput: TextInput = null;
+
+	constructor( props: PropsType ) {
+		super( props );
+	}
+
+	shouldComponentUpdate() {
+		return Platform.OS === 'android';
+	}
+
+	render() {
+		console.log("Rendering text");
+		const behavior = Platform.OS === 'ios' ? 'padding' : null;
+		const htmlInputRef = ( el ) => this._htmlTextInput = el;
+
+		return (
+			<KeyboardAvoidingView style={ { flex: 1 } } behavior={ behavior }>
+				<TextInput
+					textAlignVertical="top"
+					multiline
+					ref={ htmlInputRef }
+					numberOfLines={ 0 }
+					style={ styles.htmlView }
+					value={ this.props.value }
+					onChangeText={ this.props.onChange } 
+				/>
+			</KeyboardAvoidingView>
+		);
+	}
+}

--- a/src/components/html-text-input.scss
+++ b/src/components/html-text-input.scss
@@ -1,0 +1,13 @@
+/** @format */
+
+@import '../variables.scss';
+
+.htmlView {
+	font-family: $default-monospace-font;
+	flex: 1;
+	background-color: #eee;
+	padding-left: 8;
+	padding-right: 8;
+	padding-top: 8;
+	padding-bottom: 8;
+}


### PR DESCRIPTION
This PR adds a new component `HTMLTextInput` to hide the different InputView implementation between iOS and Android.

It should continue working as before. That means that the remaining Android UX issues specified in #118 are not yet fixed, but this gives a better place to fix them in the future.

By creating a separated component, we can now use the component's `shouldComponentUpdate` method to give a better solution to the Android/iOS update issue .

To Test:
- Run the app on both iOS and Android.
- Switch to HTML Output.
- Edit the text.
- Check that on iOS it works correctly.
- Check that on Android it can be modified.
- Go back to Blocks view.
- Check that the changes on html are represented on the blocks view.