### PR TITLE
Fix: html editor

### DIFF
--- a/src/components/html-text-input.js
+++ b/src/components/html-text-input.js
@@ -29,8 +29,8 @@ export default class HTMLInputView extends React.Component<PropsType, StateType>
 	componentDidMount() {
 		const html = this.serializeBlocksToHtml();
 		this.setState( { html } );
-		if (this.isIOS) {
-			this.textInput.setNativeProps({text: html});
+		if ( this.isIOS ) {
+			this.textInput.setNativeProps( { text: html } );
 		}
 	}
 
@@ -40,7 +40,7 @@ export default class HTMLInputView extends React.Component<PropsType, StateType>
 	}
 
 	shouldComponentUpdate() {
-		return !this.isIOS;
+		return ! this.isIOS;
 	}
 
 	serializeBlocksToHtml() {
@@ -63,7 +63,7 @@ export default class HTMLInputView extends React.Component<PropsType, StateType>
 		return (
 			<KeyboardAvoidingView style={ styles.container } behavior={ behavior }>
 				<TextInput
-					ref={ textInput => this.textInput = textInput }
+					ref={ ( textInput ) => this.textInput = textInput }
 					textAlignVertical="top"
 					multiline
 					numberOfLines={ 0 }

--- a/src/components/html-text-input.js
+++ b/src/components/html-text-input.js
@@ -23,10 +23,15 @@ export default class HTMLInputView extends React.Component<PropsType, StateType>
 	state = {
 		html: '',
 	}
+	isIOS: boolean = Platform.OS === 'ios';
+	textInput: TextInput;
 
 	componentDidMount() {
 		const html = this.serializeBlocksToHtml();
 		this.setState( { html } );
+		if (this.isIOS) {
+			this.textInput.setNativeProps({text: html});
+		}
 	}
 
 	componentWillUnmount() {
@@ -35,8 +40,7 @@ export default class HTMLInputView extends React.Component<PropsType, StateType>
 	}
 
 	shouldComponentUpdate() {
-		const isIOS = Platform.OS === 'ios';
-		if ( isIOS ) {
+		if ( this.isIOS ) {
 			// iOS TextInput gets jumpy if it's updated on every key stroke.
 			// The first render will always be empty, so:
 			// If the previous state was empty, we let update the component to show the next state.
@@ -60,16 +64,17 @@ export default class HTMLInputView extends React.Component<PropsType, StateType>
 	}
 
 	render() {
-		const behavior = Platform.OS === 'ios' ? 'padding' : null;
+		const behavior = this.isIOS ? 'padding' : null;
 
 		return (
 			<KeyboardAvoidingView style={ styles.container } behavior={ behavior }>
 				<TextInput
+					ref={ textInput => this.textInput = textInput }
 					textAlignVertical="top"
 					multiline
 					numberOfLines={ 0 }
 					style={ styles.htmlView }
-					value={ this.state.html }
+					value={ this.isIOS ? null : this.state.html }
 					onChangeText={ ( html ) => this.setState( { html } ) }
 				/>
 			</KeyboardAvoidingView>

--- a/src/components/html-text-input.js
+++ b/src/components/html-text-input.js
@@ -40,13 +40,7 @@ export default class HTMLInputView extends React.Component<PropsType, StateType>
 	}
 
 	shouldComponentUpdate() {
-		if ( this.isIOS ) {
-			// iOS TextInput gets jumpy if it's updated on every key stroke.
-			// The first render will always be empty, so:
-			// If the previous state was empty, we let update the component to show the next state.
-			return this.state.html === '';
-		}
-		return true;
+		return !this.isIOS;
 	}
 
 	serializeBlocksToHtml() {


### PR DESCRIPTION
This was a regression from (I think) updating `react-native`.
Some internal on how the TextView works on iOS broke our (hacky) HTML editor implementation.

The original problem look like this:
![editor](https://user-images.githubusercontent.com/9772967/46964168-e79b3c80-d07d-11e8-8942-683b9906f78c.gif)

Now if we set a value directly to the TextInput component, and we don't let it re-render, the component will keep that state not allowing editions:
![editor_2](https://user-images.githubusercontent.com/9772967/46964344-3648d680-d07e-11e8-891a-573093806ce2.gif)


This PR solves that problem by setting the TextView text value directly using a reference.

@marecar3 Could you please take a look at this?

To test:
- Run the project on iOS
- Check that the HTML Editor behaves normally.