### PR TITLE
Fix block toolbar that sometime doesn't appear when the block get the focus

### DIFF
--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -48,7 +48,7 @@ export default class BlockHolder extends React.Component<PropsType> {
 				setAttributes={ ( attrs ) =>
 					this.props.onChange( this.props.clientId, { ...this.props.attributes, ...attrs } )
 				}
-				onFocus={this.props.onBlockHolderPressed.bind( this, this.props.clientId )}
+				onFocus={ this.props.onBlockHolderPressed.bind( this, this.props.clientId ) }
 				onReplace={ this.props.onReplace }
 				insertBlocksAfter={ this.props.insertBlocksAfter }
 				mergeBlocks={ this.props.mergeBlocks }

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -48,6 +48,7 @@ export default class BlockHolder extends React.Component<PropsType> {
 				setAttributes={ ( attrs ) =>
 					this.props.onChange( this.props.clientId, { ...this.props.attributes, ...attrs } )
 				}
+				onFocus={this.props.onBlockHolderPressed.bind( this, this.props.clientId )}
 				onReplace={ this.props.onReplace }
 				insertBlocksAfter={ this.props.insertBlocksAfter }
 				mergeBlocks={ this.props.mergeBlocks }


### PR DESCRIPTION
This PR fixes an issue where tapping on a `PlainText` or `AztecWrapper` block does not make the bottom bar following the focus, and be visible attached to the correct block. #251

It seems that the problem was related to the `onFocus` method not properly propagated up in the software layers, and our data model was lagging one step behind the focus. 

Companion GB PR is here: https://github.com/WordPress/gutenberg/pull/12316

To test:
- Start the demo app
- Tap on a `Para` block and check that the toolbar is visible
- Tap on a `Code` block and check that the toolbar is visible
- Tap on a `More` block and check that the toolbar is visible