### PR TITLE
Accept initial content via the root props

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -9,20 +9,32 @@ import { setupStore, html2State } from '../store';
 import AppContainer from './AppContainer';
 import { Store } from 'redux';
 
+import initialHtml from './initial-html';
+
 type PropsType = {
-	initialHtml: string,
+	initialData: string | Store,
 };
-type StateType = {};
+type StateType = {
+	store: Store,
+};
 
 export default class AppProvider extends React.Component<PropsType, StateType> {
-	constructor( props ) {
+	state: StateType;
+
+	constructor( props: PropsType ) {
 		super( props );
-		this.store = setupStore( html2State( this.props.initialHtml ) );
+
+		this.state = {
+			store:
+				typeof props.initialData === 'object' ?
+					props.initialData :
+					setupStore( html2State( props.initialData || initialHtml ) ),
+		};
 	}
 
 	render() {
 		return (
-			<Provider store={ this.store }>
+			<Provider store={ this.state.store }>
 				<AppContainer />
 			</Provider>
 		);

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -5,24 +5,26 @@ import '../globals';
 
 import React from 'react';
 import { Provider } from 'react-redux';
-import { setupStore } from '../store';
+import { setupStore, html2State } from '../store';
 import AppContainer from './AppContainer';
 import { Store } from 'redux';
 
 type PropsType = {
-	store: Store,
+	initialHtml: string,
 };
 type StateType = {};
 
-export class AppProvider extends React.Component<PropsType, StateType> {
+export default class AppProvider extends React.Component<PropsType, StateType> {
+	constructor( props ) {
+		super( props );
+		this.store = setupStore( html2State( this.props.initialHtml ) );
+	}
+
 	render() {
 		return (
-			<Provider store={ this.props.store }>
+			<Provider store={ this.store }>
 				<AppContainer />
 			</Provider>
 		);
 	}
 }
-
-// eslint-disable-next-line react/display-name
-export default () => <AppProvider store={ setupStore() } />;

--- a/src/app/App.test.js
+++ b/src/app/App.test.js
@@ -2,8 +2,9 @@
 
 import renderer from 'react-test-renderer';
 
-import App, { AppProvider } from './App';
-import { initialState, setupStore } from '../store';
+import App from './App';
+import initialHtml from './initial-html';
+import { html2State, setupStore } from '../store';
 import BlockHolder from '../block-management/block-holder';
 
 describe( 'App', () => {
@@ -13,9 +14,9 @@ describe( 'App', () => {
 		expect( rendered ).toBeTruthy();
 	} );
 
-	it( 'renders without crashing with a block focused', () => {
+	it.only( 'renders without crashing with a block focused', () => {
 		// construct a state object with the first block focused
-		const state = { ...initialState };
+		const state = html2State( initialHtml );
 		const block0 = { ...state.blocks[ 0 ] };
 		block0.focused = true;
 		state.blocks[ 0 ] = block0;
@@ -24,7 +25,7 @@ describe( 'App', () => {
 		const store = setupStore( state );
 
 		// render an App using the specified Store
-		const app = renderer.create( <AppProvider store={ store } /> );
+		const app = renderer.create( <App initialData={ store } /> );
 		const rendered = app.toJSON();
 
 		// App should be rendered OK

--- a/src/app/initial-html.js
+++ b/src/app/initial-html.js
@@ -1,0 +1,47 @@
+/**
+ * @format
+ * @flow
+ */
+
+export default `
+<!-- wp:image -->
+<figure class="wp-block-image"><img alt=""/></figure>
+<!-- /wp:image -->
+
+<!-- wp:image -->
+<figure class="wp-block-image"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
+<!-- /wp:image -->
+
+<!-- wp:title -->
+Hello World
+<!-- /wp:title -->
+
+<!-- wp:heading {"level": 2} -->
+<h2>Welcome to Gutenberg</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><b>Hello</b> World!</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"dropCap":true,"backgroundColor":"vivid-red","fontSize":"large","className":"custom-class-1 custom-class-2"} -->
+<p class="has-background has-drop-cap has-large-font-size has-vivid-red-background-color custom-class-1 custom-class-2">
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer tempor tincidunt sapien, quis dictum orci sollicitudin quis. Proin sed elit id est pulvinar feugiat vitae eget dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+<!-- /wp:paragraph -->
+
+
+<!-- wp:code -->
+<pre class="wp-block-code"><code>if name == "World":
+    return "Hello World"
+else:
+    return "Hello Pony"</code></pre>
+<!-- /wp:code -->
+
+<!-- wp:more -->
+<!--more-->
+<!-- /wp:more -->
+
+<!-- wp:p4ragraph -->
+Лорем ипсум долор сит амет, адиписци трацтатос еа еум. Меа аудиам малуиссет те, хас меис либрис елеифенд ин. Нец ех тота деленит сусципит. Яуас порро инструцтиор но нец.
+<!-- /wp:p4ragraph -->
+`;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -5,11 +5,7 @@
 
 // Gutenberg imports
 import { registerCoreBlocks } from '@wordpress/block-library';
-import {
-	parse,
-	registerBlockType,
-	setUnknownTypeHandlerName,
-} from '@wordpress/blocks';
+import { parse, registerBlockType, setUnknownTypeHandlerName } from '@wordpress/blocks';
 
 import { createStore } from 'redux';
 import { reducer } from './reducers';
@@ -77,20 +73,22 @@ else:
 <!-- /wp:p4ragraph -->
 `;
 
-const initialBlocks = parse( initialHtml );
-
-export const initialState: StateType = {
-	// TODO: get blocks list block state should be externalized (shared with Gutenberg at some point?).
-	// If not it should be created from a string parsing (commented HTML to json).
-	blocks: initialBlocks.map( ( block ) => ( { ...block, focused: false } ) ),
-	refresh: false,
-};
+export function html2State( html ) {
+	const blocksFromHtml = parse( html );
+	const state: StateType = {
+		// TODO: get blocks list block state should be externalized (shared with Gutenberg at some point?).
+		// If not it should be created from a string parsing (commented HTML to json).
+		blocks: blocksFromHtml.map( block => ( { ...block, focused: false } ) ),
+		refresh: false,
+	};
+	return state;
+}
 
 const devToolsEnhancer =
 	// ( 'development' === process.env.NODE_ENV && require( 'remote-redux-devtools' ).default ) ||
 	() => {};
 
-export function setupStore( state: StateType = initialState ) {
+export function setupStore( state: StateType = html2State( initialHtml ) ) {
 	const store = createStore( reducer, state, devToolsEnhancer() );
 	return store;
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -30,55 +30,12 @@ registerCoreBlocks();
 registerBlockType( UnsupportedBlock.name, UnsupportedBlock.settings );
 setUnknownTypeHandlerName( UnsupportedBlock.name );
 
-const initialHtml = `
-<!-- wp:image -->
-<figure class="wp-block-image"><img alt=""/></figure>
-<!-- /wp:image -->
-
-<!-- wp:image -->
-<figure class="wp-block-image"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
-<!-- /wp:image -->
-
-<!-- wp:title -->
-Hello World
-<!-- /wp:title -->
-
-<!-- wp:heading {"level": 2} -->
-<h2>Welcome to Gutenberg</h2>
-<!-- /wp:heading -->
-
-<!-- wp:paragraph -->
-<p><b>Hello</b> World!</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph {"dropCap":true,"backgroundColor":"vivid-red","fontSize":"large","className":"custom-class-1 custom-class-2"} -->
-<p class="has-background has-drop-cap has-large-font-size has-vivid-red-background-color custom-class-1 custom-class-2">
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer tempor tincidunt sapien, quis dictum orci sollicitudin quis. Proin sed elit id est pulvinar feugiat vitae eget dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-<!-- /wp:paragraph -->
-
-
-<!-- wp:code -->
-<pre class="wp-block-code"><code>if name == "World":
-    return "Hello World"
-else:
-    return "Hello Pony"</code></pre>
-<!-- /wp:code -->
-
-<!-- wp:more -->
-<!--more-->
-<!-- /wp:more -->
-
-<!-- wp:p4ragraph -->
-Лорем ипсум долор сит амет, адиписци трацтатос еа еум. Меа аудиам малуиссет те, хас меис либрис елеифенд ин. Нец ех тота деленит сусципит. Яуас порро инструцтиор но нец.
-<!-- /wp:p4ragraph -->
-`;
-
-export function html2State( html ) {
+export function html2State( html: string ) {
 	const blocksFromHtml = parse( html );
 	const state: StateType = {
 		// TODO: get blocks list block state should be externalized (shared with Gutenberg at some point?).
 		// If not it should be created from a string parsing (commented HTML to json).
-		blocks: blocksFromHtml.map( block => ( { ...block, focused: false } ) ),
+		blocks: blocksFromHtml.map( ( block ) => ( { ...block, focused: false } ) ),
 		refresh: false,
 	};
 	return state;
@@ -88,7 +45,7 @@ const devToolsEnhancer =
 	// ( 'development' === process.env.NODE_ENV && require( 'remote-redux-devtools' ).default ) ||
 	() => {};
 
-export function setupStore( state: StateType = html2State( initialHtml ) ) {
+export function setupStore( state: StateType = html2State( '' ) ) {
 	const store = createStore( reducer, state, devToolsEnhancer() );
 	return store;
 }


### PR DESCRIPTION
This PR allows the app to receive the initial html content via the initial props React Native is passing when bootstrapping the app. This enabled passing an initial post content via a parent app when the RN app is embedded.

### To test 1:
Running the app as normal should work OK with the usual demo content coming up when ran.

### To test 2:
Tests should also pass green.

### To test 3 (Android only):
* clone the WordPress Android app from git@github.com:wordpress-mobile/WordPress-Android.git
* cd into the cloned repo check out the `feature/integrate-gutenberg` branch
* in the terminal again, `git submodule update --init` to pull the mobile Gutenberg codetree
* cd into the mobile Gutenberg tree (`libs/gutenberg-mobile`) and as normal, do `git submodule update --init`, `yarn install` and `yarn start` to start Metro
* open the wpandroid project in AndroidStudio. Remember to have a valid `gradle.properties` in the root folder as well.
* Run wpandroid
* Make sure you've ran `adb reverse tcp:8081 tcp:8081` to setup the port forwarding so the app can reach the Metro server.
* Login and head to the posts list. Open one of the posts for editing. Ideally a simple Gutenberg created post.
* There will probably be a red scren now with "Block validation" error. Just dismiss it for now.
* You should be able to see the React Native app embedded in the view, showing the post content in some of its block glory.

cc @etoledom since you're also working on the integration task, on iOS side.