### PR TITLE
Fix modal animation

### DIFF
--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -34,7 +34,6 @@ export default class BlockPicker extends Component<PropsType, StateType> {
 	render() {
 		return (
 			<Modal
-				animationType="slide"
 				transparent={ true }
 				isVisible={ true }
 				onSwipe={ this.props.onDismiss.bind( this ) }


### PR DESCRIPTION
Letting the modal library use the default animation looks similar to me and
fixes the issue where the translucid background also slides in.