### PR TITLE
[Bridge iOS]: Adding isLoading public variable.

### DIFF
--- a/react-native-gutenberg-bridge/ios/Gutenberg.swift
+++ b/react-native-gutenberg-bridge/ios/Gutenberg.swift
@@ -22,6 +22,10 @@ public class Gutenberg: NSObject {
         }
     }
 
+    public var isLoaded: Bool {
+        return !bridge.isLoading
+    }
+
     private let bridgeModule = RNReactNativeGutenbergBridge()
     private unowned let dataSource: GutenbergBridgeDataSource
 


### PR DESCRIPTION
This PR adds a `isLoading` public variable to the iOS Gutenberg bridge.
Needed for this PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/10674

To test:
- Refer to the previously mentioned PR.