### PR TITLE
Fix Android back button not dismissing the inserter's block-type picker

### DIFF
--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -39,6 +39,7 @@ export default class BlockPicker extends Component<PropsType, StateType> {
 				transparent={ true }
 				isVisible={ this.props.visible }
 				onSwipe={ this.props.onDismiss.bind( this ) }
+				onBackButtonPress={ this.props.onDismiss.bind( this ) }
 				swipeDirection="down"
 				style={ [ styles.bottomModal, this.props.style ] }
 				backdropColor={ 'lightgrey' }


### PR DESCRIPTION
This PR adds the behavior to dismiss the block-type picker modal when the user taps `back` on Android without needing to touch outside the modal or swipe it down.

First reported by @daniloercoli .

To test:
1. open the demo app on Android
2. tap on the `+` inserter button
3. tap `back` 
4. observe the modal is dismissed.
