### PR TITLE
Fix simple-html-tokenizer changes in `@wordpress/blocks` breaking our tests

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -39,6 +39,9 @@
 <PROJECT_ROOT>/node_modules/fbjs/.*
 <PROJECT_ROOT>/node_modules/graphql/.*
 <PROJECT_ROOT>/node_modules/prettier/.*
+<PROJECT_ROOT>/node_modules/enzyme-matchers/.*
+<PROJECT_ROOT>/node_modules/jest-enzyme/.*
+<PROJECT_ROOT>/node_modules/jsx-to-string/.*
 
 ; Ignore react-native-recyclerview-list example app
 <PROJECT_ROOT>/node_modules/react-native-recyclerview-list/example

--- a/.flowconfig
+++ b/.flowconfig
@@ -39,9 +39,6 @@
 <PROJECT_ROOT>/node_modules/fbjs/.*
 <PROJECT_ROOT>/node_modules/graphql/.*
 <PROJECT_ROOT>/node_modules/prettier/.*
-<PROJECT_ROOT>/node_modules/enzyme-matchers/.*
-<PROJECT_ROOT>/node_modules/jest-enzyme/.*
-<PROJECT_ROOT>/node_modules/jsx-to-string/.*
 
 ; Ignore react-native-recyclerview-list example app
 <PROJECT_ROOT>/node_modules/react-native-recyclerview-list/example

--- a/jest.config.js
+++ b/jest.config.js
@@ -42,7 +42,7 @@ module.exports = {
 			'react-native-svg',
 		],
 	},
-	"transformIgnorePatterns": [
-		"<rootDir>/node_modules/simple-html-tokenizer/",
-	]
+	transformIgnorePatterns: [
+		'<rootDir>/node_modules/simple-html-tokenizer/',
+	],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -43,8 +43,10 @@ module.exports = {
 		],
 	},
 	transformIgnorePatterns: [
-		// this is required for now to have jest transform some of our modules
+		// This is required for now to have jest transform some of our modules
 		// See: https://github.com/wordpress-mobile/gutenberg-mobile/pull/257#discussion_r234978268
-		'node_modules/(?!(simple-html-tokenizer|react-native|react-native-svg|react-native-recyclerview-list|react-native-modal|react-native-animatable)/)',
+		// There is no overloading in jest so we need to rewrite the config from react-native-jest-preset:
+		// https://github.com/facebook/react-native/blob/master/jest-preset.json#L20
+		'node_modules/(?!(simple-html-tokenizer|(jest-)?react-native|react-clone-referenced-element))',
 	],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -43,6 +43,8 @@ module.exports = {
 		],
 	},
 	transformIgnorePatterns: [
+		// this is required for now to have jest transform some of our modules
+		// See: https://github.com/wordpress-mobile/gutenberg-mobile/pull/257#discussion_r234978268
 		'node_modules/(?!(simple-html-tokenizer|react-native|react-native-svg|react-native-recyclerview-list|react-native-modal|react-native-animatable)/)',
 	],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -42,4 +42,7 @@ module.exports = {
 			'react-native-svg',
 		],
 	},
+	"transformIgnorePatterns": [
+		"<rootDir>/node_modules/simple-html-tokenizer/",
+	]
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -43,6 +43,6 @@ module.exports = {
 		],
 	},
 	transformIgnorePatterns: [
-		'<rootDir>/node_modules/simple-html-tokenizer/',
+		'node_modules/(?!(simple-html-tokenizer|react-native|react-native-svg|react-native-recyclerview-list|react-native-modal|react-native-animatable)/)',
 	],
 };

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "refx": "^3.0.0",
     "rememo": "^3.0.0",
     "shallowequal": "^1.0.2",
-    "simple-html-tokenizer": "^0.5.1",
+    "simple-html-tokenizer": "^0.4.1",
     "tannin": "^1.0.1",
     "tinycolor2": "^1.4.1",
     "turbo-combine-reducers": "^1.0.2"

--- a/symlinked-packages-in-parent/@wordpress/html-entities
+++ b/symlinked-packages-in-parent/@wordpress/html-entities
@@ -1,0 +1,1 @@
+../../../packages/html-entities/src/

--- a/symlinked-packages/@wordpress/html-entities
+++ b/symlinked-packages/@wordpress/html-entities
@@ -1,0 +1,1 @@
+../../gutenberg/packages/html-entities/src/

--- a/yarn.lock
+++ b/yarn.lock
@@ -8542,10 +8542,10 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
-simple-html-tokenizer@^0.5.1:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.7.tgz#8eca336ecfbe2b3c6166cbb31b2682088de79f40"
-  integrity sha512-APW9iYbkJ5cijjX4Ljhf3VG8SwYPUJT5gZrwci/wieMabQxWFiV5VwsrP5c6GMRvXKEQMGkAB1d9dvW66dTqpg==
+simple-html-tokenizer@^0.4.1:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.4.3.tgz#9b00b766e30058b4bb377c0d4f97566a13ab1be1"
+  integrity sha512-OpUzgR+P/Qsu6ztZehr4PxvTbV4sDW91hAqc2tnz4fjuFTqErWIUdUMbnzX+19F4IEpSSfa0vCAz5xJSs0LpPw==
 
 simple-plist@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
This PR attempts to fix the `simple-html-tokenizer` changes in `@wordpress/blocks` that are making our test fail when upgrading `gutenberg` to `master`:
```
    /home/travis/build/wordpress-mobile/gutenberg-mobile/node_modules/simple-html-tokenizer/dist/es6/tokenizer.js:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){import EventedTokenizer from './evented-tokenizer';
                                                                                             ^^^^^^
    
    SyntaxError: Unexpected token import
      29 |  */
      30 | const REGEXP_WHITESPACE = /[\t\n\r\v\f ]+/g;
    > 31 | 
      32 | /**
      33 |  * Matches a string containing only whitespace
      34 |  *
      
      at ScriptTransformer._transformAndBuildScript (node_modules/jest-runtime/build/script_transformer.js:316:17)
      at Object.<anonymous> (gutenberg/packages/blocks/src/api/validation.js:31:41)
      at Object.<anonymous> (gutenberg/packages/blocks/src/api/parser.js:38:19)
```
For that it downgrades `simple-html-tokenizer` to the same version used in `@wordpress/blocks` and adda a `transformIgnorePatterns` to our `jest.config.js` in order to have jest transform only a specific set of modules. 
It seems fragile but it fixes our problems for now. I suggest we come back to it later.

It also fixes the following error that arrises after the update:
```
  ● Test suite failed to run

    Cannot find module '@wordpress/html-entities' from 'validation.js'

      33 |  * Matches a string containing only whitespace
      34 |  *
    > 35 |  * @type {RegExp}
      36 |  */
      37 | const REGEXP_ONLY_WHITESPACE = /^[\t\n\r\v\f ]*$/;
      38 |

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:169:17)
      at Object.<anonymous> (gutenberg/packages/blocks/src/api/validation.js:35:21)
```

by adding symlinks to `@wordpress/html-entities` sources so they can be resolved during tests.
