### PR TITLE
iOS Only - Re-arrange scroll position of text inputs on landscape mode

### DIFF
--- a/src/components/keyboard-aware-flat-list.android.js
+++ b/src/components/keyboard-aware-flat-list.android.js
@@ -2,7 +2,8 @@
 * @format
 * @flow
 */
-import { FlatList, KeyboardAvoidingView } from 'react-native';
+import { FlatList } from 'react-native';
+import KeyboardAvoidingView from '../components/keyboard-avoiding-view';
 
 type PropsType = {
 	...FlatList.propTypes,

--- a/src/components/keyboard-aware-flat-list.ios.js
+++ b/src/components/keyboard-aware-flat-list.ios.js
@@ -27,11 +27,11 @@ const KeyboardAwareFlatList = ( props: PropsType ) => {
 		const { height: fullHeight, width: fullWidth } = Dimensions.get( 'window' );
 		const keyboardVerticalOffset = fullHeight - parentHeight;
 		const blockHolderPadding = 8;
-		
+
 		if ( fullWidth > fullHeight ) { //landscape mode
 			//we won't try to make inner block visible in landscape mode because there's not enough room for it
 			return blockToolbarHeight + keyboardVerticalOffset;
-		} 
+		}
 		//portrait mode
 		return blockToolbarHeight + keyboardVerticalOffset + blockHolderPadding + innerToolbarHeight;
 	} )();

--- a/src/components/keyboard-aware-flat-list.ios.js
+++ b/src/components/keyboard-aware-flat-list.ios.js
@@ -22,10 +22,19 @@ const KeyboardAwareFlatList = ( props: PropsType ) => {
 		shouldPreventAutomaticScroll,
 		...listProps
 	} = props;
-	const { height: fullHeight } = Dimensions.get( 'window' );
-	const keyboardVerticalOffset = fullHeight - parentHeight;
-	const blockHolderPadding = 8;
-	const extraScrollHeight = blockToolbarHeight + innerToolbarHeight + blockHolderPadding + keyboardVerticalOffset;
+
+	const extraScrollHeight = ( () => {
+		const { height: fullHeight, width: fullWidth } = Dimensions.get( 'window' );
+		const keyboardVerticalOffset = fullHeight - parentHeight;
+		const blockHolderPadding = 8;
+		
+		if ( fullWidth > fullHeight ) { //landscape mode
+			//we won't try to make inner block visible in landscape mode because there's not enough room for it
+			return blockToolbarHeight + keyboardVerticalOffset;
+		} 
+		//portrait mode
+		return blockToolbarHeight + keyboardVerticalOffset + blockHolderPadding + innerToolbarHeight;
+	} )();
 
 	return (
 		<KeyboardAwareScrollView


### PR DESCRIPTION
This PR re-arranges the scrolling offset of text inputs for landscape mode.

We are showing the inner toolbar in portrait mode but in landscape mode we don't have room for it so we won't show that.

Before:

![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/5032900/50160250-dd015b80-02e9-11e9-83af-57a8f1fa0fe5.gif)

After:
![ezgif com-video-to-gif 2](https://user-images.githubusercontent.com/5032900/50160416-5ac56700-02ea-11e9-8291-23480a5d88ff.gif)

Fixes part of https://github.com/wordpress-mobile/gutenberg-mobile/issues/197

**To Test**

Test 1 - Landscape mode

- Open a blog post on WPiOS app
- Switch to landscape mode
- Add one of the text input blocks with the return button on keyboard
- Verify that focused field is viewable
- Add one of the text input blocks with (+) button
- Verify that focused field is viewable
- Close the keyboard, focus again on one of the text input blocks
- Verify that focused field is viewable

Test 2 - Portait mode

- Open a blog post on WPiOS app
- Switch to portrait mode
- Add one of the text input blocks with the return button on keyboard
- Verify that focused field is viewable with the inner toolbar
- Add one of the text input blocks with (+) button
- Verify that focused field is viewable with the inner toolbar
- Close the keyboard, focus again on one of the text input blocks
- Verify that focused field is viewable with the inner toolbar