### PR TITLE
Add the ability to react to focus lost and change the UI accordingly 

### DIFF
--- a/src/app/AppContainer.js
+++ b/src/app/AppContainer.js
@@ -91,6 +91,7 @@ class AppContainer extends React.Component<PropsType> {
 			<MainApp
 				blocks={ this.props.blocks }
 				onChange={ this.onChange }
+				onBlur={ this.props.clearSelectedBlock }
 				focusBlockAction={ this.focusBlockAction }
 				moveBlockUpAction={ this.moveBlockUpAction }
 				moveBlockDownAction={ this.moveBlockDownAction }

--- a/src/app/AppContainer.js
+++ b/src/app/AppContainer.js
@@ -22,6 +22,7 @@ type PropsType = {
 	onRemove: string => mixed,
 	onResetBlocks: Array<BlockType> => mixed,
 	onSelect: string => mixed,
+	clearSelectedBlock: void => void,
 	onAttributesUpdate: ( string, mixed ) => mixed,
 	initialHtml: string,
 	setupEditor: ( mixed, ?mixed ) => mixed,

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -18,6 +18,7 @@ type PropsType = BlockType & {
 	showTitle: boolean,
 	onChange: ( clientId: string, attributes: mixed ) => void,
 	onReplace: ( blocks: Array<Object> ) => void,
+	onBlur: void => void,
 	onInlineToolbarButtonPressed: ( button: number, clientId: string ) => void,
 	onBlockHolderPressed: ( clientId: string ) => void,
 	insertBlocksAfter: ( blocks: Array<Object> ) => void,

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -49,6 +49,7 @@ export default class BlockHolder extends React.Component<PropsType> {
 					this.props.onChange( this.props.clientId, { ...this.props.attributes, ...attrs } )
 				}
 				onFocus={ this.props.onBlockHolderPressed.bind( this, this.props.clientId ) }
+				onBlur={ this.props.onBlur }
 				onReplace={ this.props.onReplace }
 				insertBlocksAfter={ this.props.insertBlocksAfter }
 				mergeBlocks={ this.props.mergeBlocks }

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -284,6 +284,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 					key={ value.item.clientId }
 					onInlineToolbarButtonPressed={ this.onInlineToolbarButtonPressed }
 					onBlockHolderPressed={ this.props.focusBlockAction }
+					onBlur={ this.props.onBlur }
 					onChange={ this.props.onChange }
 					showTitle={ this.state.inspectBlocks }
 					focused={ value.item.focused }

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -25,6 +25,7 @@ const keyboardDidHide = 'keyboardDidHide';
 
 export type BlockListType = {
 	onChange: ( clientId: string, attributes: mixed ) => void,
+	onBlur: void => void,
 	focusBlockAction: string => void,
 	moveBlockUpAction: string => mixed,
 	moveBlockDownAction: string => mixed,


### PR DESCRIPTION
This PR adds ability to listen on the focus lost event / onBlur so that we can unselect the block => clear the selected block =>  dismiss the block toolbar.

To test this PR:
- Start the demo app
- Tap on a para block
- The bottom toolbar is visible together with the keyboard
- Tap on page break block
- The bottom toolbar is NOT visible, nor the keyboard
- Tap on a code block
- The bottom toolbar is visible together with the keyboard
- Tap on an unsupported block
- The bottom toolbar is NOT visible, nor the keyboard


GB side PR available here: https://github.com/WordPress/gutenberg/pull/12370

Note: there are still minor issues in the editing flow, like the keyword is dismissed when it should not. Or to start editing into a block you need to tap it twice or three. Will report this issues on separate tickets.

