### PR TITLE
Use wpandroid compat aztec and list

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "react": "16.5.0",
     "react-native": "0.57.1",
     "react-native-modal": "^6.5.0",
-    "react-native-recyclerview-list": "git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#8a4058672821f8e28c063ca5c8671bae67ae8254",
+    "react-native-recyclerview-list": "git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#336f7159eb6e7bad467c041b3f34667d485e7b58",
     "react-native-svg": "^6.5.2",
     "react-native-hr": "git+https://github.com/Riglerr/react-native-hr.git#2d01a5cf77212d100e8b99e0310cce5234f977b3",
     "react-redux": "^5.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7256,9 +7256,9 @@ react-native-randombytes@^2.2.0:
     buffer "^4.9.1"
     sjcl "^1.0.3"
 
-"react-native-recyclerview-list@git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#8a4058672821f8e28c063ca5c8671bae67ae8254":
+"react-native-recyclerview-list@git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#336f7159eb6e7bad467c041b3f34667d485e7b58":
   version "0.3.2"
-  resolved "git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#8a4058672821f8e28c063ca5c8671bae67ae8254"
+  resolved "git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#336f7159eb6e7bad467c041b3f34667d485e7b58"
   dependencies:
     prop-types "^15.6.0"
 


### PR DESCRIPTION
This PR follows up #201 and merges to master the updated refs to `react-native-aztec` and `react-native-recyclerview-list`.

The changes where tested via #201 , https://github.com/wordpress-mobile/react-native-aztec/pull/66 and https://github.com/wordpress-mobile/react-native-recyclerview-list/pull/9