### PR TITLE
Store 3rd party podspecs in the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ yarn-error.log*
 *.class
 
 # generated files
-bin/
 gen/
 build/
 build.log

--- a/bin/generate-podspecs.sh
+++ b/bin/generate-podspecs.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# Exit if any command fails
+set -e
+
+# Change to the expected directory.
+cd "$( dirname $0 )"
+cd ..
+
+# Check for cocoapods
+command -v pod > /dev/null || ( echo Cocoapods is required to generate podspecs; exit 1 )
+
+PODSPECS=$(cat <<EOP
+node_modules/react-native/React.podspec
+node_modules/react-native/ReactCommon/yoga/yoga.podspec
+node_modules/react-native/third-party-podspecs/Folly.podspec
+node_modules/react-native/third-party-podspecs/DoubleConversion.podspec
+node_modules/react-native/third-party-podspecs/glog.podspec
+EOP
+)
+
+DEST="react-native-gutenberg-bridge/third-party-podspecs"
+
+for podspec in $PODSPECS
+do
+    pod=`basename $podspec .podspec`
+    echo "Generating podspec for $pod"
+    INSTALL_YOGA_WITHOUT_PATH_OPTION=1 pod ipc spec $podspec > "$DEST/$pod.podspec.json"
+done

--- a/react-native-gutenberg-bridge/third-party-podspecs/DoubleConversion.podspec.json
+++ b/react-native-gutenberg-bridge/third-party-podspecs/DoubleConversion.podspec.json
@@ -1,0 +1,21 @@
+{
+  "name": "DoubleConversion",
+  "version": "1.1.6",
+  "license": {
+    "type": "MIT"
+  },
+  "homepage": "https://github.com/google/double-conversion",
+  "summary": "Efficient binary-decimal and decimal-binary conversion routines for IEEE doubles",
+  "authors": "Google",
+  "prepare_command": "mv src double-conversion",
+  "source": {
+    "git": "https://github.com/google/double-conversion.git",
+    "tag": "v1.1.6"
+  },
+  "module_name": "DoubleConversion",
+  "source_files": "double-conversion/*.{h,cc}",
+  "platforms": {
+    "ios": "9.0",
+    "tvos": "9.2"
+  }
+}

--- a/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
+++ b/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
@@ -1,0 +1,53 @@
+{
+  "name": "Folly",
+  "version": "2016.10.31.00",
+  "license": {
+    "type": "Apache License, Version 2.0"
+  },
+  "homepage": "https://github.com/facebook/folly",
+  "summary": "An open-source C++ library developed and used at Facebook.",
+  "authors": "Facebook",
+  "source": {
+    "git": "https://github.com/facebook/folly.git",
+    "tag": "v2016.10.31.00"
+  },
+  "module_name": "folly",
+  "dependencies": {
+    "boost-for-react-native": [
+
+    ],
+    "DoubleConversion": [
+
+    ],
+    "glog": [
+
+    ]
+  },
+  "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+  "source_files": [
+    "folly/Bits.cpp",
+    "folly/Conv.cpp",
+    "folly/Demangle.cpp",
+    "folly/StringBase.cpp",
+    "folly/Unicode.cpp",
+    "folly/dynamic.cpp",
+    "folly/json.cpp",
+    "folly/portability/BitsFunctexcept.cpp",
+    "folly/detail/MallocImpl.cpp"
+  ],
+  "preserve_paths": [
+    "folly/*.h",
+    "folly/detail/*.h",
+    "folly/portability/*.h"
+  ],
+  "libraries": "stdc++",
+  "pod_target_xcconfig": {
+    "USE_HEADERMAP": "NO",
+    "CLANG_CXX_LANGUAGE_STANDARD": "c++14",
+    "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\""
+  },
+  "platforms": {
+    "ios": "9.0",
+    "tvos": "9.2"
+  }
+}

--- a/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
+++ b/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
@@ -1,0 +1,528 @@
+{
+  "name": "React",
+  "version": "0.57.5",
+  "summary": "A framework for building native apps using React",
+  "description": "React Native apps are built using the React JS\nframework, and render directly to native UIKit\nelements using a fully asynchronous architecture.\nThere is no browser and no HTML. We have picked what\nwe think is the best set of features from these and\nother technologies to build what we hope to become\nthe best product development framework available,\nwith an emphasis on iteration speed, developer\ndelight, continuity of technology, and absolutely\nbeautiful and fast products with no compromises in\nquality or capability.",
+  "homepage": "http://facebook.github.io/react-native/",
+  "license": "MIT",
+  "authors": "Facebook",
+  "source": {
+    "git": "https://github.com/facebook/react-native.git",
+    "tag": "v0.57.5"
+  },
+  "default_subspecs": "Core",
+  "requires_arc": true,
+  "platforms": {
+    "ios": "9.0",
+    "tvos": "9.2"
+  },
+  "pod_target_xcconfig": {
+    "CLANG_CXX_LANGUAGE_STANDARD": "c++14"
+  },
+  "preserve_paths": [
+    "package.json",
+    "LICENSE",
+    "LICENSE-docs"
+  ],
+  "cocoapods_version": ">= 1.2.0",
+  "subspecs": [
+    {
+      "name": "Core",
+      "dependencies": {
+        "yoga": [
+          "0.57.5.React"
+        ]
+      },
+      "source_files": "React/**/*.{c,h,m,mm,S,cpp}",
+      "exclude_files": [
+        "**/__tests__/*",
+        "IntegrationTests/*",
+        "React/DevSupport/*",
+        "React/Inspector/*",
+        "ReactCommon/yoga/*",
+        "React/Cxx*/*",
+        "React/Fabric/**/*"
+      ],
+      "ios": {
+        "exclude_files": "React/**/RCTTV*.*"
+      },
+      "tvos": {
+        "exclude_files": [
+          "React/Modules/RCTClipboard*",
+          "React/Views/RCTDatePicker*",
+          "React/Views/RCTPicker*",
+          "React/Views/RCTRefreshControl*",
+          "React/Views/RCTSlider*",
+          "React/Views/RCTSwitch*",
+          "React/Views/RCTWebView*"
+        ]
+      },
+      "header_dir": "React",
+      "frameworks": "JavaScriptCore",
+      "libraries": "stdc++",
+      "pod_target_xcconfig": {
+        "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\""
+      }
+    },
+    {
+      "name": "CxxBridge",
+      "dependencies": {
+        "Folly": [
+          "2016.10.31.00"
+        ],
+        "React/Core": [
+
+        ],
+        "React/cxxreact": [
+
+        ]
+      },
+      "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+      "private_header_files": "React/Cxx*/*.h",
+      "source_files": "React/Cxx*/*.{h,m,mm}"
+    },
+    {
+      "name": "DevSupport",
+      "dependencies": {
+        "React/Core": [
+
+        ],
+        "React/RCTWebSocket": [
+
+        ]
+      },
+      "source_files": [
+        "React/DevSupport/*",
+        "React/Inspector/*"
+      ]
+    },
+    {
+      "name": "RCTFabric",
+      "dependencies": {
+        "Folly": [
+          "2016.10.31.00"
+        ],
+        "React/Core": [
+
+        ],
+        "React/fabric": [
+
+        ]
+      },
+      "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+      "source_files": "React/Fabric/**/*.{c,h,m,mm,S,cpp}",
+      "exclude_files": "**/tests/*",
+      "header_dir": "React",
+      "frameworks": "JavaScriptCore",
+      "pod_target_xcconfig": {
+        "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\""
+      }
+    },
+    {
+      "name": "tvOS",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "React/**/RCTTV*.{h,m}"
+    },
+    {
+      "name": "jschelpers",
+      "dependencies": {
+        "Folly": [
+          "2016.10.31.00"
+        ],
+        "React/PrivateDatabase": [
+
+        ]
+      },
+      "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+      "source_files": "ReactCommon/jschelpers/*.{cpp,h}",
+      "private_header_files": "ReactCommon/jschelpers/*.h",
+      "pod_target_xcconfig": {
+        "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\""
+      },
+      "frameworks": "JavaScriptCore"
+    },
+    {
+      "name": "jsinspector",
+      "source_files": "ReactCommon/jsinspector/*.{cpp,h}",
+      "private_header_files": "ReactCommon/jsinspector/*.h",
+      "pod_target_xcconfig": {
+        "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\""
+      }
+    },
+    {
+      "name": "PrivateDatabase",
+      "source_files": "ReactCommon/privatedata/*.{cpp,h}",
+      "private_header_files": "ReactCommon/privatedata/*.h",
+      "pod_target_xcconfig": {
+        "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\""
+      }
+    },
+    {
+      "name": "cxxreact",
+      "dependencies": {
+        "React/jschelpers": [
+
+        ],
+        "React/jsinspector": [
+
+        ],
+        "boost-for-react-native": [
+          "1.63.0"
+        ],
+        "Folly": [
+          "2016.10.31.00"
+        ]
+      },
+      "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+      "source_files": "ReactCommon/cxxreact/*.{cpp,h}",
+      "exclude_files": "ReactCommon/cxxreact/SampleCxxModule.*",
+      "private_header_files": "ReactCommon/cxxreact/*.h",
+      "pod_target_xcconfig": {
+        "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/Folly\""
+      }
+    },
+    {
+      "name": "fabric",
+      "subspecs": [
+        {
+          "name": "activityindicator",
+          "dependencies": {
+            "Folly": [
+              "2016.10.31.00"
+            ]
+          },
+          "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+          "source_files": "ReactCommon/fabric/activityindicator/**/*.{cpp,h}",
+          "exclude_files": "**/tests/*",
+          "header_dir": "fabric/activityindicator",
+          "pod_target_xcconfig": {
+            "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\""
+          }
+        },
+        {
+          "name": "attributedstring",
+          "dependencies": {
+            "Folly": [
+              "2016.10.31.00"
+            ]
+          },
+          "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+          "source_files": "ReactCommon/fabric/attributedstring/**/*.{cpp,h}",
+          "exclude_files": "**/tests/*",
+          "header_dir": "fabric/attributedstring",
+          "pod_target_xcconfig": {
+            "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\""
+          }
+        },
+        {
+          "name": "core",
+          "dependencies": {
+            "Folly": [
+              "2016.10.31.00"
+            ]
+          },
+          "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+          "source_files": "ReactCommon/fabric/core/**/*.{cpp,h}",
+          "exclude_files": "**/tests/*",
+          "header_dir": "fabric/core",
+          "pod_target_xcconfig": {
+            "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\""
+          }
+        },
+        {
+          "name": "debug",
+          "dependencies": {
+            "Folly": [
+              "2016.10.31.00"
+            ]
+          },
+          "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+          "source_files": "ReactCommon/fabric/debug/**/*.{cpp,h}",
+          "exclude_files": "**/tests/*",
+          "header_dir": "fabric/debug",
+          "pod_target_xcconfig": {
+            "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\""
+          }
+        },
+        {
+          "name": "graphics",
+          "dependencies": {
+            "Folly": [
+              "2016.10.31.00"
+            ]
+          },
+          "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+          "source_files": "ReactCommon/fabric/graphics/**/*.{cpp,h}",
+          "exclude_files": "**/tests/*",
+          "header_dir": "fabric/graphics",
+          "pod_target_xcconfig": {
+            "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\""
+          }
+        },
+        {
+          "name": "scrollview",
+          "dependencies": {
+            "Folly": [
+              "2016.10.31.00"
+            ]
+          },
+          "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+          "source_files": "ReactCommon/fabric/scrollview/**/*.{cpp,h}",
+          "exclude_files": "**/tests/*",
+          "header_dir": "fabric/scrollview",
+          "pod_target_xcconfig": {
+            "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\""
+          }
+        },
+        {
+          "name": "text",
+          "dependencies": {
+            "Folly": [
+              "2016.10.31.00"
+            ]
+          },
+          "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+          "source_files": "ReactCommon/fabric/text/**/*.{cpp,h}",
+          "exclude_files": "**/tests/*",
+          "header_dir": "fabric/text",
+          "pod_target_xcconfig": {
+            "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\""
+          }
+        },
+        {
+          "name": "textlayoutmanager",
+          "dependencies": {
+            "Folly": [
+              "2016.10.31.00"
+            ]
+          },
+          "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+          "source_files": "ReactCommon/fabric/textlayoutmanager/**/*.{cpp,h,mm}",
+          "exclude_files": "**/tests/*",
+          "header_dir": "fabric/textlayoutmanager",
+          "pod_target_xcconfig": {
+            "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\""
+          }
+        },
+        {
+          "name": "uimanager",
+          "dependencies": {
+            "Folly": [
+              "2016.10.31.00"
+            ]
+          },
+          "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+          "source_files": "ReactCommon/fabric/uimanager/**/*.{cpp,h}",
+          "exclude_files": "**/tests/*",
+          "header_dir": "fabric/uimanager",
+          "pod_target_xcconfig": {
+            "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\""
+          }
+        },
+        {
+          "name": "view",
+          "dependencies": {
+            "Folly": [
+              "2016.10.31.00"
+            ],
+            "yoga": [
+
+            ]
+          },
+          "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+          "source_files": "ReactCommon/fabric/view/**/*.{cpp,h}",
+          "exclude_files": "**/tests/*",
+          "header_dir": "fabric/view",
+          "pod_target_xcconfig": {
+            "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\""
+          }
+        }
+      ]
+    },
+    {
+      "name": "RCTFabricSample",
+      "dependencies": {
+        "Folly": [
+          "2016.10.31.00"
+        ]
+      },
+      "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+      "source_files": "ReactCommon/fabric/sample/**/*.{cpp,h}",
+      "exclude_files": "**/tests/*",
+      "header_dir": "fabric/sample",
+      "pod_target_xcconfig": {
+        "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\""
+      }
+    },
+    {
+      "name": "ART",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "Libraries/ART/**/*.{h,m}"
+    },
+    {
+      "name": "RCTActionSheet",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "Libraries/ActionSheetIOS/*.{h,m}"
+    },
+    {
+      "name": "RCTAnimation",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "Libraries/NativeAnimation/{Drivers/*,Nodes/*,*}.{h,m}",
+      "header_dir": "RCTAnimation"
+    },
+    {
+      "name": "RCTBlob",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "Libraries/Blob/*.{h,m,mm}",
+      "preserve_paths": "Libraries/Blob/*.js"
+    },
+    {
+      "name": "RCTCameraRoll",
+      "dependencies": {
+        "React/Core": [
+
+        ],
+        "React/RCTImage": [
+
+        ]
+      },
+      "source_files": "Libraries/CameraRoll/*.{h,m}"
+    },
+    {
+      "name": "RCTGeolocation",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "Libraries/Geolocation/*.{h,m}"
+    },
+    {
+      "name": "RCTImage",
+      "dependencies": {
+        "React/Core": [
+
+        ],
+        "React/RCTNetwork": [
+
+        ]
+      },
+      "source_files": "Libraries/Image/*.{h,m}"
+    },
+    {
+      "name": "RCTNetwork",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "Libraries/Network/*.{h,m,mm}"
+    },
+    {
+      "name": "RCTPushNotification",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "Libraries/PushNotificationIOS/*.{h,m}"
+    },
+    {
+      "name": "RCTSettings",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "Libraries/Settings/*.{h,m}"
+    },
+    {
+      "name": "RCTText",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "Libraries/Text/**/*.{h,m}"
+    },
+    {
+      "name": "RCTVibration",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "Libraries/Vibration/*.{h,m}"
+    },
+    {
+      "name": "RCTWebSocket",
+      "dependencies": {
+        "React/Core": [
+
+        ],
+        "React/RCTBlob": [
+
+        ],
+        "React/fishhook": [
+
+        ]
+      },
+      "source_files": "Libraries/WebSocket/*.{h,m}"
+    },
+    {
+      "name": "fishhook",
+      "header_dir": "fishhook",
+      "source_files": "Libraries/fishhook/*.{h,c}"
+    },
+    {
+      "name": "RCTLinkingIOS",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "Libraries/LinkingIOS/*.{h,m}"
+    },
+    {
+      "name": "RCTTest",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "Libraries/RCTTest/**/*.{h,m}",
+      "frameworks": "XCTest"
+    },
+    {
+      "name": "_ignore_me_subspec_for_linting_",
+      "dependencies": {
+        "React/Core": [
+
+        ],
+        "React/CxxBridge": [
+
+        ]
+      }
+    }
+  ]
+}

--- a/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json
+++ b/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json
@@ -1,0 +1,42 @@
+{
+  "name": "glog",
+  "version": "0.3.5",
+  "license": {
+    "type": "Google",
+    "file": "COPYING"
+  },
+  "homepage": "https://github.com/google/glog",
+  "summary": "Google logging module",
+  "authors": "Google",
+  "prepare_command": "#!/bin/bash\nset -e\n\nPLATFORM_NAME=\"${PLATFORM_NAME:-iphoneos}\"\nCURRENT_ARCH=\"${CURRENT_ARCH}\"\n\nif [ -z \"$CURRENT_ARCH\" ] || [ \"$CURRENT_ARCH\" == \"undefined_arch\" ]; then\n    # Xcode 10 beta sets CURRENT_ARCH to \"undefined_arch\", this leads to incorrect linker arg.\n    # it's better to rely on platform name as fallback because architecture differs between simulator and device\n\n    if [[ \"$PLATFORM_NAME\" == *\"simulator\"* ]]; then\n        CURRENT_ARCH=\"x86_64\"\n    else \n        CURRENT_ARCH=\"armv7\"\n    fi\nfi\n\nexport CC=\"$(xcrun -find -sdk $PLATFORM_NAME cc) -arch $CURRENT_ARCH -isysroot $(xcrun -sdk $PLATFORM_NAME --show-sdk-path)\"\nexport CXX=\"$CC\"\n\n# Remove automake symlink if it exists\nif [ -h \"test-driver\" ]; then\n    rm test-driver\nfi\n\n./configure --host arm-apple-darwin\n\n# Fix build for tvOS\ncat << EOF >> src/config.h\n\n/* Add in so we have Apple Target Conditionals */\n#ifdef __APPLE__\n#include <TargetConditionals.h>\n#include <Availability.h>\n#endif\n\n/* Special configuration for AppleTVOS */\n#if TARGET_OS_TV\n#undef HAVE_SYSCALL_H\n#undef HAVE_SYS_SYSCALL_H\n#undef OS_MACOSX\n#endif\n\n/* Special configuration for ucontext */\n#undef HAVE_UCONTEXT_H\n#undef PC_FROM_UCONTEXT\n#if defined(__x86_64__)\n#define PC_FROM_UCONTEXT uc_mcontext->__ss.__rip\n#elif defined(__i386__)\n#define PC_FROM_UCONTEXT uc_mcontext->__ss.__eip\n#endif\nEOF",
+  "source": {
+    "git": "https://github.com/google/glog.git",
+    "tag": "v0.3.5"
+  },
+  "module_name": "glog",
+  "header_dir": "glog",
+  "source_files": [
+    "src/glog/*.h",
+    "src/demangle.cc",
+    "src/logging.cc",
+    "src/raw_logging.cc",
+    "src/signalhandler.cc",
+    "src/symbolize.cc",
+    "src/utilities.cc",
+    "src/vlog_is_on.cc"
+  ],
+  "preserve_paths": [
+    "src/*.h",
+    "src/base/*.h"
+  ],
+  "exclude_files": "src/windows/**/*",
+  "libraries": "stdc++",
+  "pod_target_xcconfig": {
+    "USE_HEADERMAP": "NO",
+    "HEADER_SEARCH_PATHS": "$(PODS_TARGET_SRCROOT)/src"
+  },
+  "platforms": {
+    "ios": "9.0",
+    "tvos": "9.2"
+  }
+}

--- a/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
+++ b/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
@@ -1,0 +1,32 @@
+{
+  "name": "yoga",
+  "version": "0.57.5.React",
+  "license": {
+    "type": "MIT"
+  },
+  "homepage": "https://facebook.github.io/yoga/",
+  "documentation_url": "https://facebook.github.io/yoga/docs/api/c/",
+  "summary": "Yoga is a cross-platform layout engine which implements Flexbox.",
+  "description": "Yoga is a cross-platform layout engine enabling maximum collaboration within your team by implementing an API many designers are familiar with, and opening it up to developers across different platforms.",
+  "authors": "Facebook",
+  "source": {
+    "git": "https://github.com/facebook/react-native.git",
+    "tag": "v0.57.5"
+  },
+  "module_name": "yoga",
+  "requires_arc": false,
+  "compiler_flags": [
+    "-fno-omit-frame-pointer",
+    "-fexceptions",
+    "-Wall",
+    "-Werror",
+    "-std=c++1y",
+    "-fPIC"
+  ],
+  "platforms": {
+    "ios": "9.0",
+    "tvos": "9.2"
+  },
+  "source_files": "ReactCommon/yoga/yoga/**/*.{cpp,h}",
+  "public_header_files": "ReactCommon/yoga/yoga/{Yoga,YGEnums,YGMacros}.h"
+}


### PR DESCRIPTION
This ensures that the app will always fetch the React Native podspecs matching the React Native version used.

To test, you can check out the other PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/10505