### PR TITLE
Create the Android JS bundle only on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,14 @@ matrix:
         LANE='node'
         CHECK_TESTS='true'
         TEST_RN_PLATFORM='android'
+        ARTIFACTS_BUCKET='gutenberg-mobile-js-bundle'
+        ARTIFACTS_PATHS="./bundle"
       cache:
         yarn: true
       script:
         - ./.travis/travis-checks-js.sh
+        - yarn bundle:android
+        - rm -Rf bundle/ios # delete the ios bundle since it's not up to date and we don't need to publish to S3
     - language: node_js
       node_js: 8
       env:
@@ -44,14 +48,3 @@ matrix:
         yarn: true
       script:
         - ./.travis/travis-checks-js.sh
-    - language: node_js
-      node_js: 8
-      env:
-        LANE='node'
-        ARTIFACTS_BUCKET='gutenberg-mobile-js-bundle'
-        ARTIFACTS_PATHS="./bundle"
-      cache:
-        yarn: true
-      script:
-        - yarn bundle:android
-        - rm -Rf bundle/ios # delete the ios bundle since it's not up to date and we don't need to publish to S3

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,11 @@ matrix:
       cache:
         yarn: true
       script:
+        - set -e # make sure Travis stops if any of the script lines error
         - ./.travis/travis-checks-js.sh
         - yarn bundle:android # rebuild the Android JS bundle
         - rm -Rf bundle/ios # delete the ios bundle since it's not up to date and we don't need to publish to S3
+        - set +e
     - language: node_js
       node_js: 8
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
         yarn: true
       script:
         - ./.travis/travis-checks-js.sh
-        - yarn bundle:android
+        - yarn bundle:android # rebuild the Android JS bundle
         - rm -Rf bundle/ios # delete the ios bundle since it's not up to date and we don't need to publish to S3
     - language: node_js
       node_js: 8

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,4 +53,5 @@ matrix:
       cache:
         yarn: true
       script:
-        - yarn bundle
+        - yarn bundle:android
+        - rm -Rf bundle/ios # delete the ios bundle since it's not up to date and we don't need to publish to S3


### PR DESCRIPTION
This PR removes the automatic generation and upload of the iOS JS bundle on Travis since the iOS side of the integration is not using it.

While at it, it removes the dedicated Travis job and piggybacks on the Android tests jobs for faster total time.

To test:

Check out the Travis build and notice only 3 jobs are there. Also notice that the Android job has building and uploading of the JS bundle artifact.