### PR TITLE
Adding gutenbergDidLoad to iOS Bridge.

### DIFF
--- a/ios/gutenberg/GutenbergViewController.swift
+++ b/ios/gutenberg/GutenbergViewController.swift
@@ -29,6 +29,10 @@ class GutenbergViewController: UIViewController {
 }
 
 extension GutenbergViewController: GutenbergBridgeDelegate {
+    func gutenbergDidLoad() {
+
+    }
+
     func gutenbergDidProvideHTML(_ html: String, changed: Bool) {
         print("Did receive HTML: \(html) changed: \(changed)")
     }

--- a/react-native-gutenberg-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/react-native-gutenberg-bridge/ios/GutenbergBridgeDelegate.swift
@@ -19,9 +19,3 @@ public protocol GutenbergBridgeDelegate: class {
     ///
     func gutenbergDidLoad()
 }
-
-// MARK: - Default / optional methods.
-
-extension GutenbergBridgeDelegate {
-    func gutenbergDidLoad() {}
-}

--- a/react-native-gutenberg-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/react-native-gutenberg-bridge/ios/GutenbergBridgeDelegate.swift
@@ -14,4 +14,14 @@ public protocol GutenbergBridgeDelegate: class {
     /// - Parameter callback: A callbak block to be called with the selected
     ///                       image Url or nil to signal that the action was canceled.
     func gutenbergDidRequestMediaPicker(with callback: @escaping MediaPickerDidPickMediaCallback)
+
+    /// Informs the delegate that the Gutenberg module has finished loading.
+    ///
+    func gutenbergDidLoad()
+}
+
+// MARK: - Default / optional methods.
+
+extension GutenbergBridgeDelegate {
+    func gutenbergDidLoad() {}
 }

--- a/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -1,6 +1,7 @@
 @objc (RNReactNativeGutenbergBridge)
 public class RNReactNativeGutenbergBridge: RCTEventEmitter {
     weak var delegate: GutenbergBridgeDelegate?
+    private var isJSLoading = true
 
     // MARK: - Messaging methods
 
@@ -34,6 +35,15 @@ extension RNReactNativeGutenbergBridge {
 
     public override static func requiresMainQueueSetup() -> Bool {
         return true
+    }
+
+    public override func batchDidComplete() {
+        if isJSLoading {
+            isJSLoading = false
+            DispatchQueue.main.async {
+                self.delegate?.gutenbergDidLoad()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This is necessary to solve #357 

The idea is to let the delegate knows when the Gutenberg module has finish loading.
There was an issue before when we try to show the keyboard on load, that the toolbar wasn't showing. That is because the keyboard was shown before the gutenberg module had time to finish loading.

Using this method, we can present the keyboard safely.

To test:
- Clean build folder of example app.
- Build and run the example app.
- Check that there are no errors.
- Follow the instructions from https://github.com/wordpress-mobile/WordPress-iOS/pull/10654
