### PR TITLE
[iOS]: Make post content aware of Safe Areas.

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -6,7 +6,7 @@
 import React from 'react';
 import { isEqual } from 'lodash';
 
-import { Text, View, FlatList, Keyboard, LayoutChangeEvent } from 'react-native';
+import { Text, View, FlatList, Keyboard, LayoutChangeEvent, SafeAreaView } from 'react-native';
 import BlockHolder from './block-holder';
 import { InlineToolbarActions } from './inline-toolbar';
 import type { BlockType } from '../store/types';
@@ -253,11 +253,11 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 		);
 
 		return (
-			<View style={ styles.container } onLayout={ this.onRootViewLayout }>
+			<SafeAreaView style={ styles.container } onLayout={ this.onRootViewLayout }>
 				{ this.props.showHtml && this.renderHTML() }
 				{ ! this.props.showHtml && list }
 				{ this.state.blockTypePickerVisible && blockTypePicker }
-			</View>
+			</SafeAreaView>
 		);
 	}
 


### PR DESCRIPTION
This PR adds a `SafeAreaView` to block-manager content. This makes the content aware of iOS safe areas.

The use of `SafeAreaView` should not affect Android in any way.

<img width="819" alt="screen shot 2018-12-17 at 1 25 41 pm" src="https://user-images.githubusercontent.com/9772967/50084316-4193bc00-01ff-11e9-9f83-678d3ed4d297.png">

To test:
- Run `yarn ios` (it should open a iPhone X simulator)
- Set the simulator on LandScape.
- Check that the content looks like in the screenshot.
- Check that the same is true for the HTML view.