### PR TITLE
Initial flag for html mode

### DIFF
--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -48,4 +48,8 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
             }
         });
     }
+
+    public void toggleEditorMode() {
+        emitToJS("toggleHTMLMode", null);
+    }
 }

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -201,5 +201,9 @@ public class WPAndroidGlueCode {
             mPendingMediaSelectedCallback = null;
         }
     }
+
+    public void toggleEditorMode() {
+        mRnReactNativeGutenbergBridgePackage.getRNReactNativeGutenbergBridgeModule().toggleEditorMode();
+    }
 }
 

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -41,6 +41,7 @@ public class WPAndroidGlueCode {
     private CountDownLatch mGetContentCountDownLatch;
 
     private static final String PROP_NAME_INITIAL_DATA = "initialData";
+    private static final String PROP_NAME_INITIAL_HTML_MODE_ENABLED = "initialHtmlModeEnabled";
 
     public void onCreate(Context context) {
         SoLoader.init(context, /* native exopackage */ false);
@@ -84,7 +85,8 @@ public class WPAndroidGlueCode {
                 mRnReactNativeGutenbergBridgePackage);
     }
 
-    public void onCreateView(View reactRootView, OnMediaLibraryButtonListener onMediaLibraryButtonListener,
+    public void onCreateView(View reactRootView, boolean htmlModeEnabled,
+                             OnMediaLibraryButtonListener onMediaLibraryButtonListener,
                              Application application, boolean isDebug, boolean buildGutenbergFromSource) {
         mReactRootView = (ReactRootView) reactRootView;
 
@@ -110,6 +112,7 @@ public class WPAndroidGlueCode {
             initialProps = new Bundle();
         }
         initialProps.putString(PROP_NAME_INITIAL_DATA, "");
+        initialProps.putBoolean(PROP_NAME_INITIAL_HTML_MODE_ENABLED, htmlModeEnabled);
 
 
         // The string here (e.g. "MyReactNativeApp") has to match

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -20,14 +20,15 @@ setUnregisteredTypeHandlerName( UnsupportedBlock.name );
 
 type PropsType = {
 	initialData: string,
+	initialHtmlModeEnabled: boolean,
 };
 
-const AppProvider = ( { initialData }: PropsType ) => {
+const AppProvider = ( { initialData, initialHtmlModeEnabled }: PropsType ) => {
 	if ( initialData === undefined ) {
 		initialData = initialHtml;
 	}
 	return (
-		<AppContainer initialHtml={ initialData } />
+		<AppContainer initialHtml={ initialData } initialHtmlModeEnabled={ initialHtmlModeEnabled } />
 	);
 };
 

--- a/src/app/AppContainer.js
+++ b/src/app/AppContainer.js
@@ -13,6 +13,7 @@ import type { BlockType } from '../store/types';
 type PropsType = {
 	rootClientId: ?string,
 	isBlockSelected: string => boolean,
+	initialHtmlModeEnabled: boolean,
 	showHtml: boolean,
 	editedPostContent: string,
 	selectedBlockIndex: number,
@@ -48,6 +49,11 @@ class AppContainer extends React.Component<PropsType> {
 
 		this.props.setupEditor( post );
 		this.lastHtml = serialize( parse( props.initialHtml ) );
+
+		if ( props.initialHtmlModeEnabled && ! props.showHtml ) {
+			// enable html mode if the initial mode the parent wants it but we're not already in it
+			this.toggleHtmlModeAction();
+		}
 	}
 
 	onChange = ( clientId, attributes ) => {


### PR DESCRIPTION
This PR adds support for setting the html/visual mode upon start-up. A flag passed down via the top-level props is used to signal this.

To test:
* Need to test this via the wpandroid app. Use this PR: https://github.com/wordpress-mobile/WordPress-Android/pull/8778