### PR TITLE
Feature/port nextpage block

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "react-native-modal": "^6.5.0",
     "react-native-recyclerview-list": "git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#c073c0335ebe0398c85648ffeb11cbed4ee79229",
     "react-native-svg": "^6.5.2",
+    "react-native-hr": "git+https://github.com/Riglerr/react-native-hr.git#2d01a5cf77212d100e8b99e0310cce5234f977b3",
     "react-redux": "^5.0.7",
     "redux": "^3.7.2",
     "rememo": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7236,6 +7236,10 @@ react-native-crypto@^2.0.1:
     pbkdf2 "3.0.8"
     public-encrypt "^4.0.0"
 
+"react-native-hr@git+https://github.com/Riglerr/react-native-hr.git#2d01a5cf77212d100e8b99e0310cce5234f977b3":
+  version "1.1.3"
+  resolved "git+https://github.com/Riglerr/react-native-hr.git#2d01a5cf77212d100e8b99e0310cce5234f977b3"
+
 react-native-modal@^6.5.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/react-native-modal/-/react-native-modal-6.5.0.tgz#46220b2289a41597d344c1db17454611b426a758"


### PR DESCRIPTION
This is a simple PR that adds the [react-native-hr](https://github.com/Riglerr/react-native-hr) library to GB mobile. It will be used by the nextpage block.