### PR TITLE
Feature/update html

### DIFF
--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -16,6 +16,11 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
     private final ReactApplicationContext mReactContext;
     private final GutenbergBridgeJS2Parent mGutenbergBridgeJS2Parent;
 
+    private static final String EVENT_NAME_REQUEST_GET_HTML = "requestGetHtml";
+    private static final String EVENT_NAME_UPDATE_HTML = "updateHtml";
+
+    private static final String MAP_KEY_UPDATE_HTML = "html";
+
     public RNReactNativeGutenbergBridgeModule(ReactApplicationContext reactContext,
             GutenbergBridgeJS2Parent gutenbergBridgeJS2Parent) {
         super(reactContext);
@@ -33,13 +38,13 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
     }
 
     public void getHtmlFromJS() {
-        emitToJS("requestGetHtml", null);
+        emitToJS(EVENT_NAME_REQUEST_GET_HTML, null);
     }
 
     public void updateHtml(String html) {
         WritableMap writableMap = new WritableNativeMap();
-        writableMap.putString("html", html);
-        emitToJS("updateHtml", writableMap);
+        writableMap.putString(MAP_KEY_UPDATE_HTML, html);
+        emitToJS(EVENT_NAME_UPDATE_HTML, writableMap);
     }
 
     @ReactMethod

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -7,6 +7,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.MediaSelectedCallback;
@@ -33,6 +34,12 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
 
     public void getHtmlFromJS() {
         emitToJS("requestGetHtml", null);
+    }
+
+    public void updateHtml(String html) {
+        WritableMap writableMap = new WritableNativeMap();
+        writableMap.putString("html", html);
+        emitToJS("updateHtml", writableMap);
     }
 
     @ReactMethod

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -41,7 +41,7 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
         emitToJS(EVENT_NAME_REQUEST_GET_HTML, null);
     }
 
-    public void updateHtml(String html) {
+    public void setHtmlInJS(String html) {
         WritableMap writableMap = new WritableNativeMap();
         writableMap.putString(MAP_KEY_UPDATE_HTML, html);
         emitToJS(EVENT_NAME_UPDATE_HTML, writableMap);

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -161,6 +161,8 @@ public class WPAndroidGlueCode {
             return;
         }
 
+        // Content can be set directly to RootView only once (per RootView instance)
+        // otherwise it should be done through module interface
         if (mShouldUpdateContent) {
             updateContent(postContent);
         } else {
@@ -180,7 +182,7 @@ public class WPAndroidGlueCode {
 
     private void updateContent(String content) {
         if (mReactContext != null) {
-            mRnReactNativeGutenbergBridgePackage.getRNReactNativeGutenbergBridgeModule().updateHtml(content);
+            mRnReactNativeGutenbergBridgePackage.getRNReactNativeGutenbergBridgeModule().setHtmlInJS(content);
         }
     }
 

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -38,6 +38,7 @@ public class WPAndroidGlueCode {
 
     private String mContentHtml = "";
     private boolean mContentChanged;
+    private boolean mShouldUpdateContent;
     private CountDownLatch mGetContentCountDownLatch;
 
     private static final String PROP_NAME_INITIAL_DATA = "initialData";
@@ -160,12 +161,27 @@ public class WPAndroidGlueCode {
             return;
         }
 
+        if (mShouldUpdateContent) {
+            updateContent(postContent);
+        } else {
+            mShouldUpdateContent = true;
+            initContent(postContent);
+        }
+    }
+
+    private void initContent(String content) {
         Bundle appProps = mReactRootView.getAppProperties();
         if (appProps == null) {
             appProps = new Bundle();
         }
-        appProps.putString(PROP_NAME_INITIAL_DATA, postContent);
+        appProps.putString(PROP_NAME_INITIAL_DATA, content);
         mReactRootView.setAppProperties(appProps);
+    }
+
+    private void updateContent(String content) {
+        if (mReactContext != null) {
+            mRnReactNativeGutenbergBridgePackage.getRNReactNativeGutenbergBridgeModule().updateHtml(content);
+        }
     }
 
     public interface OnGetContentTimeout {

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -162,7 +162,8 @@ public class WPAndroidGlueCode {
         }
 
         // Content can be set directly to RootView only once (per RootView instance)
-        // otherwise it should be done through module interface
+        // because we don't want to bootstrap the whole Gutenberg state.
+        // Otherwise it should be done through module interface
         if (mShouldUpdateContent) {
             updateContent(postContent);
         } else {


### PR DESCRIPTION
This PR adds the ability to update the editor content through the bridge. This is for being able to return back to a previous revision that parent app will provide(a.k.a. History feature).

To test:

It can be tested from the WPAndroid app based on [this PR](https://github.com/wordpress-mobile/WordPress-Android/pull/8768).