### PR TITLE
Show default block appender component when post is empty

### DIFF
--- a/src/app/App.test.js
+++ b/src/app/App.test.js
@@ -28,11 +28,12 @@ describe( 'App', () => {
 			.forEach( ( blockHolder ) => {
 				if ( 'core/code' === blockHolder.props.name ) {
 					// TODO: hardcoded indices are ugly and error prone. Can we do better here?
-					const blockHolderContainer = blockHolder.children[ 0 ].children[ 0 ].children[ 0 ];
+					const blockHolderContainer = blockHolder.children[ 0 ].children[ 0 ].children[ 0 ].children[ 0 ].children[ 0 ];
 					const contentComponent = blockHolderContainer.children[ 0 ];
 					const inputComponent =
 						contentComponent.children[ 0 ].children[ 0 ].children[ 0 ].children[ 0 ].children[ 0 ]
-							.children[ 0 ].children[ 0 ].children[ 0 ].children[ 0 ].children[ 0 ];
+							.children[ 0 ].children[ 0 ].children[ 0 ].children[ 0 ].children[ 0 ].children[ 0 ].children[ 0 ];
+
 					expect( inputComponent.type ).toBe( 'TextInput' );
 				}
 			} );

--- a/src/app/AppContainer.js
+++ b/src/app/AppContainer.js
@@ -41,7 +41,7 @@ class AppContainer extends React.Component<PropsType> {
 		const post = props.post || {
 			id: 1,
 			content: {
-				raw: props.initialHtml,
+				raw: '',// props.initialHtml,
 			},
 			type: 'draft',
 		};

--- a/src/app/AppContainer.js
+++ b/src/app/AppContainer.js
@@ -41,7 +41,7 @@ class AppContainer extends React.Component<PropsType> {
 		const post = props.post || {
 			id: 1,
 			content: {
-				raw: '',// props.initialHtml,
+				raw: '', // props.initialHtml,
 			},
 			type: 'draft',
 		};

--- a/src/app/AppContainer.js
+++ b/src/app/AppContainer.js
@@ -41,7 +41,7 @@ class AppContainer extends React.Component<PropsType> {
 		const post = props.post || {
 			id: 1,
 			content: {
-				raw: '', // props.initialHtml,
+				raw: props.initialHtml,
 			},
 			type: 'draft',
 		};

--- a/src/app/AppContainer.js
+++ b/src/app/AppContainer.js
@@ -41,7 +41,7 @@ class AppContainer extends React.Component<PropsType> {
 		const post = props.post || {
 			id: 1,
 			content: {
-				raw: props.initialHtml,
+				raw: '',// props.initialHtml,
 			},
 			type: 'draft',
 		};
@@ -101,6 +101,7 @@ class AppContainer extends React.Component<PropsType> {
 	render() {
 		return (
 			<MainApp
+				rootClientId={ this.props.rootClientId }
 				blocks={ this.props.blocks }
 				showHtml={ this.props.showHtml }
 				onChange={ this.onChange }

--- a/src/app/AppContainer.js
+++ b/src/app/AppContainer.js
@@ -41,7 +41,7 @@ class AppContainer extends React.Component<PropsType> {
 		const post = props.post || {
 			id: 1,
 			content: {
-				raw: '',// props.initialHtml,
+				raw: props.initialHtml,
 			},
 			type: 'draft',
 		};

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -18,11 +18,12 @@ import styles from './block-holder.scss';
 import { BlockEdit } from '@wordpress/editor';
 
 type PropsType = BlockType & {
+	isSelected: boolean,
 	showTitle: boolean,
 	onChange: ( clientId: string, attributes: mixed ) => void,
 	onReplace: ( blocks: Array<Object> ) => void,
 	onInlineToolbarButtonPressed: ( button: number, clientId: string ) => void,
-	onBlockHolderPressed: ( clientId: string ) => void,
+	onSelect: void => void,
 	insertBlocksAfter: ( blocks: Array<Object> ) => void,
 	mergeBlocks: ( forward: boolean ) => void,
 	canMoveUp: boolean,

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -56,7 +56,6 @@ export default class BlockHolder extends React.Component<PropsType> {
 				onReplace={ this.props.onReplace }
 				insertBlocksAfter={ this.props.insertBlocksAfter }
 				mergeBlocks={ this.props.mergeBlocks }
-				isSelected={ this.props.focused }
 			/>
 		);
 	}

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -276,10 +276,8 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 				<BlockHolder
 					key={ value.item.clientId }
 					onInlineToolbarButtonPressed={ this.onInlineToolbarButtonPressed }
-					onBlockHolderPressed={ this.props.focusBlockAction }
 					onChange={ this.props.onChange }
 					showTitle={ false }
-					focused={ value.item.focused }
 					clientId={ value.item.clientId }
 					canMoveUp={ canMoveUp }
 					canMoveDown={ canMoveDown }

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -26,6 +26,7 @@ const keyboardDidShow = 'keyboardDidShow';
 const keyboardDidHide = 'keyboardDidHide';
 
 export type BlockListType = {
+	rootClientId: ?string,
 	onChange: ( clientId: string, attributes: mixed ) => void,
 	focusBlockAction: string => void,
 	moveBlockUpAction: string => mixed,

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -18,6 +18,8 @@ import KeyboardAvoidingView from '../components/keyboard-avoiding-view';
 
 // Gutenberg imports
 import { createBlock } from '@wordpress/blocks';
+import { DefaultBlockAppender } from '@wordpress/editor';
+
 import EventEmitter from 'events';
 
 const keyboardDidShow = 'keyboardDidShow';
@@ -211,6 +213,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		);
 		return (
 			<KeyboardAvoidingView style={ { flex: 1 } } parentHeight={ this.state.rootViewHeight }>
+				<DefaultBlockAppender rootClientId={ this.props.rootClientId } />
 				{ list }
 				<BlockToolbar
 					onInsertClick={ () => {


### PR DESCRIPTION
Requires https://github.com/WordPress/gutenberg/pull/12434

This PR adds a default text in the content area when no blocks are available. Clicking on it will replace it with an empty paragraph block by default.
This is close to what's available in the web version with with `BlockListAppender` even though it's simpler at this stage.

You can test this without using the parent app if you manually set `initialHtml` to `""` (empty string).
For instance in `App.js`: 
```
<AppContainer initialHtml="" />
```