### PR TITLE
Add undo redo

### DIFF
--- a/src/app/AppContainer.js
+++ b/src/app/AppContainer.js
@@ -24,7 +24,7 @@ type PropsType = {
 	onSelect: string => mixed,
 	onAttributesUpdate: ( string, mixed ) => mixed,
 	initialHtml: string,
-	setupEditor: ( mixed, Array<BlockType> ) => mixed,
+	setupEditor: ( mixed, ?mixed ) => mixed,
 };
 
 class AppContainer extends React.Component<PropsType> {

--- a/src/app/AppContainer.js
+++ b/src/app/AppContainer.js
@@ -28,7 +28,7 @@ type PropsType = {
 };
 
 class AppContainer extends React.Component<PropsType> {
-	lastHtml: ?string
+	lastHtml: ?string;
 
 	constructor( props: PropsType ) {
 		super( props );
@@ -40,10 +40,9 @@ class AppContainer extends React.Component<PropsType> {
 			},
 			type: 'draft',
 		};
-		const blocks = parse( props.initialHtml );
 
-		this.props.setupEditor( post, blocks );
-		this.lastHtml = serialize( blocks );
+		this.props.setupEditor( post );
+		this.lastHtml = serialize( parse( props.initialHtml ) );
 	}
 
 	onChange = ( clientId, attributes ) => {

--- a/src/app/AppContainer.js
+++ b/src/app/AppContainer.js
@@ -24,6 +24,7 @@ type PropsType = {
 	onSelect: string => mixed,
 	onAttributesUpdate: ( string, mixed ) => mixed,
 	initialHtml: string,
+	setupEditor: ( mixed, Array<BlockType> ) => mixed,
 };
 
 class AppContainer extends React.Component<PropsType> {
@@ -32,7 +33,17 @@ class AppContainer extends React.Component<PropsType> {
 	constructor( props: PropsType ) {
 		super( props );
 
-		this.parseBlocksAction( props.initialHtml );
+		const post = props.post || {
+			id: 1,
+			content: {
+				raw: props.initialHtml,
+			},
+			type: 'draft',
+		};
+		const blocks = parse( props.initialHtml );
+
+		this.props.setupEditor( post, blocks );
+		this.lastHtml = serialize( blocks );
 	}
 
 	onChange = ( clientId, attributes ) => {
@@ -64,7 +75,6 @@ class AppContainer extends React.Component<PropsType> {
 	parseBlocksAction = ( html = '' ) => {
 		const parsed = parse( html );
 		this.props.onResetBlocks( parsed );
-		this.lastHtml = serialize( parsed );
 	};
 
 	serializeToNativeAction = () => {
@@ -122,6 +132,7 @@ export default compose( [
 			removeBlock,
 			resetBlocks,
 			selectBlock,
+			setupEditor,
 			updateBlockAttributes,
 		} = dispatch( 'core/editor' );
 
@@ -138,6 +149,7 @@ export default compose( [
 				selectBlock( clientId );
 			},
 			onAttributesUpdate: updateBlockAttributes,
+			setupEditor,
 		};
 	} ),
 ] )( AppContainer );

--- a/src/block-management/block-toolbar.js
+++ b/src/block-management/block-toolbar.js
@@ -17,6 +17,10 @@ type PropsType = {
 	onInsertClick: void => void,
 	onKeyboardHide: void => void,
 	showKeyboardHideButton: boolean,
+	hasRedo: boolean,
+	hasUndo: boolean,
+	redo: void => void,
+	undo: void => void,
 };
 
 export class BlockToolbar extends Component<PropsType> {

--- a/src/block-management/block-toolbar.js
+++ b/src/block-management/block-toolbar.js
@@ -5,11 +5,9 @@
 
 import React, { Component } from 'react';
 import { View } from 'react-native';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
 import { Toolbar, ToolbarButton } from '@wordpress/components';
-import {
-	EditorHistoryRedo,
-	EditorHistoryUndo,
-} from '@wordpress/editor';
 import { BlockFormatControls, BlockControls } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 
@@ -21,24 +19,44 @@ type PropsType = {
 	showKeyboardHideButton: boolean,
 };
 
-export default class BlockToolbar extends Component<PropsType> {
+export class BlockToolbar extends Component<PropsType> {
 	render() {
+		const {
+			hasRedo,
+			hasUndo,
+			redo,
+			undo,
+			onInsertClick,
+			onKeyboardHide,
+			showKeyboardHideButton,
+		} = this.props;
+
 		return (
 			<View style={ styles.container }>
 				<Toolbar>
 					<ToolbarButton
 						label={ __( 'Add block' ) }
 						icon="insert"
-						onClick={ this.props.onInsertClick }
+						onClick={ onInsertClick }
+					/>
+					<ToolbarButton
+						label={ __( 'Undo' ) }
+						icon="undo"
+						disabled={ ! hasUndo }
+						onClick={ hasUndo ? undo : undefined }
+					/>
+					<ToolbarButton
+						label={ __( 'Redo' ) }
+						icon="redo"
+						disabled={ ! hasRedo }
+						onClick={ hasRedo ? redo : undefined }
 					/>
 				</Toolbar>
-				<EditorHistoryUndo />
-				<EditorHistoryRedo />
-				{ this.props.showKeyboardHideButton && ( <Toolbar>
+				{ showKeyboardHideButton && ( <Toolbar>
 					<ToolbarButton
 						label={ __( 'Keyboard hide' ) }
 						icon="arrow-down"
-						onClick={ this.props.onKeyboardHide }
+						onClick={ onKeyboardHide }
 					/>
 				</Toolbar> ) }
 				<BlockControls.Slot />
@@ -47,3 +65,14 @@ export default class BlockToolbar extends Component<PropsType> {
 		);
 	}
 }
+
+export default compose( [
+	withSelect( ( select ) => ( {
+		hasRedo: select( 'core/editor' ).hasEditorRedo(),
+		hasUndo: select( 'core/editor' ).hasEditorUndo(),
+	} ) ),
+	withDispatch( ( dispatch ) => ( {
+		redo: dispatch( 'core/editor' ).redo,
+		undo: dispatch( 'core/editor' ).undo,
+	} ) ),
+] )( BlockToolbar );

--- a/src/block-management/block-toolbar.js
+++ b/src/block-management/block-toolbar.js
@@ -42,13 +42,13 @@ export class BlockToolbar extends Component<PropsType> {
 					<ToolbarButton
 						label={ __( 'Undo' ) }
 						icon="undo"
-						disabled={ ! hasUndo }
+						isDisabled={ ! hasUndo }
 						onClick={ undo }
 					/>
 					<ToolbarButton
 						label={ __( 'Redo' ) }
 						icon="redo"
-						disabled={ ! hasRedo }
+						isDisabled={ ! hasRedo }
 						onClick={ redo }
 					/>
 				</Toolbar>

--- a/src/block-management/block-toolbar.js
+++ b/src/block-management/block-toolbar.js
@@ -6,6 +6,10 @@
 import React, { Component } from 'react';
 import { View } from 'react-native';
 import { Toolbar, ToolbarButton } from '@wordpress/components';
+import {
+	EditorHistoryRedo,
+	EditorHistoryUndo,
+} from '@wordpress/editor';
 import { BlockFormatControls, BlockControls } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 
@@ -28,6 +32,8 @@ export default class BlockToolbar extends Component<PropsType> {
 						onClick={ this.props.onInsertClick }
 					/>
 				</Toolbar>
+				<EditorHistoryUndo />
+				<EditorHistoryRedo />
 				{ this.props.showKeyboardHideButton && ( <Toolbar>
 					<ToolbarButton
 						label={ __( 'Keyboard hide' ) }

--- a/src/block-management/block-toolbar.js
+++ b/src/block-management/block-toolbar.js
@@ -43,13 +43,13 @@ export class BlockToolbar extends Component<PropsType> {
 						label={ __( 'Undo' ) }
 						icon="undo"
 						disabled={ ! hasUndo }
-						onClick={ hasUndo ? undo : undefined }
+						onClick={ undo }
 					/>
 					<ToolbarButton
 						label={ __( 'Redo' ) }
 						icon="redo"
 						disabled={ ! hasRedo }
-						onClick={ hasRedo ? redo : undefined }
+						onClick={ redo }
 					/>
 				</Toolbar>
 				{ showKeyboardHideButton && ( <Toolbar>


### PR DESCRIPTION
Addresses https://github.com/wordpress-mobile/gutenberg-mobile/issues/171
Requires Gutenberg changes https://github.com/WordPress/gutenberg/pull/12231

This PR adds the undo and redo feature to the block toolbar, right next to the add block button:

![simulator screen shot - iphone x - 2018-11-22 at 16 45 05](https://user-images.githubusercontent.com/230230/48912565-479fb280-ee76-11e8-94b1-2e503709f790.png)

For this we simply import the right components from the `@wordpress/editor` Gutenberg package.
