### PR TITLE
Adding SafeAreaView to block-toolbar component.

### DIFF
--- a/src/block-management/block-toolbar.js
+++ b/src/block-management/block-toolbar.js
@@ -4,7 +4,7 @@
  */
 
 import React, { Component } from 'react';
-import { View, ScrollView } from 'react-native';
+import { View, ScrollView, SafeAreaView } from 'react-native';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { Toolbar, ToolbarButton } from '@wordpress/components';
@@ -36,43 +36,45 @@ export class BlockToolbar extends Component<PropsType> {
 		} = this.props;
 
 		return (
-			<View style={ styles.container }>
-				<ScrollView
-					horizontal={ true }
-					showsHorizontalScrollIndicator={ false }
-					keyboardShouldPersistTaps={ 'always' }
-					alwaysBounceHorizontal={ false }
-				>
-					<Toolbar>
-						<ToolbarButton
-							label={ __( 'Add block' ) }
-							icon="insert"
-							onClick={ onInsertClick }
-						/>
-						<ToolbarButton
-							label={ __( 'Undo' ) }
-							icon="undo"
-							isDisabled={ ! hasUndo }
-							onClick={ undo }
-						/>
-						<ToolbarButton
-							label={ __( 'Redo' ) }
-							icon="redo"
-							isDisabled={ ! hasRedo }
-							onClick={ redo }
-						/>
-					</Toolbar>
-					{ showKeyboardHideButton && ( <Toolbar>
-						<ToolbarButton
-							label={ __( 'Keyboard hide' ) }
-							icon="arrow-down"
-							onClick={ onKeyboardHide }
-						/>
-					</Toolbar> ) }
-					<BlockControls.Slot />
-					<BlockFormatControls.Slot />
-				</ScrollView>
-			</View>
+			<SafeAreaView>
+				<View style={ styles.container }>
+					<ScrollView
+						horizontal={ true }
+						showsHorizontalScrollIndicator={ false }
+						keyboardShouldPersistTaps={ 'always' }
+						alwaysBounceHorizontal={ false }
+					>
+						<Toolbar>
+							<ToolbarButton
+								label={ __( 'Add block' ) }
+								icon="insert"
+								onClick={ onInsertClick }
+							/>
+							<ToolbarButton
+								label={ __( 'Undo' ) }
+								icon="undo"
+								isDisabled={ ! hasUndo }
+								onClick={ undo }
+							/>
+							<ToolbarButton
+								label={ __( 'Redo' ) }
+								icon="redo"
+								isDisabled={ ! hasRedo }
+								onClick={ redo }
+							/>
+						</Toolbar>
+						{ showKeyboardHideButton && ( <Toolbar>
+							<ToolbarButton
+								label={ __( 'Keyboard hide' ) }
+								icon="arrow-down"
+								onClick={ onKeyboardHide }
+							/>
+						</Toolbar> ) }
+						<BlockControls.Slot />
+						<BlockFormatControls.Slot />
+					</ScrollView>
+				</View>
+			</SafeAreaView>
 		);
 	}
 }


### PR DESCRIPTION
Fixes #354 

This PR adds `SafeAreaView` to the toolbar to make it aware of iOS Safe Areas.

<img width="385" alt="screen shot 2018-12-12 at 11 24 24 am" src="https://user-images.githubusercontent.com/9772967/49859561-7e774180-fe00-11e8-8da8-5aaeeed4d771.png">

![safe_area](https://user-images.githubusercontent.com/9772967/49859545-6ef7f880-fe00-11e8-923f-7c546741a6bb.gif)


To Test:

- Build and run the iOS example project.
- Check that the tool bar is over the bottom safe area (as shown in the image).
- Tap on a block to show the keyboard.
- Check that the tool bar is still properly visible.

This should not affect Android.
- Check that Android toolbar is unchanged.


