### PR TITLE
Un-wire `onBlur` and make the Toolbar working again

### DIFF
--- a/src/app/AppContainer.js
+++ b/src/app/AppContainer.js
@@ -92,7 +92,6 @@ class AppContainer extends React.Component<PropsType> {
 			<MainApp
 				blocks={ this.props.blocks }
 				onChange={ this.onChange }
-				onBlur={ this.props.clearSelectedBlock }
 				focusBlockAction={ this.focusBlockAction }
 				moveBlockUpAction={ this.moveBlockUpAction }
 				moveBlockDownAction={ this.moveBlockDownAction }

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -18,7 +18,6 @@ type PropsType = BlockType & {
 	showTitle: boolean,
 	onChange: ( clientId: string, attributes: mixed ) => void,
 	onReplace: ( blocks: Array<Object> ) => void,
-	onBlur: void => void,
 	onInlineToolbarButtonPressed: ( button: number, clientId: string ) => void,
 	onBlockHolderPressed: ( clientId: string ) => void,
 	insertBlocksAfter: ( blocks: Array<Object> ) => void,
@@ -50,7 +49,6 @@ export default class BlockHolder extends React.Component<PropsType> {
 					this.props.onChange( this.props.clientId, { ...this.props.attributes, ...attrs } )
 				}
 				onFocus={ this.props.onBlockHolderPressed.bind( this, this.props.clientId ) }
-				onBlur={ this.props.onBlur }
 				onReplace={ this.props.onReplace }
 				insertBlocksAfter={ this.props.insertBlocksAfter }
 				mergeBlocks={ this.props.mergeBlocks }

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -25,7 +25,6 @@ const keyboardDidHide = 'keyboardDidHide';
 
 export type BlockListType = {
 	onChange: ( clientId: string, attributes: mixed ) => void,
-	onBlur: void => void,
 	focusBlockAction: string => void,
 	moveBlockUpAction: string => mixed,
 	moveBlockDownAction: string => mixed,
@@ -292,7 +291,6 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 					key={ value.item.clientId }
 					onInlineToolbarButtonPressed={ this.onInlineToolbarButtonPressed }
 					onBlockHolderPressed={ this.props.focusBlockAction }
-					onBlur={ this.props.onBlur }
 					onChange={ this.props.onChange }
 					showTitle={ this.state.inspectBlocks }
 					focused={ value.item.focused }


### PR DESCRIPTION
This PR does fix a problem where the Toolbar is unusable when the `onBlur` event is connected, and used to deselect the current block. 
Problem introduced in this PR here: https://github.com/wordpress-mobile/gutenberg-mobile/pull/283

Un-wiring the `onBlur` took us one step back but makes the toolbar usable again.
The whole `onBlur` infrastructure/code is kept in place for future usage.
