### PR TITLE
Fix broken jest platform resolution

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 ; ignore the submodules
 gutenberg
+symlinked-packages-in-parent
 react-native-aztec
 

--- a/.flowconfig
+++ b/.flowconfig
@@ -74,6 +74,8 @@ libdefs.js
 emoji=true
 
 module.system=haste
+module.system.node.resolve_dirname=node_modules
+module.system.node.resolve_dirname=symlinked-packages
 
 module.file_ext=.js
 module.file_ext=.jsx
@@ -84,10 +86,6 @@ module.file_ext=.scss
 munge_underscores=true
 
 module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> 'RelativeImageStub'
-module.name_mapper='@wordpress/block-library' -> '<PROJECT_ROOT>/gutenberg/packages/block-library/src'
-module.name_mapper='@wordpress/blocks' -> '<PROJECT_ROOT>/gutenberg/packages/blocks/src'
-module.name_mapper='@wordpress/element' -> '<PROJECT_ROOT>/gutenberg/packages/element/src'
-module.name_mapper='@wordpress/components' -> '<PROJECT_ROOT>/gutenberg/packages/components/src'
 
 ; mock/ignore style files
 module.name_mapper='.*\(.scss\)' -> 'empty/object'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -99,7 +99,7 @@ android {
 
     defaultConfig {
         applicationId "com.gutenberg"
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"
@@ -155,6 +155,12 @@ repositories {
     jcenter()
     google()
     maven { url "https://jitpack.io" }
+}
+
+configurations.all {
+    resolutionStrategy {
+        force 'org.webkit:android-jsc:r224109'
+    }
 }
 
 dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,5 +33,9 @@ allprojects {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
         }
+        maven {
+           // Local Maven repo containing AARs with JSC library built for Android
+           url "$rootDir/../node_modules/jsc-android/dist"
+        }
     }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,7 +17,7 @@ module.exports = {
 	testEnvironment: 'jsdom',
 	testPathIgnorePatterns: [
 		'/node_modules/',
-		'/gutenberg/gutenberg-mobile/',
+		'<rootDir>/gutenberg/gutenberg-mobile/',
 		'/gutenberg/test/',
 		'/gutenberg/packages/',
 	],

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,26 +21,9 @@ module.exports = {
 		'/gutenberg/test/',
 		'/gutenberg/packages/',
 	],
-	moduleFileExtensions: [
-		'native.js',
-		'android.js',
-		'ios.js',
-		'js',
-		'native.json',
-		'android.json',
-		'ios.json',
-		'json',
-		'native.jsx',
-		'android.jsx',
-		'ios.jsx',
-		'jsx',
-		'node',
-	],
 	modulePathIgnorePatterns: [ '<rootDir>/gutenberg/gutenberg-mobile' ],
+	moduleDirectories: [ 'node_modules', 'symlinked-packages' ],
 	moduleNameMapper: {
-		'@wordpress\\/(block-serialization-default-parser|blocks|data|element|deprecated|editor|block-library|components|keycodes|url|a11y|viewport|core-data|api-fetch|nux)$':
-			'<rootDir>/gutenberg/packages/$1/src/index',
-
 		// Mock the CSS modules. See https://facebook.github.io/jest/docs/en/webpack.html#handling-static-assets
 		'\\.(scss)$': '<rootDir>/__mocks__/styleMock.js',
 	},

--- a/jest_gb.config.js
+++ b/jest_gb.config.js
@@ -5,11 +5,5 @@ const main = require( './jest.config.js' );
 
 module.exports = {
 	...main,
-	moduleNameMapper: {
-		'@wordpress\\/(blocks|data|element|deprecated|editor|block-library|components|keycodes|url|a11y|viewport|core-data|api-fetch|nux|block-serialization-default-parser)$':
-			'<rootDir>/../packages/$1/build/index',
-
-		// Mock the CSS modules. See https://facebook.github.io/jest/docs/en/webpack.html#handling-static-assets
-		'\\.(scss)$': '<rootDir>/__mocks__/styleMock.js',
-	},
+	moduleDirectories: [ 'node_modules', 'symlinked-packages-in-parent' ],
 };

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "hpq": "^1.2.0",
     "jed": "^1.1.1",
     "js-beautify": "^1.7.5",
+    "jsc-android": "224109.x.x",
     "jsdom-jscore": "git+https://github.com/iamcco/jsdom-jscore-rn.git#6eac88dd5d5e7c21ce6382abde7dbc376d7f7f59",
     "jsx-to-string": "^1.3.1",
     "memize": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-native-sass-transformer": "^1.1.1",
     "react-test-renderer": "16.3.1",
     "remote-redux-devtools": "^0.5.12",
+    "rungen": "^0.3.2",
     "sprintf-js": "^1.1.1"
   },
   "scripts": {
@@ -71,15 +72,6 @@
     "lint:fix": "yarn lint --fix"
   },
   "dependencies": {
-    "@wordpress/autop": "^1.0.6",
-    "@wordpress/blob": "^2.0.0",
-    "@wordpress/compose": "^1.0.1",
-    "@wordpress/deprecated": "^1.0.0-alpha.2",
-    "@wordpress/element": "^1.0.2",
-    "@wordpress/hooks": "^1.2.1",
-    "@wordpress/i18n": "^1.1.0",
-    "@wordpress/is-shallow-equal": "^1.0.1",
-    "@wordpress/redux-routine": "^2.0.0",
     "babel-preset-es2015": "^6.24.1",
     "classnames": "^2.2.5",
     "dom-react": "^2.2.1",

--- a/rn-cli.config.js
+++ b/rn-cli.config.js
@@ -5,13 +5,9 @@ const enm = require( './extra-node-modules.config.js' );
 module.exports = {
 	extraNodeModules: enm,
 	getBlacklistRE: function() {
-		// Blacklist the GB packages we want to consume from NPM (online) directly.
-		// On the other hand, GB packages that are loaded from the source tree directly
-		// are automagically resolved by Metro so, there is no list of them anywhere.
-		return blacklist( [
-			/gutenberg\/packages\/(autop|compose|deprecated|hooks|i18n|is-shallow-equal|blob|redux-routine)\/.*/,
-			/gutenberg\/gutenberg-mobile\/.*/,
-		] );
+		// There's a nested checkout of the mobile code inside the Gutenberg repo
+		//  as a submodule. Blacklist it to avoid errors due to duplicate modules.
+		return blacklist( [ /gutenberg\/gutenberg-mobile\/.*/ ] );
 	},
 	getTransformModulePath() {
 		return require.resolve( './sass-transformer.js' );

--- a/rn-cli.config.js
+++ b/rn-cli.config.js
@@ -1,5 +1,6 @@
 /** @format */
 const blacklist = require( 'metro' ).createBlacklist;
+const path = require( 'path' );
 const enm = require( './extra-node-modules.config.js' );
 
 module.exports = {
@@ -7,7 +8,7 @@ module.exports = {
 	getBlacklistRE: function() {
 		// There's a nested checkout of the mobile code inside the Gutenberg repo
 		//  as a submodule. Blacklist it to avoid errors due to duplicate modules.
-		return blacklist( [ /gutenberg\/gutenberg-mobile\/.*/ ] );
+		return blacklist( [ new RegExp( path.basename( __dirname ) + '/gutenberg/gutenberg-mobile/.*/' ) ] );
 	},
 	getTransformModulePath() {
 		return require.resolve( './sass-transformer.js' );

--- a/symlinked-packages-in-parent/@wordpress/a11y
+++ b/symlinked-packages-in-parent/@wordpress/a11y
@@ -1,0 +1,1 @@
+../../../packages/a11y/build/

--- a/symlinked-packages-in-parent/@wordpress/api-fetch
+++ b/symlinked-packages-in-parent/@wordpress/api-fetch
@@ -1,0 +1,1 @@
+../../../packages/api-fetch/build/

--- a/symlinked-packages-in-parent/@wordpress/autop
+++ b/symlinked-packages-in-parent/@wordpress/autop
@@ -1,0 +1,1 @@
+../../../packages/autop/build/

--- a/symlinked-packages-in-parent/@wordpress/blob
+++ b/symlinked-packages-in-parent/@wordpress/blob
@@ -1,0 +1,1 @@
+../../../packages/blob/src/

--- a/symlinked-packages-in-parent/@wordpress/block-library
+++ b/symlinked-packages-in-parent/@wordpress/block-library
@@ -1,0 +1,1 @@
+../../../packages/block-library/build/

--- a/symlinked-packages-in-parent/@wordpress/block-serialization-default-parser
+++ b/symlinked-packages-in-parent/@wordpress/block-serialization-default-parser
@@ -1,0 +1,1 @@
+../../../packages/block-serialization-default-parser/build/

--- a/symlinked-packages-in-parent/@wordpress/blocks
+++ b/symlinked-packages-in-parent/@wordpress/blocks
@@ -1,0 +1,1 @@
+../../../packages/blocks/build/

--- a/symlinked-packages-in-parent/@wordpress/components
+++ b/symlinked-packages-in-parent/@wordpress/components
@@ -1,0 +1,1 @@
+../../../packages/components/build/

--- a/symlinked-packages-in-parent/@wordpress/compose
+++ b/symlinked-packages-in-parent/@wordpress/compose
@@ -1,0 +1,1 @@
+../../../packages/compose/build/

--- a/symlinked-packages-in-parent/@wordpress/core-data
+++ b/symlinked-packages-in-parent/@wordpress/core-data
@@ -1,0 +1,1 @@
+../../../packages/core-data/build/

--- a/symlinked-packages-in-parent/@wordpress/data
+++ b/symlinked-packages-in-parent/@wordpress/data
@@ -1,0 +1,1 @@
+../../../packages/data/build/

--- a/symlinked-packages-in-parent/@wordpress/deprecated
+++ b/symlinked-packages-in-parent/@wordpress/deprecated
@@ -1,0 +1,1 @@
+../../../packages/deprecated/build/

--- a/symlinked-packages-in-parent/@wordpress/editor
+++ b/symlinked-packages-in-parent/@wordpress/editor
@@ -1,0 +1,1 @@
+../../../packages/editor/build/

--- a/symlinked-packages-in-parent/@wordpress/element
+++ b/symlinked-packages-in-parent/@wordpress/element
@@ -1,0 +1,1 @@
+../../../packages/element/build/

--- a/symlinked-packages-in-parent/@wordpress/hooks
+++ b/symlinked-packages-in-parent/@wordpress/hooks
@@ -1,0 +1,1 @@
+../../../packages/hooks/build/

--- a/symlinked-packages-in-parent/@wordpress/i18n
+++ b/symlinked-packages-in-parent/@wordpress/i18n
@@ -1,0 +1,1 @@
+../../../packages/i18n/build/

--- a/symlinked-packages-in-parent/@wordpress/is-shallow-equal
+++ b/symlinked-packages-in-parent/@wordpress/is-shallow-equal
@@ -1,0 +1,1 @@
+../../../packages/is-shallow-equal/build/

--- a/symlinked-packages-in-parent/@wordpress/keycodes
+++ b/symlinked-packages-in-parent/@wordpress/keycodes
@@ -1,0 +1,1 @@
+../../../packages/keycodes/build/

--- a/symlinked-packages-in-parent/@wordpress/nux
+++ b/symlinked-packages-in-parent/@wordpress/nux
@@ -1,0 +1,1 @@
+../../../packages/nux/build/

--- a/symlinked-packages-in-parent/@wordpress/redux-routine
+++ b/symlinked-packages-in-parent/@wordpress/redux-routine
@@ -1,0 +1,1 @@
+../../../packages/redux-routine/build/

--- a/symlinked-packages-in-parent/@wordpress/url
+++ b/symlinked-packages-in-parent/@wordpress/url
@@ -1,0 +1,1 @@
+../../../packages/url/build/

--- a/symlinked-packages-in-parent/@wordpress/viewport
+++ b/symlinked-packages-in-parent/@wordpress/viewport
@@ -1,0 +1,1 @@
+../../../packages/viewport/build/

--- a/symlinked-packages/@wordpress/a11y
+++ b/symlinked-packages/@wordpress/a11y
@@ -1,0 +1,1 @@
+../../gutenberg/packages/a11y/src/

--- a/symlinked-packages/@wordpress/api-fetch
+++ b/symlinked-packages/@wordpress/api-fetch
@@ -1,0 +1,1 @@
+../../gutenberg/packages/api-fetch/src/

--- a/symlinked-packages/@wordpress/autop
+++ b/symlinked-packages/@wordpress/autop
@@ -1,0 +1,1 @@
+../../gutenberg/packages/autop/src/

--- a/symlinked-packages/@wordpress/blob
+++ b/symlinked-packages/@wordpress/blob
@@ -1,0 +1,1 @@
+../../gutenberg/packages/blob/src/

--- a/symlinked-packages/@wordpress/block-library
+++ b/symlinked-packages/@wordpress/block-library
@@ -1,0 +1,1 @@
+../../gutenberg/packages/block-library/src/

--- a/symlinked-packages/@wordpress/block-serialization-default-parser
+++ b/symlinked-packages/@wordpress/block-serialization-default-parser
@@ -1,0 +1,1 @@
+../../gutenberg/packages/block-serialization-default-parser/src/

--- a/symlinked-packages/@wordpress/blocks
+++ b/symlinked-packages/@wordpress/blocks
@@ -1,0 +1,1 @@
+../../gutenberg/packages/blocks/src/

--- a/symlinked-packages/@wordpress/components
+++ b/symlinked-packages/@wordpress/components
@@ -1,0 +1,1 @@
+../../gutenberg/packages/components/src/

--- a/symlinked-packages/@wordpress/compose
+++ b/symlinked-packages/@wordpress/compose
@@ -1,0 +1,1 @@
+../../gutenberg/packages/compose/src/

--- a/symlinked-packages/@wordpress/core-data
+++ b/symlinked-packages/@wordpress/core-data
@@ -1,0 +1,1 @@
+../../gutenberg/packages/core-data/src/

--- a/symlinked-packages/@wordpress/data
+++ b/symlinked-packages/@wordpress/data
@@ -1,0 +1,1 @@
+../../gutenberg/packages/data/src/

--- a/symlinked-packages/@wordpress/deprecated
+++ b/symlinked-packages/@wordpress/deprecated
@@ -1,0 +1,1 @@
+../../gutenberg/packages/deprecated/src/

--- a/symlinked-packages/@wordpress/editor
+++ b/symlinked-packages/@wordpress/editor
@@ -1,0 +1,1 @@
+../../gutenberg/packages/editor/src/

--- a/symlinked-packages/@wordpress/element
+++ b/symlinked-packages/@wordpress/element
@@ -1,0 +1,1 @@
+../../gutenberg/packages/element/src/

--- a/symlinked-packages/@wordpress/hooks
+++ b/symlinked-packages/@wordpress/hooks
@@ -1,0 +1,1 @@
+../../gutenberg/packages/hooks/src/

--- a/symlinked-packages/@wordpress/i18n
+++ b/symlinked-packages/@wordpress/i18n
@@ -1,0 +1,1 @@
+../../gutenberg/packages/i18n/src/

--- a/symlinked-packages/@wordpress/is-shallow-equal
+++ b/symlinked-packages/@wordpress/is-shallow-equal
@@ -1,0 +1,1 @@
+../../gutenberg/packages/is-shallow-equal/

--- a/symlinked-packages/@wordpress/keycodes
+++ b/symlinked-packages/@wordpress/keycodes
@@ -1,0 +1,1 @@
+../../gutenberg/packages/keycodes/src/

--- a/symlinked-packages/@wordpress/nux
+++ b/symlinked-packages/@wordpress/nux
@@ -1,0 +1,1 @@
+../../gutenberg/packages/nux/src/

--- a/symlinked-packages/@wordpress/redux-routine
+++ b/symlinked-packages/@wordpress/redux-routine
@@ -1,0 +1,1 @@
+../../gutenberg/packages/redux-routine/src/

--- a/symlinked-packages/@wordpress/url
+++ b/symlinked-packages/@wordpress/url
@@ -1,0 +1,1 @@
+../../gutenberg/packages/url/src/

--- a/symlinked-packages/@wordpress/viewport
+++ b/symlinked-packages/@wordpress/viewport
@@ -1,0 +1,1 @@
+../../gutenberg/packages/viewport/src/

--- a/yarn.lock
+++ b/yarn.lock
@@ -4659,6 +4659,10 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
+jsc-android@224109.x.x:
+  version "224109.1.0"
+  resolved "https://registry.yarnpkg.com/jsc-android/-/jsc-android-224109.1.0.tgz#9749ec92f1e284b3c09befe7c47cc6e60b1f0cdf"
+
 "jsdom-jscore@git+https://github.com/iamcco/jsdom-jscore-rn.git#6eac88dd5d5e7c21ce6382abde7dbc376d7f7f59":
   version "0.1.7"
   resolved "git+https://github.com/iamcco/jsdom-jscore-rn.git#6eac88dd5d5e7c21ce6382abde7dbc376d7f7f59"

--- a/yarn.lock
+++ b/yarn.lock
@@ -445,19 +445,6 @@
     pirates "^4.0.0"
     source-map-support "^0.4.2"
 
-"@babel/runtime@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0.tgz#adeb78fedfc855aa05bc041640f3f6f98e85424c"
-  dependencies:
-    regenerator-runtime "^0.12.0"
-
-"@babel/runtime@^7.0.0-beta.52":
-  version "7.0.0-beta.54"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.54.tgz#39ebb42723fe7ca4b3e1b00e967e80138d47cadf"
-  dependencies:
-    core-js "^2.5.7"
-    regenerator-runtime "^0.12.0"
-
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.44.tgz#f8832f4fdcee5d59bf515e595fc5106c529b394f"
@@ -525,12 +512,6 @@
   version "10.5.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.2.tgz#f19f05314d5421fe37e74153254201a7bf00a707"
 
-"@wordpress/autop@^1.0.6":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/autop/-/autop-1.1.1.tgz#00a4b91ef2feaf5dfb704383f2dd16b880604084"
-  dependencies:
-    "@babel/runtime" "^7.0.0-beta.52"
-
 "@wordpress/babel-preset-default@^1.1.2":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@wordpress/babel-preset-default/-/babel-preset-default-1.3.0.tgz#e5818a448812a2966d308e9f82097b9f81514b77"
@@ -542,12 +523,6 @@
     babel-plugin-transform-runtime "^6.23.0"
     babel-preset-env "^1.6.1"
 
-"@wordpress/blob@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/blob/-/blob-2.0.0.tgz#b310674a93f7484c0b4492e6698aba55a1e04f48"
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-
 "@wordpress/block-serialization-spec-parser@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@wordpress/block-serialization-spec-parser/-/block-serialization-spec-parser-1.0.0.tgz#a51a9276421629d4be398dfcc9bab52e303c3403"
@@ -555,83 +530,6 @@
 "@wordpress/browserslist-config@^2.1.4":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@wordpress/browserslist-config/-/browserslist-config-2.2.0.tgz#7fcc77db40d4d846dbb158e485a6badc143c76d2"
-
-"@wordpress/compose@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/compose/-/compose-1.0.1.tgz#fdfb24b27390ca97db432108c47188b4fc96dea8"
-  dependencies:
-    "@babel/runtime" "^7.0.0-beta.52"
-    "@wordpress/element" "^1.0.1"
-    "@wordpress/is-shallow-equal" "^1.1.1"
-    lodash "^4.17.10"
-
-"@wordpress/deprecated@^1.0.0-alpha.2", "@wordpress/deprecated@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/deprecated/-/deprecated-1.0.1.tgz#8769d791b228022caef156dbbff0f21eb2b21f3e"
-  dependencies:
-    "@babel/runtime" "^7.0.0-beta.52"
-
-"@wordpress/deprecated@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@wordpress/deprecated/-/deprecated-1.0.2.tgz#ac69168d55b790d797946ef2dfd2eeda13bf1c56"
-  dependencies:
-    "@babel/runtime" "^7.0.0-beta.52"
-
-"@wordpress/element@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-1.0.1.tgz#d9e31e437793655556816e6328bc67bfbecc4a27"
-  dependencies:
-    "@babel/runtime" "^7.0.0-beta.52"
-    "@wordpress/deprecated" "^1.0.1"
-    "@wordpress/is-shallow-equal" "^1.1.1"
-    lodash "^4.17.10"
-    react "^16.4.1"
-    react-dom "^16.4.1"
-
-"@wordpress/element@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-1.0.2.tgz#1b2c8e245ce9e7d126d6521f2a93e69606d1c71c"
-  dependencies:
-    "@babel/runtime" "^7.0.0-beta.52"
-    "@wordpress/deprecated" "^1.0.2"
-    "@wordpress/is-shallow-equal" "^1.1.2"
-    lodash "^4.17.10"
-    react "^16.4.1"
-    react-dom "^16.4.1"
-
-"@wordpress/hooks@^1.2.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/hooks/-/hooks-1.3.1.tgz#1ee50c777938060a96b202e22ca2e902eacce335"
-  dependencies:
-    "@babel/runtime" "^7.0.0-beta.52"
-
-"@wordpress/i18n@^1.1.0":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/i18n/-/i18n-1.2.1.tgz#b5c7c52065db9fa13a3d1872ddb9a198bc8ea29a"
-  dependencies:
-    "@babel/runtime" "^7.0.0-beta.52"
-    gettext-parser "^1.3.1"
-    jed "^1.1.1"
-    lodash "^4.17.10"
-    memize "^1.0.5"
-
-"@wordpress/is-shallow-equal@^1.0.1", "@wordpress/is-shallow-equal@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/is-shallow-equal/-/is-shallow-equal-1.1.1.tgz#377db18206afe2a6e787862106c3ff5c27d65e36"
-  dependencies:
-    "@babel/runtime" "^7.0.0-beta.52"
-
-"@wordpress/is-shallow-equal@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@wordpress/is-shallow-equal/-/is-shallow-equal-1.1.2.tgz#360a3d06a5805148d05e00cf92e5e42360baf0a2"
-  dependencies:
-    "@babel/runtime" "^7.0.0-beta.52"
-
-"@wordpress/redux-routine@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/redux-routine/-/redux-routine-2.0.0.tgz#9ec9afa29abc69510c80f3c2d0d2a392d6c7604f"
-  dependencies:
-    "@babel/runtime" "^7.0.0"
 
 abab@^1.0.4:
   version "1.0.4"
@@ -2911,7 +2809,7 @@ encodeurl@~1.0.1, encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
 
-encoding@^0.1.11, encoding@^0.1.12:
+encoding@^0.1.11:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
   dependencies:
@@ -3642,13 +3540,6 @@ getpass@^0.1.1:
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
   dependencies:
     assert-plus "^1.0.0"
-
-gettext-parser@^1.3.1:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/gettext-parser/-/gettext-parser-1.4.0.tgz#f8baf34a292f03d5e42f02df099d301f167a7ace"
-  dependencies:
-    encoding "^0.1.12"
-    safe-buffer "^5.1.1"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -6362,7 +6253,7 @@ react-devtools-core@3.1.0:
     shell-quote "^1.6.1"
     ws "^2.0.3"
 
-react-dom@^16.2.0, react-dom@^16.4.1:
+react-dom@^16.2.0:
   version "16.4.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.1.tgz#7f8b0223b3a5fbe205116c56deb85de32685dad6"
   dependencies:
@@ -6549,15 +6440,6 @@ react@^0.14.0:
     envify "^3.0.0"
     fbjs "^0.6.1"
 
-react@^16.4.1:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.4.1.tgz#de51ba5764b5dbcd1f9079037b862bd26b82fe32"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
-
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
@@ -6645,10 +6527,6 @@ regenerate@^1.2.1:
 regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
-
-regenerator-runtime@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.0.tgz#8052ac952d85b10f3425192cd0c53f45cf65c6cb"
 
 regenerator-transform@^0.10.0:
   version "0.10.1"
@@ -6951,6 +6829,10 @@ run-async@^2.2.0:
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
   dependencies:
     is-promise "^2.1.0"
+
+rungen@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/rungen/-/rungen-0.3.2.tgz#400c09ebe914e7b17e0b6ef3263400fc2abc7cb3"
 
 rx-lite-aggregates@^4.0.8:
   version "4.0.8"


### PR DESCRIPTION
## Fixes #153 

This PR alters the way packages are resolved during the Jest run. Up to now, we were relying on the `moduleNameMapper` Jest config to map various `@wordpres/...` packages directly to the `src/index` module and call it a day.

Relevant PR on the Gutenberg repo: https://github.com/WordPress/gutenberg/pull/10131

### Background

Unfortunately, the Jest platform resolution setup was actually broken for some time now. See #153. Rootcause for #153 is the extensions defined in `moduleFileExtensions`. Unfortunately those were effectively bypassing the proper platform resolution mechanism in Jest/Haste.

By removing the excess extension definitions (leaving `moduleFileExtensions` with its defaults by deleting the whole field anyway) surfaced another problem, where the module mapper in Jest was breaking how Haste resolves packages: For example, Haste was having the `@wordpress/a11n` module in its cache but, because the mapping (apparently) happens after the cache is built the mapped module (`<fullpath>/gutenberg/packages/a11n/src/index`) cannot be found in the cache and fails to resolve. Removing the mapping fixes the issue but, Jest can no longer find the packages at all.

That's where the folder with the symlinks come into play. `symlinked-packages` is a folder that has a `@wordpress` subfolder in which there are now a set of symlinks, each named after the package we're interested in loading from the Gutenberg code. The symlink is pointing directly to the `src/` folder of the respective package. `symlinked-packages` is added as an extra node modules directory in Jest's config. When Jest tries to resolve, say, `@wordpress/a11n` it can find it inside `symlinked-packages`. Similar situation with `symlinked-packages-in-parent` but for the inside-gb setup.

In a slightly unrelated way, it happens that at the time of writing, the `@wordpress/element` package on NPM doesn't match the local one and the local one has proper serialization code for the blocks that `save` using React's `Provider`s. Using the package from NPM leads to all block get serialized to empty string, failing all the `isValid()` block checks. It's clear that we should either use *all* the packages from NPM or *all* the packages from local. This PR changes the dependencies to only use the local packages.

### "Can't find variable: Symbol" error

It also happens that the `@wordpress/redux-routine` package (local version at the time of writing) introduces the use of the `rungen` package which happens to be incompatible with the version of the JavascriptCore used in the Android RN app. This PR follows https://github.com/react-community/jsc-android-buildscripts#how-to-use-it-with-my-react-native-app to include an updated version of JavascriptCore but bumps the Android `minSdkVersion` to 21 at the same time. That makes the app requiring Android 5.0 and above.

## To Test

**Test A:**
No new functionality is added by this PR and in general, the app and tests should work as normal.

**Test B:**
Steps to test the #153 fix:
* Make a platform specific version of the `src/app/App.js` module as `src/app/App.ios.js`
* Edit the iOS variant and put a `console.log( 'This is an iOS specific module!' );` early on top of the module
* `yarn test src/app/App.test.js` to run a single test module so we can more easily observe the console logs. Notice that without any command line parameters like that, the tests are set up to run the Android codepaths (`Setting RN platform to: default (android)` printed in the console).
* Notice that the `This is an iOS specific module!` log is *not* printed.
* Now, use `TEST_RN_PLATFORM=ios yarn test src/app/App.test.js` to run the same test module but setting the platform to `ios`. Notice the `This is an iOS specific module!` is now printed.