### PR TITLE
Fix maven dependency error with Android Studio 3.2

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -142,6 +142,7 @@ android {
 
 buildscript {
     repositories {
+        maven { url 'https://maven.google.com' }
         jcenter()
         google()
     }
@@ -152,6 +153,7 @@ buildscript {
 }
 
 repositories {
+    maven { url 'https://maven.google.com' }
     jcenter()
     google()
     maven { url "https://jitpack.io" }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -95,7 +95,7 @@ def enableProguardInReleaseBuilds = false
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.2"
+    buildToolsVersion "28.0.2"
 
     defaultConfig {
         applicationId "com.gutenberg"
@@ -142,20 +142,18 @@ android {
 
 buildscript {
     repositories {
-        maven { url 'https://maven.google.com' }
-        jcenter()
         google()
+        jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
     }
 }
 
 repositories {
-    maven { url 'https://maven.google.com' }
-    jcenter()
     google()
+    jcenter()
     maven { url "https://jitpack.io" }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,6 +14,7 @@ buildscript {
     }
 
     repositories {
+        maven { url 'https://maven.google.com' }
         jcenter()
         google()
     }
@@ -28,6 +29,7 @@ allprojects {
     repositories {
         mavenLocal()
         google()
+        maven { url 'https://maven.google.com' }
         jcenter()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        gradlePluginVersion = '3.0.1'
+        gradlePluginVersion = '3.1.0'
         kotlinVersion = '1.2.31'
         supportLibVersion = '27.1.1'
         tagSoupVersion = '1.2.2'
@@ -14,9 +14,8 @@ buildscript {
     }
 
     repositories {
-        maven { url 'https://maven.google.com' }
-        jcenter()
         google()
+        jcenter()
     }
 
     dependencies {
@@ -29,7 +28,6 @@ allprojects {
     repositories {
         mavenLocal()
         google()
-        maven { url 'https://maven.google.com' }
         jcenter()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm


### PR DESCRIPTION
Currently you might see the following error when running `yarn android`:

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'gutenberg'.
> Could not resolve all files for configuration ':classpath'.
   > Could not find intellij-core.jar (com.android.tools.external.com-intellij:intellij-core:26.0.1).
     Searched in the following locations:
         https://jcenter.bintray.com/com/android/tools/external/com-intellij/intellij-core/26.0.1/intellij-core-26.0.1.jar
```

This PR should fix it.

### Testing Instructions
- Install `gutenberg-mobile` from scratch
- Install Android Studio 3.2
- Run `yarn install`
- Run `yarn android`

