### PR TITLE
Removing `visible` prop from `BlockPicker`.

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -300,7 +300,6 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		const list = this.renderList();
 		const blockTypePicker = (
 			<BlockPicker
-				visible={ this.state.blockTypePickerVisible }
 				onDismiss={ () => {
 					this.showBlockTypePicker( false );
 				} }
@@ -330,7 +329,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 				</View>
 				{ this.state.showHtml && this.renderHTML() }
 				{ ! this.state.showHtml && list }
-				{ blockTypePicker }
+				{ this.state.blockTypePickerVisible && blockTypePicker }
 			</View>
 		);
 	}

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -11,7 +11,6 @@ import { name as unsupportedBlockName } from '../block-types/unsupported-block';
 import { getBlockTypes } from '@wordpress/blocks';
 
 type PropsType = {
-	visible: boolean,
 	style?: StyleSheet,
 	onValueSelected: ( itemValue: string, itemIndex: number ) => void,
 	onDismiss: () => void,
@@ -37,7 +36,7 @@ export default class BlockPicker extends Component<PropsType, StateType> {
 			<Modal
 				animationType="slide"
 				transparent={ true }
-				isVisible={ this.props.visible }
+				isVisible={ true }
 				onSwipe={ this.props.onDismiss.bind( this ) }
 				onBackButtonPress={ this.props.onDismiss.bind( this ) }
 				swipeDirection="down"


### PR DESCRIPTION
This PR fixes an issue on iOS where the currently focused TextField looses focus when the `BlockPicker` component is dismissed.

Before:
Notice the cursor how it jumps to the previously focused block.
![bug](https://user-images.githubusercontent.com/9772967/48809272-b3610e80-ed02-11e8-9b2e-d4e2eaf02194.gif)

Fixed:
![fixed](https://user-images.githubusercontent.com/9772967/48809306-dab7db80-ed02-11e8-91c0-e62bd854f2c8.gif)

The code changes seems unrelated to TextField focus. It took some digging but the reason is this:

![blur](https://user-images.githubusercontent.com/9772967/48809651-3e8ed400-ed04-11e8-9bc4-f28f178a2529.png)

For some reason, the dismissing of the modal triggers (sequentially) the unfocus of the textfield.

This happens using the `isVisible` functionality of the `Modal` component. So showing and hiding the component like "any other" made the trick.

This is probably a React-Native bug.

@mzorz , since you are working on focus issues, could you take a look at this? :)
Thank you!