### PR TITLE
Sending `editorDidLayout` message to Native Bridge side.

### DIFF
--- a/react-native-gutenberg-bridge/index.js
+++ b/react-native-gutenberg-bridge/index.js
@@ -12,7 +12,7 @@ const gutenbergBridgeEvents = new NativeEventEmitter( RNReactNativeGutenbergBrid
 export function sendNativeEditorDidLayout() {
 	// For now, this is only needed on iOS to solve layout issues with the toolbar.
 	// If this become necessary on Android in the future, we can try to build a registration API from Native
-	// to register messages it wants to receive, similar to the Natice -> JS messages listener system.
+	// to register messages it wants to receive, similar to the Native -> JS messages listener system.
 	if ( isIOS ) {
 		RNReactNativeGutenbergBridge.editorDidLayout();
 	}

--- a/react-native-gutenberg-bridge/index.js
+++ b/react-native-gutenberg-bridge/index.js
@@ -3,7 +3,7 @@
 import { NativeModules, NativeEventEmitter, Platform } from 'react-native';
 
 const { RNReactNativeGutenbergBridge } = NativeModules;
-const isIOS: boolean = Platform.OS === 'ios';
+const isIOS = Platform.OS === 'ios';
 
 const gutenbergBridgeEvents = new NativeEventEmitter( RNReactNativeGutenbergBridge );
 
@@ -13,7 +13,7 @@ export function sendNativeEditorDidLayout() {
 	// For now, this is only needed on iOS to solve layout issues with the toolbar.
 	// If this become necessary on Android in the future, we can try to build a registration API from Native
 	// to register messages it wants to receive, similar to the Natice -> JS messages listener system.
-	if (isIOS) {
+	if ( isIOS ) {
 		RNReactNativeGutenbergBridge.editorDidLayout();
 	}
 }

--- a/react-native-gutenberg-bridge/index.js
+++ b/react-native-gutenberg-bridge/index.js
@@ -1,10 +1,24 @@
 /** @format */
 
-import { NativeModules, NativeEventEmitter } from 'react-native';
+import { NativeModules, NativeEventEmitter, Platform } from 'react-native';
 
 const { RNReactNativeGutenbergBridge } = NativeModules;
+const isIOS: boolean = Platform.OS === 'ios';
 
 const gutenbergBridgeEvents = new NativeEventEmitter( RNReactNativeGutenbergBridge );
+
+// Send messages
+
+export function sendNativeEditorDidLayout() {
+	// For now, this is only needed on iOS to solve layout issues with the toolbar.
+	// If this become necessary on Android in the future, we can try to build a registration API from Native
+	// to register messages it wants to receive, similar to the Natice -> JS messages listener system.
+	if (isIOS) {
+		RNReactNativeGutenbergBridge.editorDidLayout();
+	}
+}
+
+// Register listeners
 
 export function subscribeParentGetHtml( callback ) {
 	return gutenbergBridgeEvents.addListener( 'requestGetHtml', callback );

--- a/react-native-gutenberg-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/react-native-gutenberg-bridge/ios/GutenbergBridgeDelegate.swift
@@ -15,7 +15,19 @@ public protocol GutenbergBridgeDelegate: class {
     ///                       image Url or nil to signal that the action was canceled.
     func gutenbergDidRequestMediaPicker(with callback: @escaping MediaPickerDidPickMediaCallback)
 
-    /// Informs the delegate that the Gutenberg module has finished loading.
+    /// Tells the delegate that the Gutenberg module has finished loading.
     ///
     func gutenbergDidLoad()
+
+
+    /// Tells the delegate every time the editor has finished layout.
+    ///
+    func gutenbergDidLayout()
+}
+
+// MARK: - Optional GutenbergBridgeDelegate methods
+
+public extension GutenbergBridgeDelegate {
+    func gutenbergDidLoad() { }
+    func gutenbergDidLayout() { }
 }

--- a/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.m
+++ b/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.m
@@ -4,6 +4,6 @@
 
 RCT_EXTERN_METHOD(provideToNative_Html:(NSString *)html changed:(BOOL)changed)
 RCT_EXTERN_METHOD(onMediaLibraryPress:(RCTResponseSenderBlock)callback)
-RCT_EXTERN_METHOD(moduleDidMount)
+RCT_EXTERN_METHOD(editorDidLayout)
 
 @end

--- a/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -1,6 +1,7 @@
 @objc (RNReactNativeGutenbergBridge)
 public class RNReactNativeGutenbergBridge: RCTEventEmitter {
     weak var delegate: GutenbergBridgeDelegate?
+    private var isJSLoading = true
 
     // MARK: - Messaging methods
 
@@ -21,9 +22,9 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
     }
 
     @objc
-    func moduleDidMount() {
+    func editorDidLayout() {
         DispatchQueue.main.async {
-            self.delegate?.gutenbergDidLoad()
+            self.delegate?.gutenbergDidLayout()
         }
     }
 }
@@ -41,6 +42,15 @@ extension RNReactNativeGutenbergBridge {
 
     public override static func requiresMainQueueSetup() -> Bool {
         return true
+    }
+
+    public override func batchDidComplete() {
+        if isJSLoading {
+            isJSLoading = false
+            DispatchQueue.main.async {
+                self.delegate?.gutenbergDidLoad()
+            }
+        }
     }
 }
 

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -8,7 +8,6 @@ import React from 'react';
 // Gutenberg imports
 import { registerCoreBlocks } from '@wordpress/block-library';
 import { registerBlockType, setUnregisteredTypeHandlerName } from '@wordpress/blocks';
-import RNReactNativeGutenbergBridge from 'react-native-gutenberg-bridge';
 
 import AppContainer from './AppContainer';
 import initialHtml from './initial-html';
@@ -24,26 +23,13 @@ type PropsType = {
 	initialHtmlModeEnabled: boolean,
 };
 
-class AppProvider extends React.Component<PropsType> {
-	componentDidMount() {
-		// At this points (apparently) component setup haven't finished yet.
-		// Giving it one extra milisecond does the trick.
-		setTimeout( () => {
-			RNReactNativeGutenbergBridge.moduleDidMount();
-		}, 1 );
+const AppProvider = ( { initialData, initialHtmlModeEnabled }: PropsType ) => {
+	if ( initialData === undefined ) {
+		initialData = initialHtml;
 	}
-
-	render() {
-		let { initialData } = this.props;
-
-		if ( initialData === undefined ) {
-			initialData = initialHtml;
-		}
-
-		return (
-			<AppContainer initialHtml={ initialData } initialHtmlModeEnabled={ this.props.initialHtmlModeEnabled } />
-		);
-	}
-}
+	return (
+		<AppContainer initialHtml={ initialData } initialHtmlModeEnabled={ initialHtmlModeEnabled } />
+	);
+};
 
 export default AppProvider;

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -21,6 +21,7 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { createBlock, isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { DefaultBlockAppender } from '@wordpress/editor';
+import RNReactNativeGutenbergBridge from 'react-native-gutenberg-bridge';
 
 import EventEmitter from 'events';
 
@@ -142,7 +143,9 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 
 	onRootViewLayout = ( event: LayoutChangeEvent ) => {
 		const { height } = event.nativeEvent.layout;
-		this.setState( { rootViewHeight: height } );
+		this.setState( { rootViewHeight: height }, () => {
+			RNReactNativeGutenbergBridge.editorDidLayout();
+		} );
 	}
 
 	componentDidMount() {

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -24,7 +24,7 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { createBlock, isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { DefaultBlockAppender } from '@wordpress/editor';
-import RNReactNativeGutenbergBridge from 'react-native-gutenberg-bridge';
+import { sendNativeEditorDidLayout } from 'react-native-gutenberg-bridge';
 
 import EventEmitter from 'events';
 
@@ -151,7 +151,7 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 	onRootViewLayout = ( event: LayoutChangeEvent ) => {
 		const { height } = event.nativeEvent.layout;
 		this.setState( { rootViewHeight: height }, () => {
-			RNReactNativeGutenbergBridge.editorDidLayout();
+			sendNativeEditorDidLayout();
 		} );
 	}
 

--- a/src/block-management/block-toolbar.js
+++ b/src/block-management/block-toolbar.js
@@ -4,7 +4,7 @@
  */
 
 import React, { Component } from 'react';
-import { View, ScrollView, SafeAreaView } from 'react-native';
+import { View, ScrollView } from 'react-native';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { Toolbar, ToolbarButton } from '@wordpress/components';
@@ -36,43 +36,43 @@ export class BlockToolbar extends Component<PropsType> {
 		} = this.props;
 
 		return (
-				<View style={ styles.container }>
-					<ScrollView
-						horizontal={ true }
-						showsHorizontalScrollIndicator={ false }
-						keyboardShouldPersistTaps={ 'always' }
-						alwaysBounceHorizontal={ false }
-					>
-						<Toolbar>
-							<ToolbarButton
-								label={ __( 'Add block' ) }
-								icon="insert"
-								onClick={ onInsertClick }
-							/>
-							<ToolbarButton
-								label={ __( 'Undo' ) }
-								icon="undo"
-								isDisabled={ ! hasUndo }
-								onClick={ undo }
-							/>
-							<ToolbarButton
-								label={ __( 'Redo' ) }
-								icon="redo"
-								isDisabled={ ! hasRedo }
-								onClick={ redo }
-							/>
-						</Toolbar>
-						{ showKeyboardHideButton && ( <Toolbar>
-							<ToolbarButton
-								label={ __( 'Keyboard hide' ) }
-								icon="arrow-down"
-								onClick={ onKeyboardHide }
-							/>
-						</Toolbar> ) }
-						<BlockControls.Slot />
-						<BlockFormatControls.Slot />
-					</ScrollView>
-				</View>
+			<View style={ styles.container }>
+				<ScrollView
+					horizontal={ true }
+					showsHorizontalScrollIndicator={ false }
+					keyboardShouldPersistTaps={ 'always' }
+					alwaysBounceHorizontal={ false }
+				>
+					<Toolbar>
+						<ToolbarButton
+							label={ __( 'Add block' ) }
+							icon="insert"
+							onClick={ onInsertClick }
+						/>
+						<ToolbarButton
+							label={ __( 'Undo' ) }
+							icon="undo"
+							isDisabled={ ! hasUndo }
+							onClick={ undo }
+						/>
+						<ToolbarButton
+							label={ __( 'Redo' ) }
+							icon="redo"
+							isDisabled={ ! hasRedo }
+							onClick={ redo }
+						/>
+					</Toolbar>
+					{ showKeyboardHideButton && ( <Toolbar>
+						<ToolbarButton
+							label={ __( 'Keyboard hide' ) }
+							icon="arrow-down"
+							onClick={ onKeyboardHide }
+						/>
+					</Toolbar> ) }
+					<BlockControls.Slot />
+					<BlockFormatControls.Slot />
+				</ScrollView>
+			</View>
 		);
 	}
 }

--- a/src/block-management/block-toolbar.js
+++ b/src/block-management/block-toolbar.js
@@ -36,7 +36,6 @@ export class BlockToolbar extends Component<PropsType> {
 		} = this.props;
 
 		return (
-			<SafeAreaView>
 				<View style={ styles.container }>
 					<ScrollView
 						horizontal={ true }
@@ -74,7 +73,6 @@ export class BlockToolbar extends Component<PropsType> {
 						<BlockFormatControls.Slot />
 					</ScrollView>
 				</View>
-			</SafeAreaView>
 		);
 	}
 }


### PR DESCRIPTION
This PR is meant to solve a problem on iOS, where the toolbar is wrongly positioned when is automatically presented on load (WPiOS)

https://github.com/wordpress-mobile/gutenberg-mobile/pull/386 Added a `SafeAreaView` to `block-manager`. This affects the layout calculations but it's normally not a problem.

The problem happens when we try to present the toolbar before that calculation is resolved (before onLayout is called).

The idea of `editorDidLayout` is to let the Native side know when this happens, so it can present the keyboard at an appropriate time, so the toolbar displays correctly.

Check https://github.com/wordpress-mobile/WordPress-iOS/pull/10682 for more info and how to test it.