### PR TITLE
Make toolbar horizontally scrollable

### DIFF
--- a/src/block-management/block-toolbar.js
+++ b/src/block-management/block-toolbar.js
@@ -4,7 +4,7 @@
  */
 
 import React, { Component } from 'react';
-import { View } from 'react-native';
+import { View, ScrollView } from 'react-native';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { Toolbar, ToolbarButton } from '@wordpress/components';
@@ -37,34 +37,36 @@ export class BlockToolbar extends Component<PropsType> {
 
 		return (
 			<View style={ styles.container }>
-				<Toolbar>
-					<ToolbarButton
-						label={ __( 'Add block' ) }
-						icon="insert"
-						onClick={ onInsertClick }
-					/>
-					<ToolbarButton
-						label={ __( 'Undo' ) }
-						icon="undo"
-						isDisabled={ ! hasUndo }
-						onClick={ undo }
-					/>
-					<ToolbarButton
-						label={ __( 'Redo' ) }
-						icon="redo"
-						isDisabled={ ! hasRedo }
-						onClick={ redo }
-					/>
-				</Toolbar>
-				{ showKeyboardHideButton && ( <Toolbar>
-					<ToolbarButton
-						label={ __( 'Keyboard hide' ) }
-						icon="arrow-down"
-						onClick={ onKeyboardHide }
-					/>
-				</Toolbar> ) }
-				<BlockControls.Slot />
-				<BlockFormatControls.Slot />
+				<ScrollView horizontal={ true } showsHorizontalScrollIndicator={ false } keyboardShouldPersistTaps={ 'always' } alwaysBounceHorizontal={ false } >
+					<Toolbar>
+						<ToolbarButton
+							label={ __( 'Add block' ) }
+							icon="insert"
+							onClick={ onInsertClick }
+						/>
+						<ToolbarButton
+							label={ __( 'Undo' ) }
+							icon="undo"
+							isDisabled={ ! hasUndo }
+							onClick={ undo }
+						/>
+						<ToolbarButton
+							label={ __( 'Redo' ) }
+							icon="redo"
+							isDisabled={ ! hasRedo }
+							onClick={ redo }
+						/>
+					</Toolbar>
+					{ showKeyboardHideButton && ( <Toolbar>
+						<ToolbarButton
+							label={ __( 'Keyboard hide' ) }
+							icon="arrow-down"
+							onClick={ onKeyboardHide }
+						/>
+					</Toolbar> ) }
+					<BlockControls.Slot />
+					<BlockFormatControls.Slot />
+				</ScrollView>
 			</View>
 		);
 	}

--- a/src/block-management/block-toolbar.js
+++ b/src/block-management/block-toolbar.js
@@ -37,7 +37,12 @@ export class BlockToolbar extends Component<PropsType> {
 
 		return (
 			<View style={ styles.container }>
-				<ScrollView horizontal={ true } showsHorizontalScrollIndicator={ false } keyboardShouldPersistTaps={ 'always' } alwaysBounceHorizontal={ false } >
+				<ScrollView
+					horizontal={ true }
+					showsHorizontalScrollIndicator={ false }
+					keyboardShouldPersistTaps={ 'always' }
+					alwaysBounceHorizontal={ false }
+				>
 					<Toolbar>
 						<ToolbarButton
 							label={ __( 'Add block' ) }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/317

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/5032900/49520742-ff8c8100-f8b4-11e8-9fb6-6f025ddc28ae.gif)

The block toolbar is made scrollable horizontally. If the scrollbar content is smaller than the scrollbar itself then it won't scroll, thus, it won't scroll for blocks other than Heading right now, but in the future if other blocks have also lots of toolbar buttons then it will scroll also for them with no extra effort.

**To Test:**

- Add a Heading block and type something in it
- Verify that scrolling horizontally is possible
- Verify that you can tap toolbar buttons with no problem
