### PR TITLE
Prioritize JitPack over the NPM CDN and wait on all RN subprojects

### DIFF
--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -43,14 +43,14 @@ android {
     }
 }
 
-def unpkgOrNodeModules(remotePath, localPath) {
+def cdnOrNodeModules(remotePath, localPath) {
     def url
     if (rootProject.ext.buildGutenbergFromSource) {
         url = "${project.buildDir}/../../../node_modules/${localPath}"
     } else {
         // if we are the root project, use a remote maven repo so jitpack can build this lib without local RN setup
-        url = "https://unpkg.com/${remotePath}"
-        println "Will use the unpkg.com exposed maven repo at ${url}"
+        url = "https://cdn.jsdelivr.net/npm/${remotePath}"
+        println "Will use the jsdelivr.net exposed maven repo at ${url}"
     }
     return url
 }
@@ -64,11 +64,11 @@ repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries)
         def rnVersion = readReactNativeVersion('../package.json', 'peerDependencies')
-        url unpkgOrNodeModules("react-native@${rnVersion}/android", "react-native/android")
+        url cdnOrNodeModules("react-native@${rnVersion}/android", "react-native/android")
     }
     maven {
         // Maven repo containing AARs with JSC library built for Android
-        url unpkgOrNodeModules("jsc-android@224109.1.0/dist/", "jsc-android/dist")
+        url cdnOrNodeModules("jsc-android@224109.1.0/dist/", "jsc-android/dist")
     }
 }
 

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -79,9 +79,9 @@ dependencies {
         implementation project(':react-native-aztec')
         implementation project(':react-native-recyclerview-list')
     } else {
-        implementation ('com.github.wordpress-mobile:react-native-svg:faed05be8dca2b0df8957c5f72c40eccef12144d')
+        implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-svg', 'faed05be8dca2b0df8957c5f72c40eccef12144d'))
         implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-aztec', submoduleGitHash('../../', 'react-native-aztec')))
-        implementation ('com.github.wordpress-mobile:react-native-recyclerview-list:a2e8ca550412504c32218fd473c55f696f18f1f7')
+        implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-recyclerview-list', 'a2e8ca550412504c32218fd473c55f696f18f1f7'))
     }
     implementation 'com.facebook.react:react-native:+'
 }

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -59,6 +59,8 @@ repositories {
     google()
     jcenter()
 
+    maven { url "https://jitpack.io" }
+
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries)
         def rnVersion = readReactNativeVersion('../package.json', 'peerDependencies')
@@ -68,8 +70,6 @@ repositories {
         // Maven repo containing AARs with JSC library built for Android
         url unpkgOrNodeModules("jsc-android@224109.1.0/dist/", "jsc-android/dist")
     }
-
-    maven { url "https://jitpack.io" }
 }
 
 dependencies {


### PR DESCRIPTION
Similar to https://github.com/wordpress-mobile/react-native-aztec/pull/91, this PR prioritizes the JitPack maven repo over the NPM CDN's ones, uses jsdelivr.net as the CDN and additionally, it employs the `waitJitpack()` Gradle helper function to wait on all the JitPack builds for the React Native subprojects.

The `waitJitpack()` was previously reviewed in #333.

To test:
1. Change into the `react-native-gutenberg-bridge/android` subfolder
2. Run `./gradlew assemble` to build the bridge library
3. The build should suceed and two `Will use the jsdelivr.net exposed maven repo at ...` log output lines should appear, one for `react-native` and one for `jsc-android`