### PR TITLE
Recover insert block at the end, if no block is selected.

### DIFF
--- a/src/app/AppContainer.js
+++ b/src/app/AppContainer.js
@@ -58,7 +58,9 @@ class AppContainer extends React.Component<PropsType> {
 	};
 
 	createBlockAction = ( clientId, block ) => {
-		this.props.onInsertBlock( block, this.props.selectedBlockIndex + 1, this.props.rootClientId );
+		const indexAfterSelected = this.props.selectedBlockIndex + 1;
+		const insertionIndex = indexAfterSelected || this.props.blocks.length;
+		this.props.onInsertBlock( block, insertionIndex, this.props.rootClientId );
 	};
 
 	parseBlocksAction = ( html = '' ) => {


### PR DESCRIPTION
This PR recovers the functionality that insert a new block at the end, if no block is selected.

![create_bottom_demo](https://user-images.githubusercontent.com/9772967/48580203-537ef800-e8fd-11e8-98b7-c2302928c2db.gif)

To test:
- Remove all blocks from the post.
- Add a new block.
- [x] Check that it's created without problems.
- Switch between HTML and Visual mode to deselect the previously created block.
- Create a new block. 
- [x] Check that it's inserted at the end.
- Select the block at the top.
- Create a new block.
- [x] Check that it's inserted after the first block
