### PR TITLE
Image Block: Caption

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -36,10 +36,6 @@ setUnknownTypeHandlerName( UnsupportedBlock.name );
 
 const initialHtml = `
 <!-- wp:image -->
-<figure class="wp-block-image"><img alt=""/></figure>
-<!-- /wp:image -->
-
-<!-- wp:image -->
 <figure class="wp-block-image"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
 <!-- /wp:image -->
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -36,7 +36,7 @@ setUnknownTypeHandlerName( UnsupportedBlock.name );
 
 const initialHtml = `
 <!-- wp:image -->
-<figure class="wp-block-image"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
+<figure class="wp-block-image"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/><figcaption>This is a caption.</figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:title -->


### PR DESCRIPTION
Part of #140

This PR implements the [changes on the main gutenberg](https://github.com/WordPress/gutenberg/pull/10079) repo to show the image caption on the image block.

![caption](https://user-images.githubusercontent.com/9772967/45844603-52648c80-bcf9-11e8-882b-4b42f675e8bc.gif)

To test:
- Run the project.
- Check that the caption is visible.
- Check that you can edit and remove the caption.
- Check that the changes are visible on the HTML view.