### PR TITLE
Bridge: Android bundle in bridge assets

### DIFF
--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -82,3 +82,32 @@ dependencies {
     }
     implementation 'com.facebook.react:react-native:+'
 }
+
+def getGitHeadHash() {
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        workingDir project.projectDir
+        commandLine 'git', 'rev-parse', 'HEAD'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
+}
+
+task downloadJSBundle << {
+    def assetsFolderName = "${project.projectDir}/src/main/assets"
+    File assetsFolder = new File(assetsFolderName)
+    if (! assetsFolder.exists()){
+        assetsFolder.mkdirs();
+    }
+
+    def filename = 'gutenberg-mobile-bundle.js'
+    def targetFile = new File("${assetsFolderName}/${filename}")
+    def hash = getGitHeadHash()
+    def url = new URL("https://s3-us-west-1.amazonaws.com/gutenberg-mobile-js-bundle/wordpress-mobile/gutenberg-mobile/${hash}/android/App.js")
+
+    println "Downloading JS bundle from ${url}"
+    url.withInputStream{ i -> targetFile.withOutputStream{ it << i }}
+}
+
+preBuild.dependsOn(downloadJSBundle)
+

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -37,7 +37,7 @@ android {
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"
-        buildConfigField "String", "GUTENBERG_MOBILE_JS_BUNDLE_FILENAME", "\"gutenbergMobileJsBundleFilename\""
+        buildConfigField "String", "GUTENBERG_MOBILE_JS_BUNDLE_FILENAME", "\"${gutenbergMobileJsBundleFilename}\""
     }
     lintOptions {
         abortOnError false

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -25,6 +25,9 @@ group='com.github.wordpress-mobile.gutenberg-mobile'
 // fallback flag value for when lib is compiled individually (e.g. via jitpack)
 project.ext.buildGutenbergFromSource = false
 
+// define the filename to use for the JS bundle. This will "bubble" up to the Java code via a BuildConfig constant
+def gutenbergMobileJsBundleFilename = 'gutenberg-mobile-bundle.js'
+
 android {
     compileSdkVersion 27
     buildToolsVersion "27.0.3"
@@ -34,6 +37,7 @@ android {
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"
+        buildConfigField "String", "GUTENBERG_MOBILE_JS_BUNDLE_FILENAME", "\"gutenbergMobileJsBundleFilename\""
     }
     lintOptions {
         abortOnError false
@@ -100,8 +104,7 @@ task downloadJSBundle << {
         assetsFolder.mkdirs();
     }
 
-    def filename = 'gutenberg-mobile-bundle.js'
-    def targetFile = new File("${assetsFolderName}/${filename}")
+    def targetFile = new File("${assetsFolderName}/${gutenbergMobileJsBundleFilename}")
     def hash = getGitHeadHash()
     def url = new URL("https://s3-us-west-1.amazonaws.com/gutenberg-mobile-js-bundle/wordpress-mobile/gutenberg-mobile/${hash}/android/App.js")
 

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -97,19 +97,21 @@ def getGitHeadHash() {
     return stdout.toString().trim()
 }
 
-task downloadJSBundle << {
-    def assetsFolderName = "${project.projectDir}/src/main/assets"
-    File assetsFolder = new File(assetsFolderName)
-    if (! assetsFolder.exists()){
-        assetsFolder.mkdirs();
+task downloadJSBundle {
+    doLast {
+        def assetsFolderName = "${project.projectDir}/src/main/assets"
+        File assetsFolder = new File(assetsFolderName)
+        if (! assetsFolder.exists()){
+            assetsFolder.mkdirs();
+        }
+
+        def targetFile = new File("${assetsFolderName}/${gutenbergMobileJsBundleFilename}")
+        def hash = getGitHeadHash()
+        def url = new URL("https://s3-us-west-1.amazonaws.com/gutenberg-mobile-js-bundle/wordpress-mobile/gutenberg-mobile/${hash}/android/App.js")
+
+        println "Downloading JS bundle from ${url}"
+        url.withInputStream{ i -> targetFile.withOutputStream{ it << i }}
     }
-
-    def targetFile = new File("${assetsFolderName}/${gutenbergMobileJsBundleFilename}")
-    def hash = getGitHeadHash()
-    def url = new URL("https://s3-us-west-1.amazonaws.com/gutenberg-mobile-js-bundle/wordpress-mobile/gutenberg-mobile/${hash}/android/App.js")
-
-    println "Downloading JS bundle from ${url}"
-    url.withInputStream{ i -> targetFile.withOutputStream{ it << i }}
 }
 
 if (!rootProject.ext.buildGutenbergFromSource) {

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -112,5 +112,8 @@ task downloadJSBundle << {
     url.withInputStream{ i -> targetFile.withOutputStream{ it << i }}
 }
 
-preBuild.dependsOn(downloadJSBundle)
-
+if (!rootProject.ext.buildGutenbergFromSource) {
+    // Download the JS bundle if we're not building from source.
+    // Usually happens when compiling this project as standalone or via jitpack
+    preBuild.dependsOn(downloadJSBundle)
+}

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -20,6 +20,7 @@ import com.github.godness84.RNRecyclerViewList.RNRecyclerviewListPackage;
 import com.horcrux.svg.SvgPackage;
 
 import org.wordpress.mobile.ReactNativeAztec.ReactAztecPackage;
+import org.wordpress.mobile.ReactNativeGutenbergBridge.BuildConfig;
 import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent;
 import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.MediaSelectedCallback;
 import org.wordpress.mobile.ReactNativeGutenbergBridge.RNReactNativeGutenbergBridgePackage;
@@ -96,7 +97,7 @@ public class WPAndroidGlueCode {
                                     .setUseDeveloperSupport(isDebug)
                                     .setInitialLifecycleState(LifecycleState.RESUMED);
         if (!buildGutenbergFromSource) {
-            builder.setBundleAssetName("gutenberg-mobile-bundle.js");
+            builder.setBundleAssetName(BuildConfig.GUTENBERG_MOBILE_JS_BUNDLE_FILENAME);
         }
         mReactInstanceManager = builder.build();
         mReactInstanceManager.addReactInstanceEventListener(new ReactInstanceManager.ReactInstanceEventListener() {

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -96,7 +96,7 @@ public class WPAndroidGlueCode {
                                     .setUseDeveloperSupport(isDebug)
                                     .setInitialLifecycleState(LifecycleState.RESUMED);
         if (!buildGutenbergFromSource) {
-            builder.setBundleAssetName("index.android.bundle");
+            builder.setBundleAssetName("gutenberg-mobile-bundle.js");
         }
         mReactInstanceManager = builder.build();
         mReactInstanceManager.addReactInstanceEventListener(new ReactInstanceManager.ReactInstanceEventListener() {


### PR DESCRIPTION
This PR adds support for automatically fetch the Android JS bundle from S3 (see #290) and including it in the assets. WPAndroidGlueCode.java then uses it from there.

Changes in this PR:

1. Downloads the Android JS bundle from S3. Detects the commit hash and uses it for the URL.
2. Defines a filename in gradle for the JS bundle and use it in the Java code too (via BuildConfig)
3. Places the JS bundle in the assets folder to be reachable in runtime via the typical Android `assets://` URL scheme.
4. Only download the file when building the library standalone or via jitpack.


### To test A (building the library)

1. Go into the `react-native-gutenberg-bridge-android` folder
2. Run `./gradlew assemble` to start building the bridge library
3. Notice that at some point, gradle runs `downloadJSBundle` and prints "Downloading JS bundle from ...." and that the URL includes the commit hash in this PR (at the time of writing it's
ec5649e)
4. The build finishes OK
5. Feel free to examine the `build/outputs/aar/react-native-gutenberg-bridge-debug.aar` file (it's a zip file essentially) to verify that the JS bundle lies inside the assets folder.

### To test B (using the library in wpandroid)

1. Use https://github.com/wordpress-mobile/WordPress-Android/pull/8664 (hash b356abc and beyond) to run wpandroid against this library
2. Avoid or remove the `wp.BUILD_GUTENBERG_FROM_SOURCE` flag from the root `gradle.properties` file so the build will depend on binaries only
3. Running wpandroid as normal and open a Gutenberg post. It should open the block editor just fine.