### PR TITLE
Fix Picker touch handling, avoiding to have to touch twice if unfocused

### DIFF
--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -52,7 +52,7 @@ export default class BlockPicker extends Component<PropsType, StateType> {
 					</View>
 					<View style={ styles.lineStyle } />
 					<FlatList
-						keyboardShouldPersistTaps='always'
+						keyboardShouldPersistTaps="always"
 						numColumns={ 3 }
 						data={ this.availableBlockTypes }
 						keyExtractor={ ( item ) => item.name }

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -52,6 +52,7 @@ export default class BlockPicker extends Component<PropsType, StateType> {
 					</View>
 					<View style={ styles.lineStyle } />
 					<FlatList
+						keyboardShouldPersistTaps='always'
 						numColumns={ 3 }
 						data={ this.availableBlockTypes }
 						keyExtractor={ ( item ) => item.name }


### PR DESCRIPTION
This fixes an issue with the inserter's Block-Type picker that would not respond to touch at first touch when the focus was taken by a PlainText-backed block such as `Code` or `More` (implemented with InputText in React Native).

Before:
![before](https://user-images.githubusercontent.com/6597771/48630468-1f5a1480-e99b-11e8-96a8-e86a1cd336b5.gif)
(it's difficult to see, but believe me I had to tap twice :D - you'll be able to reproduce following the steps below).

After:
![after](https://user-images.githubusercontent.com/6597771/48630477-23863200-e99b-11e8-8363-e00a938a13a5.gif)



**To test:**
1. open the demo app
2. tap into a `Read More`  or `Code` block
3. observe the cursor appears and keyboard goes up
4. now tap on the inserter icon `+` 
5. see the block type picker appear
6. tap on any icon
7. observe it responds to touch at first touch.

