### PR TITLE
First step on fixing keyboard state

### DIFF
--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -111,8 +111,8 @@ export default compose( [
 			onSelect: ( event ) => {
 				if ( event ) {
 					// This fix an issue with the way we are handling focus on TextIput fields and handling the keyboard state.
-					// When moving from a TextInput field to another kind of field the call that hides the keyboard was not invoked
-					// properly resulting in the keyboard up when it should not be there.
+					// When moving from a TextInput field to another kind of field the call that hides the keyboard was not invoked properly,
+					// resulting in keyboard up when it should not be there.
 					const currentlyFocusedTextInput = TextInputState.currentlyFocusedField();
 					if ( event.nativeEvent.target !== currentlyFocusedTextInput && ! TextInputState.isTextInput( event.nativeEvent.target ) ) {
 						// This check that the current TextInputState "focused" field is the one that has the focus.

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -17,6 +17,8 @@ import styles from './block-holder.scss';
 // Gutenberg imports
 import { BlockEdit } from '@wordpress/editor';
 
+import TextInputState from 'react-native/lib/TextInputState';
+
 type PropsType = BlockType & {
 	isSelected: boolean,
 	showTitle: boolean,
@@ -106,7 +108,17 @@ export default compose( [
 		} = dispatch( 'core/editor' );
 
 		return {
-			onSelect: () => {
+			onSelect: ( event ) => {
+				if ( event ) {
+					// This fix an issue with the way we are handling focus on TextIput fields and handling the keyboard state.
+					// When moving from a TextInput field to another kind of field the call that hides the keyboard was not invoked
+					// properly resulting in the keyboard up when it should not be there.
+					const currentlyFocusedTextInput = TextInputState.currentlyFocusedField();
+					if ( event.nativeEvent.target !== currentlyFocusedTextInput && ! TextInputState.isTextInput( event.nativeEvent.target ) ) {
+						// This check that the current TextInputState "focused" field is the one that has the focus.
+						TextInputState.blurTextInput( currentlyFocusedTextInput );
+					}
+				}
 				clearSelectedBlock();
 				selectBlock( clientId );
 			},


### PR DESCRIPTION
This PR fixes #308 by making sure that the field that gets the focus on tapping is a field registered in TextInputState - That has handles focus on all TextInput fields.

React Native Aztec PR is here: https://github.com/wordpress-mobile/react-native-aztec/pull/92

Steps to repro:

- Tap on a para block
- Tap on the page break block
- The block holder should be visible on the page break block, and the keyboard dismissed
- Repeat the steps above by tapping on any of the TextInput "block", and then tap on another kind of block --> the keyboard should be visible only when the focus is on a TextInput field.

Note: The caret is still visible (and blinking) in the TextInput "powered" block that lost the focus. We will fix this in another PR.

