### PR TITLE
[Bridge iOS]: Better bridge podspec

### DIFF
--- a/react-native-gutenberg-bridge/RNReactNativeGutenbergBridge.podspec
+++ b/react-native-gutenberg-bridge/RNReactNativeGutenbergBridge.podspec
@@ -10,10 +10,10 @@ Pod::Spec.new do |s|
                    DESC
   s.homepage     = 'https://github.com/wordpress-mobile/gutenberg-mobile'
   s.license      = 'MIT'
-  s.author             = { 'author' => 'author@domain.cn' }
+  s.author       = { 'author' => 'author@domain.cn' }
   s.platform     = :ios, '10.0'
   s.source       = { :git => 'https://github.com/author/RNReactNativeGutenbergBridge.git', :tag => 'master' }
-  s.source_files  = 'ios/*.{h,m}'
+  s.source_files = 'ios/*.{h,m}'
   s.requires_arc = true
 
   s.dependency 'React/Core', react_native_version

--- a/react-native-gutenberg-bridge/RNReactNativeGutenbergBridge.podspec
+++ b/react-native-gutenberg-bridge/RNReactNativeGutenbergBridge.podspec
@@ -1,24 +1,31 @@
+# Use the same RN version that the JS tools use
+react_native_version = '0.57.1'
 
 Pod::Spec.new do |s|
-  s.name         = "RNReactNativeGutenbergBridge"
-  s.version      = "0.1.0"
-  s.summary      = "RNReactNativeGutenbergBridge"
+  s.name         = 'RNReactNativeGutenbergBridge'
+  s.version      = '0.1.0'
+  s.summary      = 'RNReactNativeGutenbergBridge'
   s.description  = <<-DESC
                   The RNReactNativeGutenbergBridge
                    DESC
-  s.homepage     = "https://github.com/wordpress-mobile/gutenberg-mobile"
-  s.license      = "MIT"
-  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
-  s.author             = { "author" => "author@domain.cn" }
-  s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/author/RNReactNativeGutenbergBridge.git", :tag => "master" }
-  s.source_files  = "ios/*.{h,m}"
+  s.homepage     = 'https://github.com/wordpress-mobile/gutenberg-mobile'
+  s.license      = 'MIT'
+  s.author             = { 'author' => 'author@domain.cn' }
+  s.platform     = :ios, '10.0'
+  s.source       = { :git => 'https://github.com/author/RNReactNativeGutenbergBridge.git', :tag => 'master' }
+  s.source_files  = 'ios/*.{h,m}'
   s.requires_arc = true
 
+  s.dependency 'React/Core', react_native_version
+  s.dependency 'React/CxxBridge', react_native_version
+  s.dependency 'React/RCTAnimation', react_native_version
+  s.dependency 'React/RCTImage', react_native_version
+  s.dependency 'React/RCTLinkingIOS', react_native_version
+  s.dependency 'React/RCTNetwork', react_native_version
+  s.dependency 'React/RCTText', react_native_version
+  s.dependency 'React/RCTActionSheet', react_native_version
 
-  s.dependency "React"
-  #s.dependency "others"
-
+  s.dependency 'yoga', "#{react_native_version}.React"
 end
 
   

--- a/react-native-gutenberg-bridge/RNReactNativeGutenbergBridge.podspec
+++ b/react-native-gutenberg-bridge/RNReactNativeGutenbergBridge.podspec
@@ -24,6 +24,7 @@ Pod::Spec.new do |s|
   s.dependency 'React/RCTNetwork', react_native_version
   s.dependency 'React/RCTText', react_native_version
   s.dependency 'React/RCTActionSheet', react_native_version
+  s.dependency 'React/DevSupport', react_native_version
 
   s.dependency 'yoga', "#{react_native_version}.React"
 end


### PR DESCRIPTION
This PR improves the integration with a parent app by declaring the dependencies needed by Gutenberg-Mobile in the `react-native-gutenberg-bridge` podspec.

**To test:**
Follow the instructions in the WPiOS integration PR.
https://github.com/wordpress-mobile/WordPress-iOS/pull/10445