### PR TITLE
Inserter button in toolbar

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -28,7 +28,7 @@ export default class AppProvider extends React.Component<PropsType, StateType> {
 			store:
 				typeof props.initialData === 'object' ?
 					props.initialData :
-					setupStore( html2State( props.initialData || initialHtml ) ),
+					setupStore( html2State( props.initialData !== undefined ? props.initialData : initialHtml ) ),
 		};
 	}
 

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -98,9 +98,9 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 	onBlockTypeSelected( itemValue: string ) {
 		this.setState( { ...this.state, selectedBlockType: itemValue, blockTypePickerVisible: false } );
 
-		// find currently focused block
+		// find currently focused block. It can be '-1' if no block is currently selected or there are no blocks at all.
 		const focusedItemIndex = this.findDataSourceIndexForFocusedItem();
-		const clientIdFocused = this.state.dataSource.get( focusedItemIndex ).clientId;
+		const clientIdFocused = focusedItemIndex > -1 ? this.state.dataSource.get( focusedItemIndex ).clientId : '';
 
 		// create an empty block of the selected type
 		const newBlock = createBlock( itemValue, { content: 'new test text for a ' + itemValue + ' block' } );
@@ -291,7 +291,11 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		return (
 			<KeyboardAvoidingView style={ { flex: 1 } } behavior={ behavior }>
 				{ list }
-				<BlockToolbar />
+				<BlockToolbar
+					onInsertClick={ () => {
+						this.showBlockTypePicker( true );
+					} }
+				/>
 			</KeyboardAvoidingView>
 		);
 	}

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -99,8 +99,11 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		this.setState( { ...this.state, selectedBlockType: itemValue, blockTypePickerVisible: false } );
 
 		// find currently focused block. It can be '-1' if no block is currently selected or there are no blocks at all.
-		const focusedItemIndex = this.findDataSourceIndexForFocusedItem();
-		const clientIdFocused = focusedItemIndex > -1 ? this.state.dataSource.get( focusedItemIndex ).clientId : '';
+		let focusedItemIndex = this.findDataSourceIndexForFocusedItem();
+		if ( focusedItemIndex === -1 ) {
+			focusedItemIndex = this.state.dataSource.size() - 1;
+		}
+		const clientIdFocused = this.state.dataSource.get( focusedItemIndex ).clientId;
 
 		// create an empty block of the selected type
 		const newBlock = createBlock( itemValue, { content: 'new test text for a ' + itemValue + ' block' } );

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -140,9 +140,6 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 				this.state.dataSource.splice( dataSourceBlockIndex, 1 );
 				this.props.deleteBlockAction( clientId );
 				break;
-			case InlineToolbarButton.PLUS:
-				this.showBlockTypePicker( true );
-				break;
 			case InlineToolbarButton.SETTINGS:
 				// TODO: implement settings
 				break;

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -42,6 +42,9 @@ type StateType = {
 };
 
 export default class BlockManager extends React.Component<PropsType, StateType> {
+	// a scrolling function for when on Android (when the dataSource is up-to-date to perform the scroll)
+	scrollTo: number => void;
+
 	constructor( props: PropsType ) {
 		super( props );
 		this.state = {
@@ -111,6 +114,10 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 
 		// set it into the datasource, and use the same object instance to send it to props/redux
 		this.state.dataSource.splice( focusedItemIndex + 1, 0, newBlock );
+		if ( this.scrollTo ) {
+			this.scrollTo( focusedItemIndex + 1 );
+		}
+
 		this.props.createBlockAction( newBlock.clientId, newBlock, clientIdFocused );
 
 		// now set the focus
@@ -266,6 +273,9 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		if ( Platform.OS === 'android' ) {
 			list = (
 				<RecyclerViewList
+					ref={ ( component: RecyclerViewList ) =>
+						( this.scrollTo = ( index ) => component.scrollToIndex( { index: index, animated: true } ) )
+					}
 					style={ styles.list }
 					dataSource={ this.state.dataSource }
 					renderItem={ this.renderItem.bind( this ) }

--- a/src/block-management/block-toolbar.js
+++ b/src/block-management/block-toolbar.js
@@ -1,11 +1,28 @@
+/**
+ * @format
+ * @flow
+ */
+
 import React, { Component } from 'react';
 import { View } from 'react-native';
+import { IconButton } from '@wordpress/components';
 import { BlockFormatControls, BlockControls } from '@wordpress/editor';
+import { __ } from '@wordpress/i18n';
 
-export default class BlockToolbar extends Component {
+type PropsType = {
+	onInsertClick: void => void,
+};
+
+export default class BlockToolbar extends Component<PropsType> {
 	render() {
 		return (
 			<View style={ { height: 50, backgroundColor: '#DCDCDC', flexDirection: 'row' } }>
+				<IconButton
+					className="block-list-appender__toggle"
+					label={ __( 'Add block' ) }
+					icon="insert"
+					onClick={ this.props.onInsertClick }
+				/>
 				<BlockControls.Slot />
 				<BlockFormatControls.Slot />
 			</View>

--- a/src/block-management/block-toolbar.js
+++ b/src/block-management/block-toolbar.js
@@ -18,7 +18,6 @@ export default class BlockToolbar extends Component<PropsType> {
 		return (
 			<View style={ { height: 50, backgroundColor: '#DCDCDC', flexDirection: 'row' } }>
 				<IconButton
-					className="block-list-appender__toggle"
 					label={ __( 'Add block' ) }
 					icon="insert"
 					onClick={ this.props.onInsertClick }

--- a/src/block-management/constants.js
+++ b/src/block-management/constants.js
@@ -4,7 +4,6 @@
  */
 
 const InlineToolbarButton = {
-	UP: 1,
 	DOWN: 2,
 	SETTINGS: 3,
 	DELETE: 4,

--- a/src/block-management/constants.js
+++ b/src/block-management/constants.js
@@ -4,10 +4,10 @@
  */
 
 const InlineToolbarButton = {
+	UP: 1,
 	DOWN: 2,
 	SETTINGS: 3,
 	DELETE: 4,
-	PLUS: 5,
 };
 
 export { InlineToolbarButton };

--- a/src/block-management/inline-toolbar.js
+++ b/src/block-management/inline-toolbar.js
@@ -17,18 +17,6 @@ export default class InlineToolbar extends React.Component<PropsType> {
 		return (
 			<View style={ styles.inlineToolbar }>
 				<TouchableOpacity
-					onPress={ this.props.onButtonPressed.bind(
-						this,
-						InlineToolbarButton.PLUS,
-						this.props.clientId
-					) }
-				>
-					<View style={ styles.inlineToolbarButton }>
-						<Text>+</Text>
-					</View>
-				</TouchableOpacity>
-				<View style={ styles.buttonSeparator } />
-				<TouchableOpacity
 					onPress={ this.props.onButtonPressed.bind( this, InlineToolbarButton.UP, this.props.clientId ) }
 				>
 					<View style={ styles.inlineToolbarButton }>


### PR DESCRIPTION
Addresses part of #58 

Adds a bottom toolbar button to trigger the Inserter. This is the minimum needed in order to be able to add a block when no block is selected or there are no blocks at all (e.g. when a new post, which is part of #182)

Changes in this PR:
1. Allow for empty string as initial data from the parent app
2. Inserter button in the bottom toolbar
3. Removal of inserter button from the inline toolbar

Scope not handled by this PR:
* Styling of the Inserter button to match https://github.com/wordpress-mobile/gutenberg-mobile/issues/58

![screenshot-1542108851184](https://user-images.githubusercontent.com/1032913/48410974-de6ac180-e748-11e8-8d89-3331e1036113.jpg)

To test 1:
* Run the app. No blocks are focused yet.
* Tap on the bottom toolbar Inserter button
* Select a block from the Inserter bottom sheet
* Scroll at the beginning of the content and notice the new block is there

To test 1:
* Run the app. No blocks are focused yet.
* Tap on the Image block to focus it
* Tap on the bottom toolbar Inserter button
* Select a block from the Inserter bottom sheet
* Notice the new block is inserted right after the Image block

