### PR TITLE
Avoid using the setUnknownTypeHandlerName deprecated APIs from Gutenberg

### DIFF
--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -12,7 +12,7 @@ import type { BlockType } from '../store/';
 import styles from './block-holder.scss';
 
 // Gutenberg imports
-import { getBlockType, getUnknownTypeHandlerName } from '@wordpress/blocks';
+import { getBlockType, getUnregisteredTypeHandlerName } from '@wordpress/blocks';
 
 type PropsType = BlockType & {
 	showTitle: boolean,
@@ -81,7 +81,7 @@ export default class BlockHolder extends React.Component<PropsType, StateType> {
 		let blockType = getBlockType( blockName );
 
 		if ( ! blockType ) {
-			const fallbackBlockName = getUnknownTypeHandlerName();
+			const fallbackBlockName = getUnregisteredTypeHandlerName();
 			blockType = getBlockType( fallbackBlockName );
 		}
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -8,7 +8,6 @@ import { registerCoreBlocks } from '@wordpress/block-library';
 import {
 	parse,
 	registerBlockType,
-	setFreeformContentHandlerName,
 	setUnregisteredTypeHandlerName,
 } from '@wordpress/blocks';
 
@@ -33,7 +32,6 @@ export type StateType = {
 
 registerCoreBlocks();
 registerBlockType( UnsupportedBlock.name, UnsupportedBlock.settings );
-setFreeformContentHandlerName( UnsupportedBlock.name );
 setUnregisteredTypeHandlerName( UnsupportedBlock.name );
 
 export function html2State( html: string ) {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -5,7 +5,12 @@
 
 // Gutenberg imports
 import { registerCoreBlocks } from '@wordpress/block-library';
-import { parse, registerBlockType, setUnknownTypeHandlerName } from '@wordpress/blocks';
+import {
+	parse,
+	registerBlockType,
+	setFreeformContentHandlerName,
+	setUnregisteredTypeHandlerName,
+} from '@wordpress/blocks';
 
 import { createStore } from 'redux';
 import { reducer } from './reducers';
@@ -28,7 +33,8 @@ export type StateType = {
 
 registerCoreBlocks();
 registerBlockType( UnsupportedBlock.name, UnsupportedBlock.settings );
-setUnknownTypeHandlerName( UnsupportedBlock.name );
+setFreeformContentHandlerName( UnsupportedBlock.name );
+setUnregisteredTypeHandlerName( UnsupportedBlock.name );
 
 export function html2State( html: string ) {
 	const blocksFromHtml = parse( html );


### PR DESCRIPTION
Youhou my first PR on the mobile repo. I don't really know how to test it at this stage but let me know how it looks.

The idea is to replace the deprecated APIs that are going to be removed from the Gutenberg repository.

Thanks for you help.

Related https://github.com/WordPress/gutenberg/pull/10952