### PR TITLE
Fix/update to gb master with mobile submodule

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,7 +15,12 @@ module.exports = {
 	verbose: true,
 	preset: 'jest-react-native',
 	testEnvironment: 'jsdom',
-	testPathIgnorePatterns: [ '/node_modules/', '/gutenberg/test/', '/gutenberg/packages/' ],
+	testPathIgnorePatterns: [
+		'/node_modules/',
+		'/gutenberg/gutenberg-mobile/',
+		'/gutenberg/test/',
+		'/gutenberg/packages/',
+	],
 	moduleFileExtensions: [
 		'native.js',
 		'android.js',
@@ -31,6 +36,7 @@ module.exports = {
 		'jsx',
 		'node',
 	],
+	modulePathIgnorePatterns: [ '<rootDir>/gutenberg/gutenberg-mobile' ],
 	moduleNameMapper: {
 		'@wordpress\\/(block-serialization-default-parser|blocks|data|element|deprecated|editor|block-library|components|keycodes|url|a11y|viewport|core-data|api-fetch|nux)$':
 			'<rootDir>/gutenberg/packages/$1/src/index',

--- a/rn-cli.config.js
+++ b/rn-cli.config.js
@@ -10,6 +10,7 @@ module.exports = {
 		// are automagically resolved by Metro so, there is no list of them anywhere.
 		return blacklist( [
 			/gutenberg\/packages\/(autop|compose|deprecated|hooks|i18n|is-shallow-equal|blob|redux-routine)\/.*/,
+			/gutenberg\/gutenberg-mobile\/.*/,
 		] );
 	},
 	getTransformModulePath() {


### PR DESCRIPTION
This PR updates the Gutenberg hash to the latest master and also fixes the Metro and Jest config to make them ignore the code duplication due to the second copy of the mobile code appearing as a submodule nested inside the Gutenberg directory.

It's unfortunate that with the current (temporary) situation, there is a
cyclic dependency between the mobile and web submodules, ending up in
the mobile submodule re-appering inside the already nested Gutenberg
dorectory.

Until we break the circle, we need to ignore that deeply nested mobile
code tree, otherwise both Metro and Jest complain for duplicate
packages/modules.

To test:
Run the app and verify it runs OK as before. Travis run should also be green.