### PR TITLE
Updated README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,22 @@ Before running the demo app, you need to download and install the project depend
 yarn install
 ```
 
-## Pre-Setup iOS
+## Prerequisites
 
-Carthage is also needed for fetching the Aztec dependency and you can get it running following command:
+Carthage is also needed for fetching the Aztec dependency.
+
+First make sure that you have installed homebrew for MacOS. You can do it with following command:
 
 ```
-yarn preios
+ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 ```
+
+When above command is exectuted with success, you can use homebrew to install Carthage. This is done via the following command:
+
+```
+brew install carthage
+```
+
 
 ## Run
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ For a developer experience closer to the one the project maintainers current hav
 * yarn (`npm install -g yarn`)
 * [AndroidStudio](https://developer.android.com/studio/) to be able to compile the Android version of the app
 * [Xcode](https://developer.apple.com/xcode/) to be able to compile the iOS app
+* [Carthage] (https://github.com/Carthage/Carthage#installing-carthage) needed for fetching the Aztec dependency.
+
 
 Note that the OS platform used by the maintainers is macOS but the tools and setup should be usable in other platforms too.
 
@@ -39,23 +41,6 @@ Before running the demo app, you need to download and install the project depend
 ```
 yarn install
 ```
-
-## Prerequisites
-
-Carthage is also needed for fetching the Aztec dependency.
-
-First make sure that you have installed homebrew for MacOS. You can do it with following command:
-
-```
-ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-```
-
-When above command is exectuted with success, you can use homebrew to install Carthage. This is done via the following command:
-
-```
-brew install carthage
-```
-
 
 ## Run
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For a developer experience closer to the one the project maintainers current hav
 * yarn (`npm install -g yarn`)
 * [AndroidStudio](https://developer.android.com/studio/) to be able to compile the Android version of the app
 * [Xcode](https://developer.apple.com/xcode/) to be able to compile the iOS app
-* [Carthage] (https://github.com/Carthage/Carthage#installing-carthage) needed for fetching the Aztec dependency.
+* [Carthage](https://github.com/Carthage/Carthage#installing-carthage) needed for fetching the Aztec dependency.
 
 
 Note that the OS platform used by the maintainers is macOS but the tools and setup should be usable in other platforms too.

--- a/README.md
+++ b/README.md
@@ -40,9 +40,15 @@ Before running the demo app, you need to download and install the project depend
 yarn install
 ```
 
-## Run
+## Pre-Setup iOS
 
-Note: the most recent and complete version of this guide is available [here](https://github.com/react-community/create-react-native-app/blob/master/react-native-scripts/template/README.md).
+Carthage is also needed for fetching the Aztec dependency and you can get it running following command:
+
+```
+yarn preios
+```
+
+## Run
 
 ```
 yarn start


### PR DESCRIPTION
Updated readme file.

1. We have added a command which installs the Carthage as it is needed when Mac OS is first time used.

2. Removed deprecated link. I tried to find some other which suits most but the newest version of the file relies on EXPO [NEW README](https://github.com/react-community/create-react-native-app) which doesn't suit our needs.

If you have something else to add on this README, please leave a commend on this PR.