### PR TITLE
Fix SVG styling

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -901,13 +901,17 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.5.0.tgz#146c2a29ee7d3bae4bf2fcb274636e264c813c45"
   integrity sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==
 
-"@wordpress/babel-plugin-import-jsx-pragma@file:gutenberg/packages/babel-plugin-import-jsx-pragma":
+"@wordpress/babel-plugin-import-jsx-pragma@^1.1.2":
   version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-1.1.2.tgz#e1b47259c5a95009152f00a840e691d833507da7"
+  integrity sha512-0w43MP56yecSLUNr1ayus2bFM7y2k9O1SpFvc7c6bAlabJ6euTpkZscVIZSjzTR+d90wSu1BclzxiX58Y4oAwQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
 
-"@wordpress/babel-preset-default@file:gutenberg/packages/babel-preset-default":
+"@wordpress/babel-preset-default@^3.0.1":
   version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/babel-preset-default/-/babel-preset-default-3.0.1.tgz#33a3eb156e31e8169636b8af8402e3cd2fae3400"
+  integrity sha512-5pbmYh0b4flwyAbuEMTOgTZJ1jqn5iucXhoAESWHZyHCn6D+s36ws0RkFrefz1mYQv4KgIoVpqshDXdN9wR/Bg==
   dependencies:
     "@babel/plugin-proposal-async-generator-functions" "^7.0.0"
     "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
@@ -915,11 +919,13 @@
     "@babel/plugin-transform-runtime" "^7.0.0"
     "@babel/preset-env" "^7.0.0"
     "@babel/runtime" "^7.0.0"
-    "@wordpress/browserslist-config" "file:../../../Library/Caches/Yarn/v2/npm-@wordpress/browserslist-config"
+    "@wordpress/browserslist-config" "^2.2.2"
     babel-core "^7.0.0-bridge.0"
 
-"@wordpress/browserslist-config@file:gutenberg/packages/browserslist-config":
+"@wordpress/browserslist-config@^2.2.2":
   version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@wordpress/browserslist-config/-/browserslist-config-2.2.2.tgz#8bc88e9e3b363ba9d64207b811d5daaaecee3ee6"
+  integrity sha512-RZ9XeDeXTc/l3RdSnfYYwcsylFPouV+2ZpQQaAgALSXthMWJT2wU61zD4mH9aMI5Oo6Z8OUVI2vOZM/7HObPxw==
 
 "@wordpress/jest-console@^2.0.6":
   version "2.0.6"


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/320
Requires https://github.com/WordPress/gutenberg/pull/12608

This PR fixes a regression on SVG styling I introduced in https://github.com/wordpress-mobile/gutenberg-mobile/pull/310.

### Testing Instructions
- Boot the app on ios and android
- Check that the buttons are not black but light gray
