### PR TITLE
Update repo URL for git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Note that the OS platform used by the maintainers is macOS but the tools and set
 
 * Clone the project and submodules:
 ```
-$ git clone --recurse-submodules https://github.com/automattic/gutenberg-mobile
+$ git clone --recurse-submodules git@github.com:wordpress-mobile/gutenberg-mobile.git
 ```
 
 * Or if you already have the project cloned, initialize and update the submodules:


### PR DESCRIPTION
Update URL from `https://github.com/automattic/gutenberg-mobile` to `git clone --recurse-submodules git@github.com:wordpress-mobile/gutenberg-mobile.git`