### PR TITLE
[iOS] Fix syntax error on xcode 9

### DIFF
--- a/ios/gutenberg/GutenbergViewController.swift
+++ b/ios/gutenberg/GutenbergViewController.swift
@@ -33,7 +33,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         print("Did receive HTML: \(html) changed: \(changed)")
     }
 
-    func gutenbergDidRequestMediaPicker(with callback: (String?) -> Void) {
+    func gutenbergDidRequestMediaPicker(with callback: @escaping MediaPickerDidPickMediaCallback) {
         print("Gutenberg did request media picker, passing a sample url in callback")
         callback("https://cldup.com/cXyG__fTLN.jpg")
     }


### PR DESCRIPTION
This PR fixes a syntax error found on Xcode 9.

To test:
- Launch the project using Xcode 9.
- Build and run.
- Check that there are no errors.