### PR TITLE
DO NOT MERGE - Implemented keyboard hide button

### DIFF
--- a/src/block-management/block-toolbar.js
+++ b/src/block-management/block-toolbar.js
@@ -13,6 +13,8 @@ import styles from './block-toolbar.scss';
 
 type PropsType = {
 	onInsertClick: void => void,
+	onKeyboardHide: void => void,
+	showKeyboardHideButton: boolean,
 };
 
 export default class BlockToolbar extends Component<PropsType> {
@@ -26,6 +28,13 @@ export default class BlockToolbar extends Component<PropsType> {
 						onClick={ this.props.onInsertClick }
 					/>
 				</Toolbar>
+				{this.props.showKeyboardHideButton && (<Toolbar>
+					<ToolbarButton
+						label={ __( 'Keyboard hide' ) }
+						icon="arrow-down"
+						onClick={ this.props.onKeyboardHide }
+					/>
+				</Toolbar>)}
 				<BlockControls.Slot />
 				<BlockFormatControls.Slot />
 			</View>


### PR DESCRIPTION
Added keyboard hide button in Toolbar. 

**Note**: Currently we can't dismiss keyboard as we are missing some logic on the Aztec level which will expose `focus()` and `blur()` methods. That should be done in [separate ticket ](https://github.com/wordpress-mobile/gutenberg-mobile/issues/240)and probably @mzorz can look at it.



![keyboard_hide_button](https://user-images.githubusercontent.com/28219092/48569525-46183c80-e902-11e8-965f-1e8f196d05c5.png)
