### PR TITLE
Create blocks empty by default

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -85,7 +85,7 @@ export default class BlockManager extends React.Component<PropsType, StateType> 
 		this.setState( { ...this.state, selectedBlockType: itemValue, blockTypePickerVisible: false } );
 
 		// create an empty block of the selected type
-		const newBlock = createBlock( itemValue, { content: 'new test text for a ' + itemValue + ' block' } );
+		const newBlock = createBlock( itemValue );
 
 		this.props.createBlockAction( newBlock.clientId, newBlock );
 


### PR DESCRIPTION
The test text was good for debugging, but new blocks should be empty by default