### PR TITLE
Add a new empty para block on Enter.KEY

### DIFF
--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -69,6 +69,7 @@ export default class BlockHolder extends React.Component<PropsType, StateType> {
 				setAttributes={ ( attrs ) =>
 					this.props.onChange( this.props.clientId, { ...this.props.attributes, ...attrs } )
 				}
+				insertBlocksAfter={ this.props.insertBlocksAfter }
 				isSelected={ this.props.focused }
 				style={ style }
 			/>

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -50,14 +50,6 @@ export default class BlockHolder extends React.Component<PropsType, StateType> {
 		return <View />;
 	}
 
-	_insertBlocksAfter( blocks: Array<Object> ) {
-		if ( ! this.props.insertBlocksAfter ) {
-			return;
-		}
-		const { insertBlocksAfter } = this.props;
-		insertBlocksAfter( this.props.clientId, blocks );
-	}
-
 	getBlockForType() {
 		// Since unsupported blocks are handled in block-manager.js, at this point the block should definitely
 		// be supported.
@@ -78,7 +70,7 @@ export default class BlockHolder extends React.Component<PropsType, StateType> {
 				setAttributes={ ( attrs ) =>
 					this.props.onChange( this.props.clientId, { ...this.props.attributes, ...attrs } )
 				}
-				insertBlocksAfter={ this._insertBlocksAfter.bind( this ) }
+				insertBlocksAfter={ this.props.insertBlocksAfter }
 				isSelected={ this.props.focused }
 				style={ style }
 			/>

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -19,6 +19,7 @@ type PropsType = BlockType & {
 	onChange: ( clientId: string, attributes: mixed ) => void,
 	onToolbarButtonPressed: ( button: number, clientId: string ) => void,
 	onBlockHolderPressed: ( clientId: string ) => void,
+	insertBlocksAfter: ( blocks: array ) => void,
 };
 
 type StateType = {

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -19,7 +19,7 @@ type PropsType = BlockType & {
 	onChange: ( clientId: string, attributes: mixed ) => void,
 	onToolbarButtonPressed: ( button: number, clientId: string ) => void,
 	onBlockHolderPressed: ( clientId: string ) => void,
-	insertBlocksAfter: ( blocks: Array<Object> ) => void,
+	insertBlocksAfter: ( clientId: string, blocks: Array<Object> ) => void,
 };
 
 type StateType = {
@@ -50,6 +50,14 @@ export default class BlockHolder extends React.Component<PropsType, StateType> {
 		return <View />;
 	}
 
+	_insertBlocksAfter( blocks: Array<Object> ) {
+		if ( ! this.props.insertBlocksAfter ) {
+			return;
+		}
+		const { insertBlocksAfter } = this.props;
+		insertBlocksAfter( this.props.clientId, blocks );
+	}
+
 	getBlockForType() {
 		// Since unsupported blocks are handled in block-manager.js, at this point the block should definitely
 		// be supported.
@@ -70,7 +78,7 @@ export default class BlockHolder extends React.Component<PropsType, StateType> {
 				setAttributes={ ( attrs ) =>
 					this.props.onChange( this.props.clientId, { ...this.props.attributes, ...attrs } )
 				}
-				insertBlocksAfter={ this.props.insertBlocksAfter }
+				insertBlocksAfter={ this._insertBlocksAfter.bind( this ) }
 				isSelected={ this.props.focused }
 				style={ style }
 			/>

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -19,7 +19,7 @@ type PropsType = BlockType & {
 	onChange: ( clientId: string, attributes: mixed ) => void,
 	onToolbarButtonPressed: ( button: number, clientId: string ) => void,
 	onBlockHolderPressed: ( clientId: string ) => void,
-	insertBlocksAfter: ( blocks: array ) => void,
+	insertBlocksAfter: ( blocks: Array<Object> ) => void,
 };
 
 type StateType = {

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -19,7 +19,7 @@ type PropsType = BlockType & {
 	onChange: ( clientId: string, attributes: mixed ) => void,
 	onToolbarButtonPressed: ( button: number, clientId: string ) => void,
 	onBlockHolderPressed: ( clientId: string ) => void,
-	insertBlocksAfter: ( clientId: string, blocks: Array<Object> ) => void,
+	insertBlocksAfter: ( blocks: Array<Object> ) => void,
 };
 
 type StateType = {

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -139,22 +139,16 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		this.state.dataSource.setDirty();
 	}
 
-	insertBlocksAfter( blocks: Array<Object> ) {
+	insertBlocksAfter( clientId: string, blocks: Array<Object> ) {
 		// find currently focused block
-		let focusedItemIndex = this.findDataSourceIndexForFocusedItem();
-		if ( focusedItemIndex === -1 ) {
-			// TODO: no focus yet? This is a well known bug on Android...Remove this as
-			// soon as we fix the focus problem on the list
-			focusedItemIndex = 3;
-		}
-		const clientIdFocused = this.state.dataSource.get( focusedItemIndex ).clientId;
+		const focusedItemIndex = this.getDataSourceIndexFromClientId( clientId );
 
 		const newBlock = blocks[ 0 ];
 		newBlock.focused = true;
 
 		// set it into the datasource, and use the same object instance to send it to props/redux
 		this.state.dataSource.splice( focusedItemIndex + 1, 0, newBlock );
-		this.props.createBlockAction( newBlock.clientId, newBlock, clientIdFocused );
+		this.props.createBlockAction( newBlock.clientId, newBlock, clientId );
 
 		// now set the focus
 		this.props.focusBlockAction( newBlock.clientId ); // this not working atm

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -143,7 +143,8 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		// find currently focused block
 		let focusedItemIndex = this.findDataSourceIndexForFocusedItem();
 		if ( focusedItemIndex == -1 ) {
-			// no focus yet? This is a well knwon bug on Android...
+			// TODO: no focus yet? This is a well known bug on Android...Remove this as
+			// soon as we fix the focus problem on the list
 			focusedItemIndex = 3;
 		}
 		const clientIdFocused = this.state.dataSource.get( focusedItemIndex ).clientId;

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -267,7 +267,9 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 					showTitle={ this.state.inspectBlocks }
 					focused={ value.item.focused }
 					clientId={ value.clientId }
-					insertBlocksAfter={ this.insertBlocksAfter.bind( this ) }
+					insertBlocksAfter={ ( blocks ) =>
+						this.insertBlocksAfter.bind( this )( value.item.clientId, blocks )
+					}
 					{ ...value.item }
 				/>
 				{ this.state.blockTypePickerVisible && value.item.focused && insertHere }

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -142,7 +142,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 	insertBlocksAfter( blocks: Array<Object> ) {
 		// find currently focused block
 		let focusedItemIndex = this.findDataSourceIndexForFocusedItem();
-		if ( focusedItemIndex == -1 ) {
+		if ( focusedItemIndex === -1 ) {
 			// TODO: no focus yet? This is a well known bug on Android...Remove this as
 			// soon as we fix the focus problem on the list
 			focusedItemIndex = 3;

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -139,7 +139,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		this.state.dataSource.setDirty();
 	}
 
-	insertBlocksAfter( blocks ) {
+	insertBlocksAfter( blocks: Array<Object> ) {
 		// find currently focused block
 		const focusedItemIndex = this.findDataSourceIndexForFocusedItem();
 		const clientIdFocused = this.state.dataSource.get( focusedItemIndex ).clientId;

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -140,14 +140,11 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 	}
 
 	insertBlocksAfter( blocks ) {
-		console.log('ci sei quasi')
-
 		// find currently focused block
 		const focusedItemIndex = this.findDataSourceIndexForFocusedItem();
-		console.log(focusedItemIndex);
 		const clientIdFocused = this.state.dataSource.get( focusedItemIndex ).clientId;
 
-		let newBlock = blocks[0];
+		const newBlock = blocks[ 0 ];
 		newBlock.focused = false;
 
 		// set it into the datasource, and use the same object instance to send it to props/redux

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -141,18 +141,22 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 
 	insertBlocksAfter( blocks: Array<Object> ) {
 		// find currently focused block
-		const focusedItemIndex = this.findDataSourceIndexForFocusedItem();
+		let focusedItemIndex = this.findDataSourceIndexForFocusedItem();
+		if ( focusedItemIndex == -1 ) {
+			// no focus yet? This is a well knwon bug on Android...
+			focusedItemIndex = 3;
+		}
 		const clientIdFocused = this.state.dataSource.get( focusedItemIndex ).clientId;
 
 		const newBlock = blocks[ 0 ];
-		newBlock.focused = false;
+		newBlock.focused = true;
 
 		// set it into the datasource, and use the same object instance to send it to props/redux
 		this.state.dataSource.splice( focusedItemIndex + 1, 0, newBlock );
 		this.props.createBlockAction( newBlock.clientId, newBlock, clientIdFocused );
 
 		// now set the focus
-		this.props.focusBlockAction( newBlock.clientId );
+		this.props.focusBlockAction( newBlock.clientId ); // this not working atm
 	}
 
 	onChange( clientId: string, attributes: mixed ) {

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -139,6 +139,25 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		this.state.dataSource.setDirty();
 	}
 
+	insertBlocksAfter( blocks ) {
+		console.log('ci sei quasi')
+
+		// find currently focused block
+		const focusedItemIndex = this.findDataSourceIndexForFocusedItem();
+		console.log(focusedItemIndex);
+		const clientIdFocused = this.state.dataSource.get( focusedItemIndex ).clientId;
+
+		let newBlock = blocks[0];
+		newBlock.focused = false;
+
+		// set it into the datasource, and use the same object instance to send it to props/redux
+		this.state.dataSource.splice( focusedItemIndex + 1, 0, newBlock );
+		this.props.createBlockAction( newBlock.clientId, newBlock, clientIdFocused );
+
+		// now set the focus
+		this.props.focusBlockAction( newBlock.clientId );
+	}
+
 	onChange( clientId: string, attributes: mixed ) {
 		// Update Redux store
 		this.props.onChange( clientId, attributes );
@@ -252,6 +271,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 					showTitle={ this.state.inspectBlocks }
 					focused={ value.item.focused }
 					clientId={ value.clientId }
+					insertBlocksAfter={ this.insertBlocksAfter.bind( this ) }
 					{ ...value.item }
 				/>
 				{ this.state.blockTypePickerVisible && value.item.focused && insertHere }


### PR DESCRIPTION
This PR updates GB hash, and adds the code to insert a new para block after the current focused when enter.key is pressed.

There are few problems at the moment, not strictly related to this PR, explained below:
- `this.props.focusBlockAction( newBlock.clientId )` in `block-manager.js` is not working fine, the new block is not getting the focus, both if you tap `+` on the bottom toolbar and both if you press Enter.key in a para/heading block. cc @mzorz 
- There are problems getting the focus on blocks on Android, and consequence of this is that the bottom block management toolbar is not visible, and the index of the current block unknown. consequence of this is that I needed to add a hack to insert the block in the middle of the list atm.


GB side PR is available here: https://github.com/WordPress/gutenberg/pull/10553


