### PR TITLE
Scroll to new block

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -62,7 +62,6 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 	keyboardDidShowListener: EventEmitter;
 	keyboardDidHideListener: EventEmitter;
 	list: FlatList;
-	viewabilityConfigCallbackPairs: mixed;
 	indexToScroll: ?number;
 
 	constructor( props: PropsType ) {

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -172,8 +172,8 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 		Keyboard.removeListener( keyboardDidHide, this.keyboardDidHide );
 	}
 
-	keyboardDidShow = ( { endCoordinates } ) => {
-		this.setState( { isKeyboardVisible: true, keyboardHeight: endCoordinates.height } );
+	keyboardDidShow = ( e: any ) => {
+		this.setState( { isKeyboardVisible: true, keyboardHeight: e.endCoordinates.height } );
 	}
 
 	keyboardDidHide = () => {

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -59,38 +59,16 @@ type StateType = {
 	keyboardHeight: number,
 };
 
-type ViewableItemInfoType = {
-	viewableItems: Array<ViewableItemType>,
-}
-
-type ViewableItemType = {
-	key: string,
-	item: BlockType,
-	isViewable: boolean,
-}
-
 export class BlockManager extends React.Component<PropsType, StateType> {
 	keyboardDidShowListener: EventEmitter;
 	keyboardDidHideListener: EventEmitter;
 	list: FlatList;
-	viewableItems: Array<ViewableItemType>;
 	viewabilityConfigCallbackPairs: mixed;
 
 	constructor( props: PropsType ) {
 		super( props );
 
 		( this: any ).onFlatListContentSizeChange = this.onFlatListContentSizeChange.bind( this );
-		( this: any ).handleViewableItemsChanged = this.handleViewableItemsChanged.bind( this );
-
-		this.viewabilityConfigCallbackPairs = [ {
-			viewabilityConfig: {
-				minimumViewTime: 100,
-				itemVisiblePercentThreshold: 50,
-			},
-			onViewableItemsChanged: this.handleViewableItemsChanged,
-		} ];
-
-		this.viewableItems = [];
 
 		const blocks = props.blocks.map( ( block ) => {
 			const newBlock = { ...block };
@@ -247,27 +225,17 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 		this.props.replaceBlock( clientId, block );
 	}
 
-	handleViewableItemsChanged( info: ViewableItemInfoType ) {
-		this.viewableItems = info.viewableItems;
-	}
-
-	isItemViewable( { clientId } ) { //returns true if item is in the viewport and visible to user
-		return this.viewableItems.filter( ( item ) => item.key === clientId ).length !== 0;
-	}
-
 	onFlatListContentSizeChange() {
 		const { selectedBlock } = this.props;
 
 		if ( this.state.indexToScroll && selectedBlock ) {
-			if ( ! this.isItemViewable( selectedBlock ) ) {
-				const scrollParams = {
-					animated: true,
-					index: this.state.indexToScroll,
-					viewPosition: 1, //1 represents scrolling to the bottom of the viewable area
-					viewOffset: -( this.state.keyboardHeight ), //offset from the bottom of the viewable area
-				};
-				this.list.scrollToIndex( scrollParams );
-			}
+			const scrollParams = {
+				animated: true,
+				index: this.state.indexToScroll,
+				viewPosition: 1, //1 represents scrolling to the bottom of the viewable area
+				viewOffset: -( this.state.keyboardHeight ), //offset from the bottom of the viewable area
+			};
+			this.list.scrollToIndex( scrollParams );
 			this.setState( { ...this.state, indexToScroll: null } ); //clear indexToScroll after we are done
 		}
 	}
@@ -282,7 +250,6 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 				} }
 				// FlatList needs this property set before you can call scrollToIndex,
 				onScrollToIndexFailed={ () => { } }
-				viewabilityConfigCallbackPairs={ this.viewabilityConfigCallbackPairs }
 				onContentSizeChange={ this.onFlatListContentSizeChange }
 				keyboardShouldPersistTaps="always"
 				style={ styles.list }

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -230,8 +230,7 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 			const scrollParams = {
 				animated: true,
 				index: this.indexToScroll,
-				viewPosition: 1, //1 represents scrolling to the bottom of the viewable area
-				viewOffset: -( this.state.keyboardHeight ), //offset from the bottom of the viewable area
+				viewPosition: 0, //0 represents scrolling to the top of the viewable area
 			};
 			this.list.scrollToIndex( scrollParams );
 			this.indexToScroll = null; //clear indexToScroll after we are done

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -55,7 +55,6 @@ type StateType = {
 	refresh: boolean,
 	isKeyboardVisible: boolean,
 	rootViewHeight: number,
-	indexToScroll: ?number,
 	keyboardHeight: number,
 };
 
@@ -64,6 +63,7 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 	keyboardDidHideListener: EventEmitter;
 	list: FlatList;
 	viewabilityConfigCallbackPairs: mixed;
+	indexToScroll: ?number;
 
 	constructor( props: PropsType ) {
 		super( props );
@@ -83,7 +83,6 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 			refresh: false,
 			isKeyboardVisible: false,
 			rootViewHeight: 0,
-			indexToScroll: null,
 			keyboardHeight: 0,
 		};
 	}
@@ -162,7 +161,7 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 		if ( this.props.blocks.length > prevProps.blocks.length ) { //if a new block is added recently
 			const indexToScroll = this.state.blocks.findIndex( ( block ) => block.focused );
 			if ( indexToScroll > -1 ) {
-				this.setState( { ...this.state, indexToScroll } );
+				this.indexToScroll = indexToScroll;
 			}
 		}
 	}
@@ -228,15 +227,15 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 	onFlatListContentSizeChange() {
 		const { selectedBlock } = this.props;
 
-		if ( this.state.indexToScroll && selectedBlock ) {
+		if ( this.indexToScroll && selectedBlock ) {
 			const scrollParams = {
 				animated: true,
-				index: this.state.indexToScroll,
+				index: this.indexToScroll,
 				viewPosition: 1, //1 represents scrolling to the bottom of the viewable area
 				viewOffset: -( this.state.keyboardHeight ), //offset from the bottom of the viewable area
 			};
 			this.list.scrollToIndex( scrollParams );
-			this.setState( { ...this.state, indexToScroll: null } ); //clear indexToScroll after we are done
+			this.indexToScroll = null; //clear indexToScroll after we are done
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/197

This change makes editor focus on the recently added block.

There are some inconsistencies that are still need to be addressed:

- Sometimes when we add a block the page is re-rendered all over again, we don't normally expect this to happen, when this happens scroll is set to the beginning and the recently created block is not viewable by user, with this PR it scrolls back to the recently created block after the re-render, but, the ideal solution would be preventing the unnecessary re-render first, because currently the scroll goes to the top and back and it doesn't look good enough I think. But I didn't have chance to prevent the re-render.

- scrollToIndex method is not working consistently, although we provide the correct scrolling position to scrollToIndex it isn't scrolling to the exact same position every time. This is another issue but I had no luck to make this work better, even if I tried to set viewPosition=0(top of the page) and viewOffset = 0 it doesn't always scroll to the top of the page. I can really use other point of views on this.

**To Test:**

- Add a new block to a position that is not viewable currently
- Verify that it becomes viewable
