### PR TITLE
Update gutenberg subrepo ref

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,7 @@
     "flowtype"
   ],
   "extends": [
-    "./gutenberg/eslint/config.js",
+    "./gutenberg/packages/eslint-config/index.js",
     "plugin:flowtype/recommended"
   ],
   "settings": {


### PR DESCRIPTION
Updating gutenberg subrepo ref to include 
WordPress/gutenberg#12409, WordPress/gutenberg#12422 from https://github.com/wordpress-mobile/WordPress-iOS/issues/10569