### PR TITLE
Upgrade react-native-svg to v8.0.9, use the forked lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "react-native-hr": "git+https://github.com/Riglerr/react-native-hr.git#2d01a5cf77212d100e8b99e0310cce5234f977b3",
     "react-native-modal": "^6.5.0",
     "react-native-recyclerview-list": "git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#v1.0.0",
-    "react-native-svg": "8.0.8",
+    "react-native-svg": "git+https://github.com/wordpress-mobile/react-native-svg.git#2b76859a986d35d741c9160aaad54aa46f268c6e",
     "react-redux": "^5.0.7",
     "redux": "^3.7.2",
     "redux-multi": "^0.1.12",

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -79,7 +79,7 @@ dependencies {
         implementation project(':react-native-aztec')
         implementation project(':react-native-recyclerview-list')
     } else {
-        implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-svg', 'faed05be8dca2b0df8957c5f72c40eccef12144d'))
+        implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-svg', '2b76859a986d35d741c9160aaad54aa46f268c6e'))
         implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-aztec', submoduleGitHash('../../', 'react-native-aztec')))
         implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-recyclerview-list', 'a2e8ca550412504c32218fd473c55f696f18f1f7'))
     }

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -20,6 +20,9 @@ apply from: 'https://gist.githubusercontent.com/hypest/e06f6097065728b6db7b7c462
 // import the `readReactNativeVersion()` function
 apply from: 'https://gist.githubusercontent.com/hypest/742448b9588b3a0aa580a5e80ae95bdf/raw/8eb62d40ee7a5104d2fcaeff21ce6f29bd93b054/readReactNativeVersion.gradle'
 
+// import the `readHashedVersion()` function
+apply from: 'https://gist.githubusercontent.com/hypest/ceaf20a8e7d9b8404e4a5ff2e6c36650/raw/e1460a128e4b9863963410d719c7d44c3adefd02/readHashedVersion.gradle'
+
 // import the `waitJitpack()` function
 apply from: 'https://gist.githubusercontent.com/hypest/f526fe0775dedce0ce0133f1400d22a4/raw/0008b271a0d28fc79957fd3c2a027f57e98f796a/wait-jitpack.gradle'
 
@@ -79,7 +82,7 @@ dependencies {
         implementation project(':react-native-aztec')
         implementation project(':react-native-recyclerview-list')
     } else {
-        implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-svg', '2b76859a986d35d741c9160aaad54aa46f268c6e'))
+        implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-svg', readHashedVersion('../../package.json', 'react-native-svg', 'dependencies')))
         implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-aztec', submoduleGitHash('../../', 'react-native-aztec')))
         implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-recyclerview-list', 'a2e8ca550412504c32218fd473c55f696f18f1f7'))
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7294,10 +7294,9 @@ react-native-sass-transformer@^1.1.1:
     css-to-react-native-transform "^1.7.0"
     semver "^5.5.0"
 
-react-native-svg@8.0.8:
-  version "8.0.8"
-  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-8.0.8.tgz#5d4c636751d9db2d98a9b3cfc4ef45c4eac65d60"
-  integrity sha512-a5q7896HJztH3XBa4MouuBcwhOvDsJXRZB/PPvEMvc4NhudIDXDUKpwd9V7Hm6beDjg5CjFIdE/c92jnVo+0CA==
+"react-native-svg@git+https://github.com/wordpress-mobile/react-native-svg.git#2b76859a986d35d741c9160aaad54aa46f268c6e":
+  version "8.0.9"
+  resolved "git+https://github.com/wordpress-mobile/react-native-svg.git#2b76859a986d35d741c9160aaad54aa46f268c6e"
   dependencies:
     color "^2.0.1"
     lodash "^4.16.6"


### PR DESCRIPTION
This PR:

- Upgrades to v8.0.9 of `react-native-svg`, needed to make the android build work (otherwise gradle complains with `Could not find com.android.tools.build:gradle:2.2.3`
- Start using the forked library, now at https://github.com/wordpress-mobile/react-native-svg, and especially the `feature/enable-android-build-of-standalone-package` branch. Background: we need to maintain the fork for now to have support for building `react-native-svg` as a standalone library via JitPack, used in the binary build pipeline of wpandroid ([See here](https://github.com/wordpress-mobile/gutenberg-mobile/blob/master/react-native-gutenberg-bridge/android/build.gradle#L82)).

To test:

* Run the demo app and notice that the various icons are working as before