### PR TITLE
Persist keyboard as you switch from one block to another

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -204,6 +204,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		// And fix problems with RecyclerViewList on Android
 		const list = (
 			<FlatList
+				keyboardShouldPersistTaps="always"
 				style={ styles.list }
 				data={ this.state.blocks }
 				extraData={ { refresh: this.state.refresh } }


### PR DESCRIPTION
Another take at #291. Most of the changes are in https://github.com/wordpress-mobile/react-native-aztec/pull/84 but this also sets `keyboardShouldPersistTaps` to `always` in the `FlatList`.

The default behavior had FlatList blurring field every time you tapped outside them, which meant they were being blurred twice and losing the keyboard.

To test, follow the steps in #291, and confirm the keyboard stays up. A known issue is that if you tap on a non-text block (image, unsupported), the current text field will keep focus, but that's a different task in #197