### PR TITLE
Allow node v10 engine in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "scssfiles": "src/*.scss src/**/*.scss"
   },
   "engines": {
-    "node": ">=8.0.0 <9.0.0",
+    "node": ">=8.0.0 <9.0.0 || >=10.0.0",
     "npm": ">=6.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This add v10 and above to the list of allowed node engines to work with this project.

We haven't yet defined a fixed version of node to use, so in the meantime let's be permissive and just exclude the engines we know don't work (v9).

