### PR TITLE
ESLint: Avoid focused unit test

### DIFF
--- a/src/app/App.test.js
+++ b/src/app/App.test.js
@@ -14,7 +14,7 @@ describe( 'App', () => {
 		expect( rendered ).toBeTruthy();
 	} );
 
-	it.only( 'renders without crashing with a block focused', () => {
+	it( 'renders without crashing with a block focused', () => {
 		// construct a state object with the first block focused
 		const state = html2State( initialHtml );
 		const block0 = { ...state.blocks[ 0 ] };


### PR DESCRIPTION
This was causing an error in a Gutenberg PR https://github.com/WordPress/gutenberg/pull/10952 but I wonder why it didn't fail in this repository before.