### PR TITLE
Tapping twice no longer removes focus.

### DIFF
--- a/src/store/reducers/index.js
+++ b/src/store/reducers/index.js
@@ -83,8 +83,7 @@ export const reducer = (
 				block.focused = false;
 			}
 
-			// Select or deselect pressed block
-			destBlock.focused = ! destBlockState;
+			destBlock.focused = true;
 			return { blocks: blocks, refresh: ! state.refresh };
 		}
 		case ActionTypes.BLOCK.MOVE_UP: {

--- a/src/store/reducers/index.js
+++ b/src/store/reducers/index.js
@@ -76,7 +76,6 @@ export const reducer = (
 		}
 		case ActionTypes.BLOCK.FOCUS: {
 			const destBlock = findBlock( blocks, action.clientId );
-			const destBlockState = destBlock.focused;
 
 			// Deselect all blocks
 			for ( const block of blocks ) {


### PR DESCRIPTION
### Description:

Fixes #190 

Tapping twice on the same block no longer removes focus from it.

### Testing:

Just tap multiple times in the same text block and make sure the bottom toolbar is never removed.