### PR TITLE
Make gutenberg-mobile universal so it works on iPad

### DIFF
--- a/ios/gutenberg.xcodeproj/project.pbxproj
+++ b/ios/gutenberg.xcodeproj/project.pbxproj
@@ -1395,6 +1395,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "gutenberg-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -1423,6 +1424,7 @@
 				PRODUCT_NAME = gutenberg;
 				SWIFT_OBJC_BRIDGING_HEADER = "gutenberg-Bridging-Header.h";
 				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;


### PR DESCRIPTION
I just went to the Xcode project and changed the target from iPhone to Universal

![gm-ipad](https://user-images.githubusercontent.com/8739/48606515-10b23400-e980-11e8-86da-a220d6a7b682.png)
