### PR TITLE
Wait JitPack to produce react-native-aztec's artifacts

### DIFF
--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -75,19 +75,13 @@ repositories {
     maven { url "https://jitpack.io" }
 }
 
-//def sleepOnJitpack() {
-//    println 'going to sleep'
-//    sleep(5000)
-//    println 'sleep ended'
-//}
-
 static def jitpackArtifactUrl(module, hash) {
     return "https://jitpack.io/com/github/wordpress-mobile/${module}/${hash}/${module}-${hash}.pom"
 }
 
 import io.github.httpbuilderng.http.HttpTask
 
-def getTaskName(backoffCount, module, hash) {
+static def getTaskName(backoffCount, module, hash) {
     return "blockOnJitpack-${backoffCount}-${module}-${hash}";
 }
 
@@ -100,7 +94,6 @@ def blockOnJitpack(group, module, hash) {
 
             config {
                 def timeout = (2**backoffCount) * 5 * 1000; // exponential timeout
-//                println("Timeout set to ${timeout}ms")
 
                 def url = jitpackArtifactUrl(module, hash)
                 request.uri = url
@@ -112,9 +105,6 @@ def blockOnJitpack(group, module, hash) {
             }
             get {
                 request.contentType = 'application/octet-stream'
-                //        response.when(200) {
-                //            sleepOnJitpack()
-                //        }
                 response.exception { Exception t ->
                     if (t instanceof SocketTimeoutException) {
                         if (backoffCount >= backoffLimit) {
@@ -130,12 +120,6 @@ def blockOnJitpack(group, module, hash) {
                         throw new RuntimeException(t)
                     }
                 }
-//                response.success { fromServer ->
-//                    def statusCode = fromServer.statusCode
-//                    println "got success ${statusCode}"
-//                    sleepOnJitpack()
-//                    println 'Jitpack is ready'
-//                }
                 response.failure { fromServer ->
                     def statusCode = fromServer.statusCode
                     println "got failure ${statusCode}"

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -11,14 +11,11 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-        classpath "gradle.plugin.io.github.http-builder-ng:http-plugin:0.1.1"
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
-
-apply plugin: "io.github.http-builder-ng.http-plugin"
 
 // import the `submoduleGitHash()` function
 apply from: 'https://gist.githubusercontent.com/hypest/e06f6097065728b6db7b7c462f8fef1a/raw/3b91756fca76e4c2a9b573313e186c47842e1f7d/submoduleGitHash.gradle'
@@ -79,61 +76,42 @@ static def jitpackArtifactUrl(module, hash) {
     return "https://jitpack.io/com/github/wordpress-mobile/${module}/${hash}/${module}-${hash}.pom"
 }
 
-import io.github.httpbuilderng.http.HttpTask
-
-static def getTaskName(backoffCount, module, hash) {
-    return "blockOnJitpack-${backoffCount}-${module}-${hash}";
-}
-
 def blockOnJitpack(group, module, hash) {
-    def backoffLimit = 7
-    (0..backoffLimit).each { backoffCount ->
-        def taskName = getTaskName(backoffCount, module, hash)
-        def task = tasks.create(name: taskName, type: HttpTask) { thisTask ->
-            thisTask.ext.doBackoff = false
+    preBuild.dependsOn(tasks.create(name: "blockOnJitpack-${module}-${hash}") { thisTask ->
+        def url = jitpackArtifactUrl(module, hash)
+        println url
 
-            config {
-                def timeout = (2**backoffCount) * 5 * 1000; // exponential timeout
+        def backoffLimit = 7
+        for (def backoffCount : (0..backoffLimit)) {
+            def connection = new URL(url).openConnection() as HttpURLConnection
 
-                def url = jitpackArtifactUrl(module, hash)
-                request.uri = url
+            def timeout = (2**backoffCount) * 5 * 1000; // exponential timeout
+            connection.setConnectTimeout(timeout)
+            connection.setReadTimeout(timeout)
 
-                client.clientCustomizer { HttpURLConnection httpURLConnection ->
-                    httpURLConnection.setConnectTimeout(timeout)
-                    httpURLConnection.setReadTimeout(timeout)
+            connection.setRequestMethod("HEAD");
+            connection.setInstanceFollowRedirects(true)
+
+            try {
+                def responseCode = connection.getResponseCode();
+                if (responseCode >= 200 && responseCode <= 299) {
+                    // success. Just bail
+                    return
+                } else {
+                    def responseMessage = connection.getResponseCode();
+                    throw new RuntimeException("Failed reaching Jitpack for ${group}:${module}:${hash}: ${responseMessage}")
                 }
-            }
-            head {
-                response.exception { Exception t ->
-                    if (t instanceof SocketTimeoutException) {
-                        if (backoffCount >= backoffLimit) {
-                            throw new Exception("Exhausted waiting for Jipack on ${group}:${module}:${hash}")
-                        }
+            } catch (SocketTimeoutException ignored) {
+                if (backoffCount == backoffLimit) {
+                    throw new Exception("Exhausted waiting for Jipack on ${group}:${module}:${hash}")
+                }
 
-                        def newBackoffCount = backoffCount + 1
-                        thisTask.ext.doBackoff = true
-                        println "Timed out. Engaging backoff count ${newBackoffCount}"
-                    } else {
-                        println "Oops, an exception was thrown!"
-                        t.printStackTrace()
-                        throw new RuntimeException(t)
-                    }
-                }
-                response.failure { fromServer ->
-                    def statusCode = fromServer.statusCode
-                    println "got failure ${statusCode}"
-                    println fs
-                }
+                println "Retrying reaching ${group}:${module}:${hash} on Jitpack"
+            } catch (Exception e) {
+                throw e
             }
         }
-
-        preBuild.dependsOn(task)
-
-        if (backoffCount > 0) {
-            def prevTaskName = getTaskName(backoffCount - 1, module, hash)
-            task.onlyIf { tasks[prevTaskName].ext.doBackoff }
-        }
-    }
+    })
 }
 
 dependencies {

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -72,13 +72,13 @@ repositories {
     maven { url "https://jitpack.io" }
 }
 
-static def jitpackArtifactUrl(module, hash) {
-    return "https://jitpack.io/com/github/wordpress-mobile/${module}/${hash}/${module}-${hash}.pom"
+static def jitpackArtifactUrl(group, module, hash) {
+    return "https://jitpack.io/${group.replace('.', '/')}/${module}/${hash}/${module}-${hash}.pom"
 }
 
 def blockOnJitpack(group, module, hash) {
     preBuild.dependsOn(tasks.create(name: "blockOnJitpack-${module}-${hash}") { thisTask ->
-        def url = jitpackArtifactUrl(module, hash)
+        def url = jitpackArtifactUrl(group, module, hash)
 
         def backoffLimit = 7
         for (def backoffCount : (0..backoffLimit)) {

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -79,7 +79,6 @@ static def jitpackArtifactUrl(module, hash) {
 def blockOnJitpack(group, module, hash) {
     preBuild.dependsOn(tasks.create(name: "blockOnJitpack-${module}-${hash}") { thisTask ->
         def url = jitpackArtifactUrl(module, hash)
-        println url
 
         def backoffLimit = 7
         for (def backoffCount : (0..backoffLimit)) {
@@ -106,7 +105,7 @@ def blockOnJitpack(group, module, hash) {
                     throw new Exception("Exhausted waiting for Jipack on ${group}:${module}:${hash}")
                 }
 
-                println "Retrying reaching ${group}:${module}:${hash} on Jitpack"
+                println "Retrying JitPack ${backoffCount+1}/${backoffLimit+1} for ${group}:${module}:${hash}"
             } catch (Exception e) {
                 throw e
             }

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -111,6 +111,8 @@ def blockOnJitpack(group, module, hash) {
             }
         }
     })
+
+    return "${group}:${module}:${hash}"
 }
 
 dependencies {
@@ -121,12 +123,7 @@ dependencies {
         implementation project(':react-native-recyclerview-list')
     } else {
         implementation ('com.github.wordpress-mobile:react-native-svg:faed05be8dca2b0df8957c5f72c40eccef12144d')
-
-        def module = 'react-native-aztec';
-        def hash = submoduleGitHash('../../', 'react-native-aztec')
-        blockOnJitpack('com.github.wordpress-mobile', module, hash)
-
-        implementation ('com.github.wordpress-mobile:react-native-aztec:' + submoduleGitHash('../../', 'react-native-aztec'))
+        implementation (blockOnJitpack('com.github.wordpress-mobile', 'react-native-aztec', submoduleGitHash('../../', 'react-native-aztec')))
         implementation ('com.github.wordpress-mobile:react-native-recyclerview-list:a2e8ca550412504c32218fd473c55f696f18f1f7')
     }
     implementation 'com.facebook.react:react-native:+'

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -3,16 +3,22 @@ buildscript {
     repositories {
         jcenter()
         google()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
+        classpath "gradle.plugin.io.github.http-builder-ng:http-plugin:0.1.1"
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
+
+apply plugin: "io.github.http-builder-ng.http-plugin"
 
 // import the `submoduleGitHash()` function
 apply from: 'https://gist.githubusercontent.com/hypest/e06f6097065728b6db7b7c462f8fef1a/raw/38557f55d0a3be9605c82b1df9ced4c846fd3aea/submoduleGitHash.gradle'
@@ -69,6 +75,33 @@ repositories {
     maven { url "https://jitpack.io" }
 }
 
+def sleepOnJitpack() {
+    println 'going to sleep'
+    sleep(5000)
+    println 'The event notification was successful'
+}
+
+static def jitpackArtifactUrl(hash) {
+    return "https://jitpack.io/com/github/wordpress-mobile/react-native-aztec/${hash}/react-native-aztec-${hash}.aar"
+}
+
+task patience(type:io.github.httpbuilderng.http.HttpTask) {
+    config {
+        def url = jitpackArtifactUrl(project.ext.hash)
+//        println url
+        request.uri = url
+    }
+    get {
+        request.contentType = 'application/octet-stream'
+        response.when(200) {
+            sleepOnJitpack()
+        }
+        response.success {
+            println 'Jitpack is ready'
+        }
+    }
+}
+
 dependencies {
     if (rootProject.ext.buildGutenbergFromSource) {
         println "using gutenberg from source"
@@ -77,6 +110,10 @@ dependencies {
         implementation project(':react-native-recyclerview-list')
     } else {
         implementation ('com.github.wordpress-mobile:react-native-svg:faed05be8dca2b0df8957c5f72c40eccef12144d')
+
+        project.ext.hash = submoduleGitHash('../../', 'react-native-aztec')
+        tasks.patience.execute()
+
         implementation ('com.github.wordpress-mobile:react-native-aztec:' + submoduleGitHash('../../', 'react-native-aztec'))
         implementation ('com.github.wordpress-mobile:react-native-recyclerview-list:a2e8ca550412504c32218fd473c55f696f18f1f7')
     }

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -23,6 +23,9 @@ apply from: 'https://gist.githubusercontent.com/hypest/e06f6097065728b6db7b7c462
 // import the `readReactNativeVersion()` function
 apply from: 'https://gist.githubusercontent.com/hypest/742448b9588b3a0aa580a5e80ae95bdf/raw/8eb62d40ee7a5104d2fcaeff21ce6f29bd93b054/readReactNativeVersion.gradle'
 
+// import the `waitJitpack()` function
+apply from: 'https://gist.githubusercontent.com/hypest/f526fe0775dedce0ce0133f1400d22a4/raw/0008b271a0d28fc79957fd3c2a027f57e98f796a/wait-jitpack.gradle'
+
 group='com.github.wordpress-mobile.gutenberg-mobile'
 
 // fallback flag value for when lib is compiled individually (e.g. via jitpack)
@@ -70,45 +73,6 @@ repositories {
     }
 
     maven { url "https://jitpack.io" }
-}
-
-def waitJitpack(group, module, hash) {
-    preBuild.dependsOn(tasks.create(name: "waitJitpack-${module}-${hash}") { thisTask ->
-        def url = "https://jitpack.io/${group.replace('.', '/')}/${module}/${hash}/${module}-${hash}.pom"
-
-        def backoffLimit = 7
-        for (def backoffCount : (0..backoffLimit)) {
-            def connection = new URL(url).openConnection() as HttpURLConnection
-
-            def timeout = (2**backoffCount) * 5 * 1000; // exponential timeout
-            connection.setConnectTimeout(timeout)
-            connection.setReadTimeout(timeout)
-
-            connection.setRequestMethod("HEAD");
-            connection.setInstanceFollowRedirects(true)
-
-            try {
-                def responseCode = connection.getResponseCode();
-                if (responseCode >= 200 && responseCode <= 299) {
-                    // success. Just bail
-                    return
-                } else {
-                    def responseMessage = connection.getResponseCode();
-                    throw new RuntimeException("Failed reaching Jitpack for ${group}:${module}:${hash}: ${responseMessage}")
-                }
-            } catch (SocketTimeoutException ignored) {
-                if (backoffCount == backoffLimit) {
-                    throw new Exception("Exhausted waiting for Jipack on ${group}:${module}:${hash}")
-                }
-
-                println "Retrying JitPack ${backoffCount+1}/${backoffLimit+1} for ${group}:${module}:${hash}"
-            } catch (Exception e) {
-                throw e
-            }
-        }
-    })
-
-    return "${group}:${module}:${hash}"
 }
 
 dependencies {

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -21,7 +21,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: "io.github.http-builder-ng.http-plugin"
 
 // import the `submoduleGitHash()` function
-apply from: 'https://gist.githubusercontent.com/hypest/e06f6097065728b6db7b7c462f8fef1a/raw/38557f55d0a3be9605c82b1df9ced4c846fd3aea/submoduleGitHash.gradle'
+apply from: 'https://gist.githubusercontent.com/hypest/e06f6097065728b6db7b7c462f8fef1a/raw/3b91756fca76e4c2a9b573313e186c47842e1f7d/submoduleGitHash.gradle'
 
 // import the `readReactNativeVersion()` function
 apply from: 'https://gist.githubusercontent.com/hypest/742448b9588b3a0aa580a5e80ae95bdf/raw/8eb62d40ee7a5104d2fcaeff21ce6f29bd93b054/readReactNativeVersion.gradle'
@@ -75,29 +75,80 @@ repositories {
     maven { url "https://jitpack.io" }
 }
 
-def sleepOnJitpack() {
-    println 'going to sleep'
-    sleep(5000)
-    println 'The event notification was successful'
+//def sleepOnJitpack() {
+//    println 'going to sleep'
+//    sleep(5000)
+//    println 'sleep ended'
+//}
+
+static def jitpackArtifactUrl(module, hash) {
+    return "https://jitpack.io/com/github/wordpress-mobile/${module}/${hash}/${module}-${hash}.pom"
 }
 
-static def jitpackArtifactUrl(hash) {
-    return "https://jitpack.io/com/github/wordpress-mobile/react-native-aztec/${hash}/react-native-aztec-${hash}.aar"
+import io.github.httpbuilderng.http.HttpTask
+
+def getTaskName(backoffCount, module, hash) {
+    return "blockOnJitpack-${backoffCount}-${module}-${hash}";
 }
 
-task patience(type:io.github.httpbuilderng.http.HttpTask) {
-    config {
-        def url = jitpackArtifactUrl(project.ext.hash)
-//        println url
-        request.uri = url
-    }
-    get {
-        request.contentType = 'application/octet-stream'
-        response.when(200) {
-            sleepOnJitpack()
+def blockOnJitpack(group, module, hash) {
+    def backoffLimit = 7
+    (0..backoffLimit).each { backoffCount ->
+        def taskName = getTaskName(backoffCount, module, hash)
+        def task = tasks.create(name: taskName, type: HttpTask) { thisTask ->
+            thisTask.ext.doBackoff = false
+
+            config {
+                def timeout = (2**backoffCount) * 5 * 1000; // exponential timeout
+//                println("Timeout set to ${timeout}ms")
+
+                def url = jitpackArtifactUrl(module, hash)
+                request.uri = url
+
+                client.clientCustomizer { HttpURLConnection httpURLConnection ->
+                    httpURLConnection.setConnectTimeout(timeout)
+                    httpURLConnection.setReadTimeout(timeout)
+                }
+            }
+            get {
+                request.contentType = 'application/octet-stream'
+                //        response.when(200) {
+                //            sleepOnJitpack()
+                //        }
+                response.exception { Exception t ->
+                    if (t instanceof SocketTimeoutException) {
+                        if (backoffCount >= backoffLimit) {
+                            throw new Exception("Exhausted waiting for Jipack on ${group}:${module}:${hash}")
+                        }
+
+                        def newBackoffCount = backoffCount + 1
+                        thisTask.ext.doBackoff = true
+                        println "Timed out. Engaging backoff count ${newBackoffCount}"
+                    } else {
+                        println "Oops, an exception was thrown!"
+                        t.printStackTrace()
+                        throw new RuntimeException(t)
+                    }
+                }
+//                response.success { fromServer ->
+//                    def statusCode = fromServer.statusCode
+//                    println "got success ${statusCode}"
+//                    sleepOnJitpack()
+//                    println 'Jitpack is ready'
+//                }
+                response.failure { fromServer ->
+                    def statusCode = fromServer.statusCode
+                    println "got failure ${statusCode}"
+                    println fs
+                }
+            }
         }
-        response.success {
-            println 'Jitpack is ready'
+
+        preBuild.dependsOn(task)
+
+        if (backoffCount > 0) {
+            def prevTaskName = getTaskName(backoffCount - 1, module, hash)
+            task.onlyIf { tasks[prevTaskName].ext.doBackoff }
         }
     }
 }
@@ -111,8 +162,9 @@ dependencies {
     } else {
         implementation ('com.github.wordpress-mobile:react-native-svg:faed05be8dca2b0df8957c5f72c40eccef12144d')
 
-        project.ext.hash = submoduleGitHash('../../', 'react-native-aztec')
-        tasks.patience.execute()
+        def module = 'react-native-aztec';
+        def hash = submoduleGitHash('../../', 'react-native-aztec')
+        blockOnJitpack('com.github.wordpress-mobile', module, hash)
 
         implementation ('com.github.wordpress-mobile:react-native-aztec:' + submoduleGitHash('../../', 'react-native-aztec'))
         implementation ('com.github.wordpress-mobile:react-native-recyclerview-list:a2e8ca550412504c32218fd473c55f696f18f1f7')

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -103,8 +103,7 @@ def blockOnJitpack(group, module, hash) {
                     httpURLConnection.setReadTimeout(timeout)
                 }
             }
-            get {
-                request.contentType = 'application/octet-stream'
+            head {
                 response.exception { Exception t ->
                     if (t instanceof SocketTimeoutException) {
                         if (backoffCount >= backoffLimit) {

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -3,9 +3,6 @@ buildscript {
     repositories {
         jcenter()
         google()
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
     }
 
     dependencies {

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -72,13 +72,9 @@ repositories {
     maven { url "https://jitpack.io" }
 }
 
-static def jitpackArtifactUrl(group, module, hash) {
-    return "https://jitpack.io/${group.replace('.', '/')}/${module}/${hash}/${module}-${hash}.pom"
-}
-
-def blockOnJitpack(group, module, hash) {
-    preBuild.dependsOn(tasks.create(name: "blockOnJitpack-${module}-${hash}") { thisTask ->
-        def url = jitpackArtifactUrl(group, module, hash)
+def waitJitpack(group, module, hash) {
+    preBuild.dependsOn(tasks.create(name: "waitJitpack-${module}-${hash}") { thisTask ->
+        def url = "https://jitpack.io/${group.replace('.', '/')}/${module}/${hash}/${module}-${hash}.pom"
 
         def backoffLimit = 7
         for (def backoffCount : (0..backoffLimit)) {
@@ -123,7 +119,7 @@ dependencies {
         implementation project(':react-native-recyclerview-list')
     } else {
         implementation ('com.github.wordpress-mobile:react-native-svg:faed05be8dca2b0df8957c5f72c40eccef12144d')
-        implementation (blockOnJitpack('com.github.wordpress-mobile', 'react-native-aztec', submoduleGitHash('../../', 'react-native-aztec')))
+        implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-aztec', submoduleGitHash('../../', 'react-native-aztec')))
         implementation ('com.github.wordpress-mobile:react-native-recyclerview-list:a2e8ca550412504c32218fd473c55f696f18f1f7')
     }
     implementation 'com.facebook.react:react-native:+'


### PR DESCRIPTION
The PR adds a "manual" wait for waiting JitPack to finish producing the artifacts for `react-native-aztec`.

The idea here is to "inject" the wait to the dependencies that change often or seem to take enough time to get produced that Gradle times out.

The "juice" lives in a function published on a gist here: https://gist.github.com/hypest/f526fe0775dedce0ce0133f1400d22a4. The git history of developing that function is in the current PR's history of commits.

Even though we could probably just get away with increasing Gradle's HTTP timeouts as suggested on [JitPack's FAQ](https://jitpack.io/docs/FAQ/), that would increase timeouts for all requests made by Gradle, with unexpected results. Instead, this PR tries to limit scope by prolonging the "wait" only for a specific artifact.

To test:

0. With the project fully checked out, submodules updated and `yarn install`'d
1. Change into the `react-native-gutenberg-bridge` folder and run `./gradlew assembleRelease`. This should succeed.
2. On a new terminal window, change to the `react-native-aztec` folder and follow the next steps
2b. Create a new git branch, say "try/just-for-test-delete-me-in-the-end"
2c. Make some trivial change to a file or create a new one and add it to git
2d. Push the branch to remote
3. Back on the first terminal window, run `./gradlew assembleRelease` again. This time the build will take longer and will print some `Retrying JitPack...` log lines.
4. After a few retries (note: timeout is exponential) the build will continue and succeed
