### PR TITLE
Fix error on iOS when adding a new block from paragraph block.

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -66,12 +66,18 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 
 	findDataSourceIndexForFocusedItem() {
 		for ( let i = 0; i < this.state.dataSource.size(); ++i ) {
-			const block = this.state.dataSource.get( i );
+			const block = this.findBlockAtIndex( i );
 			if ( block.focused === true ) {
 				return i;
 			}
 		}
 		return -1;
+	}
+
+	findBlockAtIndex( index: number ): Object {
+		return Platform.OS === 'ios' ?
+			this.props.blocks[ index ] :
+			this.state.dataSource.get( index );
 	}
 
 	// TODO: in the near future this will likely be changed to onShowBlockTypePicker and bound to this.props

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -66,18 +66,12 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 
 	findDataSourceIndexForFocusedItem() {
 		for ( let i = 0; i < this.state.dataSource.size(); ++i ) {
-			const block = this.findBlockAtIndex( i );
+			const block = this.state.dataSource.get( i );
 			if ( block.focused === true ) {
 				return i;
 			}
 		}
 		return -1;
-	}
-
-	findBlockAtIndex( index: number ): Object {
-		return Platform.OS === 'ios' ?
-			this.props.blocks[ index ] :
-			this.state.dataSource.get( index );
 	}
 
 	// TODO: in the near future this will likely be changed to onShowBlockTypePicker and bound to this.props

--- a/src/store/reducers/index.js
+++ b/src/store/reducers/index.js
@@ -65,16 +65,12 @@ export const reducer = (
 
 			// Skip update if nothing has been changed. The reference will
 			// match the original block if `reduce` had no changed values.
-			if ( nextAttributes === findBlock( blocks, action.clientId ).attributes ) {
+			if ( nextAttributes === block.attributes ) {
 				return state;
 			}
 
 			// Otherwise merge attributes into state
-			const index = findBlockIndex( blocks, action.clientId );
-			blocks[ index ] = {
-				...block,
-				attributes: nextAttributes,
-			};
+			block.attributes = nextAttributes;
 
 			return { blocks: blocks, refresh: ! state.refresh };
 		}


### PR DESCRIPTION
This PR is a proposal to fix an issue on iOS when selecting a `paragraph` block and creating a new block from it:

<img width="383" alt="screen_shot_2018-10-23_at_16 31 47" src="https://user-images.githubusercontent.com/9772967/47376368-d62ee180-d6c8-11e8-9bc7-9c0740e375bc.png">

We use `findDataSourceIndexForFocusedItem` to get the index of the focused block and insert the new block below it.

`findDataSourceIndexForFocusedItem` use `this.state.dataSource` to get the block state, and I noticed that the `focused` state of the focused block was `false`. But the same block had `focused` state `true` on `this.props.blocks`.

Using `this.props.blocks` instead of `this.state.dataSource` on iOS solved the problem.

This still feels like a workaround other than finding and fixing the real problem. Hopefully @tug 's work on Gutenberg internal state will fix this more permanently 😁

To test:
- Run the iOS example app.
- Select a paragraph block.
- Tap on the + button to add a new block.
- Try to add a new block.
- Check that the block is added successfully.