### PR TITLE
Reestablish possibility to pass initial data from a parent app

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -23,12 +23,12 @@ type PropsType = {
 };
 
 const AppProvider = ( { initialData }: PropsType ) => {
-	if (initialData === undefined) {
+	if ( initialData === undefined ) {
 		initialData = initialHtml;
 	}
 	return (
 		<AppContainer initialHtml={ initialData } />
 	);
-}
+};
 
 export default AppProvider;

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -18,8 +18,17 @@ registerCoreBlocks();
 registerBlockType( UnsupportedBlock.name, UnsupportedBlock.settings );
 setUnregisteredTypeHandlerName( UnsupportedBlock.name );
 
-const AppProvider = () => (
-	<AppContainer initialHtml={ initialHtml } />
-);
+type PropsType = {
+	initialData: string,
+};
+
+const AppProvider = ( { initialData }: PropsType ) => {
+	if (initialData === undefined) {
+		initialData = initialHtml;
+	}
+	return (
+		<AppContainer initialHtml={ initialData } />
+	);
+}
 
 export default AppProvider;


### PR DESCRIPTION
This PR reestablish possibility to pass initial data from a parent app.

As a bonus, on iOS it's now possible to send an empty string as initial data and we will get an empty post instead of the example post. (Not tested on Android)

**To test:**
- Check that the example app displays as always.

**On WPiOS:**
- Checkout https://github.com/wordpress-mobile/WordPress-iOS/pull/10467
- Check that posts from the post list open the proper post data.
- Check that a new post opens an empty post.