### PR TITLE
Added turbo-combine-reducers dependency to fix failed builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "rememo": "^3.0.0",
     "shallowequal": "^1.0.2",
     "simple-html-tokenizer": "^0.5.1",
-    "tinycolor2": "^1.4.1"
+    "tinycolor2": "^1.4.1",
+    "turbo-combine-reducers": "^1.0.2"
   }
 }


### PR DESCRIPTION
With latest [PR](https://github.com/WordPress/gutenberg/pull/11255/files) on gutenberg, we have experienced failing builds on our end. This quick fix will catch up us with gutenberg and our builds will pass with success.