### PR TITLE
Intialize with the raw post html to avoid marking posts as changed when no changes were made

### DIFF
--- a/src/app/AppContainer.js
+++ b/src/app/AppContainer.js
@@ -27,14 +27,14 @@ type PropsType = {
 };
 
 class AppContainer extends React.Component<PropsType> {
-	lastHtmlSent: ?string
+	lastHtml: ?string
 
 	constructor( props: PropsType ) {
 		super( props );
 
 		this.parseBlocksAction( props.initialHtml );
 
-		this.lastHtmlSent = null;
+		this.lastHtml = props.initialHtml;
 	}
 
 	onChange = ( clientId, attributes ) => {
@@ -70,8 +70,8 @@ class AppContainer extends React.Component<PropsType> {
 
 	serializeToNativeAction = () => {
 		const html = serialize( this.props.blocks );
-		RNReactNativeGutenbergBridge.provideToNative_Html( html, this.lastHtmlSent !== html );
-		this.lastHtmlSent = html;
+		RNReactNativeGutenbergBridge.provideToNative_Html( html, this.lastHtml !== html );
+		this.lastHtml = html;
 	};
 
 	mergeBlocksAction = ( blockOneClientId, blockTwoClientId ) => {

--- a/src/app/AppContainer.js
+++ b/src/app/AppContainer.js
@@ -33,8 +33,6 @@ class AppContainer extends React.Component<PropsType> {
 		super( props );
 
 		this.parseBlocksAction( props.initialHtml );
-
-		this.lastHtml = props.initialHtml;
 	}
 
 	onChange = ( clientId, attributes ) => {
@@ -66,6 +64,7 @@ class AppContainer extends React.Component<PropsType> {
 	parseBlocksAction = ( html = '' ) => {
 		const parsed = parse( html );
 		this.props.onResetBlocks( parsed );
+		this.lastHtml = serialize( parsed );
 	};
 
 	serializeToNativeAction = () => {


### PR DESCRIPTION
This is a fix so post aren't marked as dirty when the resulting HTML remain unchanged.

This is a follow up fix for https://github.com/wordpress-mobile/gutenberg-mobile/pull/242


