### PR TITLE
Update GB hash to latest master

### DIFF
--- a/symlinked-packages/@wordpress/escape-html
+++ b/symlinked-packages/@wordpress/escape-html
@@ -1,0 +1,1 @@
+../../gutenberg/packages/escape-html/src/

--- a/symlinked-packages/@wordpress/rich-text
+++ b/symlinked-packages/@wordpress/rich-text
@@ -1,0 +1,1 @@
+../../gutenberg/packages/rich-text/src/


### PR DESCRIPTION
Title has it. 

Better to update to GB `master` asap, and test it well since new richText format already landed in GB. (Ref: https://github.com/WordPress/gutenberg/pull/7890)