### PR TITLE
Use FlatList instead of our custom recycler view list on Android

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -268,7 +268,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		const behavior = Platform.OS === 'ios' ? 'padding' : null;
 		// TODO: we won't need this. This just a temporary solution until we implement the RecyclerViewList native code for iOS
 		// And fix problems with RecyclerViewList on Android
-		let list = (
+		const list = (
 			<FlatList
 				style={ styles.list }
 				data={ this.state.blocks }

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -7,7 +7,7 @@ import React from 'react';
 import { xorBy, isEqual } from 'lodash';
 
 import { Platform, Switch, Text, View, FlatList, KeyboardAvoidingView } from 'react-native';
-import RecyclerViewList, { DataSource } from 'react-native-recyclerview-list';
+import { DataSource } from 'react-native-recyclerview-list';
 import BlockHolder from './block-holder';
 import { InlineToolbarButton } from './constants';
 import type { BlockType } from '../store/types';
@@ -265,36 +265,18 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 	}
 
 	renderList() {
-		let list;
 		const behavior = Platform.OS === 'ios' ? 'padding' : null;
-		if ( Platform.OS === 'android' ) {
-			list = (
-				<RecyclerViewList
-					ref={ ( component: RecyclerViewList ) =>
-						( this.scrollTo = ( index ) => component.scrollToIndex( { index: index, animated: true } ) )
-					}
-					style={ styles.list }
-					dataSource={ this.state.dataSource }
-					renderItem={ this.renderItem.bind( this ) }
-					ListEmptyComponent={
-						<View style={ { borderColor: '#e7e7e7', borderWidth: 10, margin: 10, padding: 20 } }>
-							<Text style={ { fontSize: 15 } }>No blocks :(</Text>
-						</View>
-					}
-				/>
-			);
-		} else {
-			// TODO: we won't need this. This just a temporary solution until we implement the RecyclerViewList native code for iOS
-			list = (
-				<FlatList
-					style={ styles.list }
-					data={ this.state.blocks }
-					extraData={ { refresh: this.state.refresh, inspectBlocks: this.state.inspectBlocks } }
-					keyExtractor={ ( item ) => item.clientId }
-					renderItem={ this.renderItem.bind( this ) }
-				/>
-			);
-		}
+		// TODO: we won't need this. This just a temporary solution until we implement the RecyclerViewList native code for iOS
+		// And fix problems with RecyclerViewList on Android
+		let list = (
+			<FlatList
+				style={ styles.list }
+				data={ this.state.blocks }
+				extraData={ { refresh: this.state.refresh, inspectBlocks: this.state.inspectBlocks } }
+				keyExtractor={ ( item ) => item.clientId }
+				renderItem={ this.renderItem.bind( this ) }
+			/>
+		);
 		return (
 			<KeyboardAvoidingView style={ { flex: 1 } } behavior={ behavior }>
 				{ list }

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -4,10 +4,9 @@
  */
 
 import React from 'react';
-import { xorBy, isEqual } from 'lodash';
+import { isEqual } from 'lodash';
 
 import { Platform, Switch, Text, View, FlatList, KeyboardAvoidingView } from 'react-native';
-import { DataSource } from 'react-native-recyclerview-list';
 import BlockHolder from './block-holder';
 import { InlineToolbarButton } from './constants';
 import type { BlockType } from '../store/types';
@@ -21,7 +20,7 @@ import { createBlock } from '@wordpress/blocks';
 
 export type BlockListType = {
 	onChange: ( clientId: string, attributes: mixed ) => void,
-	focusBlockAction: string => mixed,
+	focusBlockAction: string => void,
 	moveBlockUpAction: string => mixed,
 	moveBlockDownAction: string => mixed,
 	deleteBlockAction: string => mixed,
@@ -35,7 +34,6 @@ export type BlockListType = {
 
 type PropsType = BlockListType;
 type StateType = {
-	dataSource: DataSource,
 	showHtml: boolean,
 	inspectBlocks: boolean,
 	blockTypePickerVisible: boolean,
@@ -45,9 +43,6 @@ type StateType = {
 };
 
 export default class BlockManager extends React.Component<PropsType, StateType> {
-	// a scrolling function for when on Android (when the dataSource is up-to-date to perform the scroll)
-	scrollTo: number => void;
-
 	constructor( props: PropsType ) {
 		super( props );
 
@@ -59,48 +54,12 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 
 		this.state = {
 			blocks: blocks,
-			dataSource: new DataSource( blocks, ( item: BlockType ) => item.clientId ),
 			showHtml: false,
 			inspectBlocks: false,
 			blockTypePickerVisible: false,
 			selectedBlockType: 'core/paragraph', // just any valid type to start from
 			refresh: false,
 		};
-	}
-
-	onBlockHolderPressed( clientId: string ) {
-		this.props.focusBlockAction( clientId );
-	}
-
-	static focusDataSourceItem( dataSource: DataSource, clientId: string ) {
-		for ( let i = 0; i < dataSource.size(); ++i ) {
-			const block = dataSource.get( i );
-			if ( block.clientId === clientId ) {
-				block.focused = true;
-			} else {
-				block.focused = false;
-			}
-		}
-	}
-
-	getDataSourceIndexFromClientId( clientId: string ) {
-		for ( let i = 0; i < this.state.dataSource.size(); ++i ) {
-			const block = this.state.dataSource.get( i );
-			if ( block.clientId === clientId ) {
-				return i;
-			}
-		}
-		return -1;
-	}
-
-	findDataSourceIndexForFocusedItem() {
-		for ( let i = 0; i < this.state.dataSource.size(); ++i ) {
-			const block = this.state.dataSource.get( i );
-			if ( block.focused === true ) {
-				return i;
-			}
-		}
-		return -1;
 	}
 
 	// TODO: in the near future this will likely be changed to onShowBlockTypePicker and bound to this.props
@@ -112,21 +71,8 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 	onBlockTypeSelected( itemValue: string ) {
 		this.setState( { ...this.state, selectedBlockType: itemValue, blockTypePickerVisible: false } );
 
-		// find currently focused block. It can be '-1' if no block is currently selected or there are no blocks at all.
-		let focusedItemIndex = this.findDataSourceIndexForFocusedItem();
-		if ( focusedItemIndex === -1 ) {
-			focusedItemIndex = this.state.dataSource.size() - 1;
-		}
-
 		// create an empty block of the selected type
 		const newBlock = createBlock( itemValue, { content: 'new test text for a ' + itemValue + ' block' } );
-
-		// set it into the datasource, and use the same object instance to send it to props/redux
-		this.state.dataSource.splice( focusedItemIndex + 1, 0, newBlock );
-
-		if ( this.scrollTo ) {
-			this.scrollTo( focusedItemIndex + 1 );
-		}
 
 		this.props.createBlockAction( newBlock.clientId, newBlock );
 
@@ -141,22 +87,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 			return newBlock;
 		} );
 
-		// if the blocks in the list (not the order or the block attribute)
-		// have changed without our knowledge, recreate the dataSource
-		if ( xorBy( state.blocks, blocks, 'clientId' ).length !== 0 ) {
-			return {
-				dataSource: new DataSource( blocks, ( item: BlockType ) => item.clientId ),
-				blocks,
-				refresh: ! state.refresh,
-			};
-		}
-
-		// if some properties of the blocks have changed, assume it's `focused` and manually update in dataSource
 		if ( ! isEqual( state.blocks, blocks ) ) {
-			const blockFocused = blocks.find( ( block ) => block.focused );
-			if ( blockFocused ) {
-				BlockManager.focusDataSourceItem( state.dataSource, blockFocused.clientId );
-			}
 			return {
 				...state,
 				blocks,
@@ -168,43 +99,30 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		return null;
 	}
 
-	onInlineToolbarButtonPressed( button: number, clientId: string ) {
-		const dataSourceBlockIndex = this.getDataSourceIndexFromClientId( clientId );
+	onInlineToolbarButtonPressed = ( button: number, clientId: string ) => {
 		switch ( button ) {
 			case InlineToolbarButton.UP:
-				this.state.dataSource.moveUp( dataSourceBlockIndex );
 				this.props.moveBlockUpAction( clientId );
 				break;
 			case InlineToolbarButton.DOWN:
-				this.state.dataSource.moveDown( dataSourceBlockIndex );
 				this.props.moveBlockDownAction( clientId );
 				break;
 			case InlineToolbarButton.DELETE:
-				this.state.dataSource.splice( dataSourceBlockIndex, 1 );
 				this.props.deleteBlockAction( clientId );
 				break;
 			case InlineToolbarButton.SETTINGS:
 				// TODO: implement settings
 				break;
 		}
-	}
-
-	componentDidUpdate() {
-		// List has been updated, tell the recycler view to update the view
-		this.state.dataSource.setDirty();
-	}
+	};
 
 	insertBlocksAfter( clientId: string, blocks: Array<Object> ) {
-		// find currently focused block
-		const focusedItemIndex = this.getDataSourceIndexFromClientId( clientId );
 		//TODO: make sure to insert all the passed blocks
 		const newBlock = blocks[ 0 ];
 		if ( ! newBlock ) {
 			return;
 		}
 
-		// set it into the datasource, and use the same object instance to send it to props/redux
-		this.state.dataSource.splice( focusedItemIndex + 1, 0, newBlock );
 		this.props.createBlockAction( newBlock.clientId, newBlock );
 
 		// now set the focus
@@ -239,28 +157,9 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		}
 	};
 
-	onChange( clientId: string, attributes: mixed ) {
-		// Update Redux store
-		this.props.onChange( clientId, attributes );
-
-		// Change the data source
-		const index = this.getDataSourceIndexFromClientId( clientId );
-		if ( index === -1 ) {
-			// do nothing if it's not found.
-			// Updates calls from the native side may arrive late, and the block already been deleted/merged
-			return;
-		}
-		const dataSource = this.state.dataSource;
-		const block = dataSource.get( index );
-		block.attributes = attributes;
-		dataSource.set( index, block );
-	}
-
 	onReplace( clientId: string, blocks: Array<Object> ) {
 		// Insert the optional blocks and then remove the block indentified by clientId
 		this.insertBlocksAfter( clientId, blocks );
-		const dataSourceBlockIndex = this.getDataSourceIndexFromClientId( clientId );
-		this.state.dataSource.splice( dataSourceBlockIndex, 1 );
 		this.props.deleteBlockAction( clientId );
 	}
 
@@ -329,11 +228,11 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 
 	handleSwitchEditor = ( showHtml: boolean ) => {
 		this.setState( { showHtml } );
-	}
+	};
 
 	handleInspectBlocksChanged = ( inspectBlocks: boolean ) => {
 		this.setState( { inspectBlocks } );
-	}
+	};
 
 	renderItem( value: { item: BlockType } ) {
 		const insertHere = (
@@ -348,19 +247,15 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 			<View>
 				<BlockHolder
 					key={ value.item.clientId }
-					onInlineToolbarButtonPressed={ this.onInlineToolbarButtonPressed.bind( this ) }
-					onBlockHolderPressed={ this.onBlockHolderPressed.bind( this ) }
-					onChange={ this.onChange.bind( this ) }
+					onInlineToolbarButtonPressed={ this.onInlineToolbarButtonPressed }
+					onBlockHolderPressed={ this.props.focusBlockAction }
+					onChange={ this.props.onChange }
 					showTitle={ this.state.inspectBlocks }
 					focused={ value.item.focused }
 					clientId={ value.item.clientId }
-					insertBlocksAfter={ ( blocks ) =>
-						this.insertBlocksAfter.bind( this )( value.item.clientId, blocks )
-					}
+					insertBlocksAfter={ ( blocks ) => this.insertBlocksAfter( value.item.clientId, blocks ) }
 					mergeBlocks={ this.mergeBlocks }
-					onReplace={ ( blocks ) =>
-						this.onReplace( value.item.clientId, blocks )
-					}
+					onReplace={ ( blocks ) => this.onReplace( value.item.clientId, blocks ) }
 					{ ...value.item }
 				/>
 				{ this.state.blockTypePickerVisible && value.item.focused && insertHere }


### PR DESCRIPTION
This PR switches the main blocks list to ReactNative `FlatList` component on Android.

- The switch back to FlatList was required since there are issues selecting text in any of the blocks in the list. The issue is not limited to AztecWrapper powered blocks, such as Para and Heading, but it's affecting the code block that is backed by `TextInput`.
- There are also problems with the contextual menu that does appear on the screen. There is no wat to paste or copy text at the moment.

I've spent some time trying to fix the issue in our recycler view list repo, with no luck.

It's not clear to me why we've selected this custom list component (beside animations), since ` FlatList renders items lazily, just when they are about to appear, and removes items that scroll way off screen to save memory and processing time.`

If we all agree on removing the Recycler list only temporary, hoping to find the time to fix the issue later,  I can open a new ticket to remind us to remove all the `Datasource` refs required by this component, if the fix on the list doesn't' happen in say 2 weeks, or a month.
Otherwise I can remove all refs in this PR.