### PR TITLE
use same behavior as Gutenberg web for replacing an empty default block

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -269,17 +269,11 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 		return index === this.state.blocks.length - 1;
 	}
 
-	isEmptyBlock( block: BlockType ) {
-		const content = block.attributes.content;
-		const innerBlocks = block.innerBlocks;
-		return ( content === undefined || content === '' ) && ( innerBlocks.length === 0 );
-	}
-
 	isReplaceable( block: ?BlockType ) {
 		if ( ! block ) {
 			return false;
 		}
-		return this.isEmptyBlock( block ) && isUnmodifiedDefaultBlock( block );
+		return isUnmodifiedDefaultBlock( block );
 	}
 
 	renderItem( value: { item: BlockType, index: number } ) {

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -19,7 +19,7 @@ import KeyboardAvoidingView from '../components/keyboard-avoiding-view';
 // Gutenberg imports
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { DefaultBlockAppender } from '@wordpress/editor';
 
 import EventEmitter from 'events';
@@ -275,15 +275,11 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 		return ( content === undefined || content === '' ) && ( innerBlocks.length === 0 );
 	}
 
-	isCandidateForReplaceBlock( block: BlockType ) {
-		return ( block.name === 'core/paragraph' || block.name === 'core/heading' || block.name === 'core/code' );
-	}
-
 	isReplaceable( block: ?BlockType ) {
 		if ( ! block ) {
 			return false;
 		}
-		return this.isEmptyBlock( block ) && this.isCandidateForReplaceBlock( block );
+		return this.isEmptyBlock( block ) && isUnmodifiedDefaultBlock( block );
 	}
 
 	renderItem( value: { item: BlockType, index: number } ) {


### PR DESCRIPTION
Comes from https://github.com/wordpress-mobile/gutenberg-mobile/pull/327#discussion_r

While PR #327 addresses #315 description, it's been observed that desired behavior is more that of following along Gutenberg web as much as we can. @koke observed the behavior should be closer to Gutenberg's by using `isUnmodifiedDefaultBlock` (see https://github.com/WordPress/gutenberg/blob/40d1282a992702e1933118ef626f0666692baf2b/packages/editor/src/components/inserter/menu.js#L389)

**Please note** that this makes the _default block_  (currently, `core/paragraph`) the only block type eligible for replacement when such a block is both empty and selected, and the user taps on + to bring up the inserter's block picker.

With this PR then, if the user is standing on an empty `Heading` or  `Code` block, they won't be able to replace such blocks anymore - the user will only be able to replace a block if they're standing on a `Paragraph` empty block.

I tested this on Gutenberg web and could observe the same.

To test: (paragraph)
1. load the demo app
2. tap on the + inserter icon to bring the BlockType picker up
3. choose Paragraph type (first on the left)
4. observe a new, empty Paragraph block is appended to the list and the editor scrolls there (the Paragraph editor gets the focus and the block is selected)
5. leaving the focus/selection there, tap on the + inserter icon again
6. now select T title block
7. observe the block is now a Title block type, as opposed to appending a new empty block once again.

To test: (other editables, non-paragraph)

8. leaving the focus/selection on the T block inserted in step 6 above:
9. tap on the + inserter icon
10. tap on any block
11. observe a new block is appended, instead of being replaced.

Try steps 8-10 again, inserting a new block while standing on a Code block instead of Title (Heading), and observe in both cases the new block is appended (or inserted below the selected block) rather than replace the previously selected block.

