### PR TITLE
Remove block top/bottom padding

### DIFF
--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -80,7 +80,7 @@ export class BlockHolder extends React.Component<PropsType> {
 			<TouchableWithoutFeedback onPress={ this.props.onSelect } >
 				<View style={ [ styles.blockHolder, focused && styles.blockHolderFocused ] }>
 					{ this.props.showTitle && this.renderBlockTitle() }
-					<View style={ styles.blockContainer }>{ this.getBlockForType() }</View>
+					<View style={ [ !focused && styles.blockContainer, focused && styles.blockContainerFocused ] }>{ this.getBlockForType() }</View>
 					{ this.renderToolbarIfBlockFocused() }
 				</View>
 			</TouchableWithoutFeedback>

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -80,7 +80,7 @@ export class BlockHolder extends React.Component<PropsType> {
 			<TouchableWithoutFeedback onPress={ this.props.onSelect } >
 				<View style={ [ styles.blockHolder, focused && styles.blockHolderFocused ] }>
 					{ this.props.showTitle && this.renderBlockTitle() }
-					<View style={ [ !focused && styles.blockContainer, focused && styles.blockContainerFocused ] }>{ this.getBlockForType() }</View>
+					<View style={ [ ! focused && styles.blockContainer, focused && styles.blockContainerFocused ] }>{ this.getBlockForType() }</View>
 					{ this.renderToolbarIfBlockFocused() }
 				</View>
 			</TouchableWithoutFeedback>

--- a/src/block-management/block-holder.scss
+++ b/src/block-management/block-holder.scss
@@ -15,8 +15,10 @@
 
 .blockContainer {
 	background-color: white;
-	padding-left: 8;
-	padding-right: 8;
+	padding-left: 16;
+	padding-right: 16;
+	padding-top: 12;
+	padding-bottom: 12;
 }
 
 .blockTitle {
@@ -32,8 +34,6 @@
 	padding-bottom: 8;
 	padding-left: 8;
 	padding-right: 8;
-	margin-top: 12;
-	margin-bottom: 12;
 }
 
 .unsupportedBlockImagePlaceholder {

--- a/src/block-management/block-holder.scss
+++ b/src/block-management/block-holder.scss
@@ -32,6 +32,8 @@
 	padding-bottom: 8;
 	padding-left: 8;
 	padding-right: 8;
+	margin-top: 12;
+	margin-bottom: 12;
 }
 
 .unsupportedBlockImagePlaceholder {

--- a/src/block-management/block-holder.scss
+++ b/src/block-management/block-holder.scss
@@ -11,6 +11,7 @@
 	border-color: $gray-lighten-30;
 	border-top-width: 1px;
 	border-bottom-width: 1px;
+	padding-bottom: -12;
 }
 
 .blockContainer {
@@ -19,6 +20,14 @@
 	padding-right: 16;
 	padding-top: 12;
 	padding-bottom: 12;
+}
+
+.blockContainerFocused {
+	background-color: white;
+	padding-left: 16;
+	padding-right: 16;
+	padding-top: 12;
+	padding-bottom: 0; // will be flushed into inline toolbar height
 }
 
 .blockTitle {

--- a/src/block-management/block-holder.scss
+++ b/src/block-management/block-holder.scss
@@ -15,7 +15,8 @@
 
 .blockContainer {
 	background-color: white;
-	padding: 8px;
+	padding-left: 8;
+	padding-right: 8;
 }
 
 .blockTitle {

--- a/src/block-management/block-holder.scss
+++ b/src/block-management/block-holder.scss
@@ -11,7 +11,6 @@
 	border-color: $gray-lighten-30;
 	border-top-width: 1px;
 	border-bottom-width: 1px;
-	padding-bottom: -12;
 }
 
 .blockContainer {


### PR DESCRIPTION
Fixes #393 

Removes the top/bottom padding on `block-container` as it was adding an unneeded extra space.

Before:
<img width="337" alt="screen shot 2018-12-18 at 11 57 55" src="https://user-images.githubusercontent.com/6597771/50162758-d8bf4900-02bd-11e9-858e-1d9431dd85a3.png">


After:
<img width="372" alt="screen shot 2018-12-18 at 11 56 39" src="https://user-images.githubusercontent.com/6597771/50162767-de1c9380-02bd-11e9-9e4c-24f66eeec361.png">


Before (WPAndroid):
<img width="312" alt="screen shot 2018-12-18 at 12 02 18" src="https://user-images.githubusercontent.com/6597771/50162820-f55b8100-02bd-11e9-9e85-f7b830b0e421.png">


After (WPAndroid):
<img width="311" alt="screen shot 2018-12-18 at 12 03 29" src="https://user-images.githubusercontent.com/6597771/50162831-fb516200-02bd-11e9-8697-c399488a5b87.png">


Before (demo app on iOS):
<img width="369" alt="screen shot 2018-12-18 at 12 13 50" src="https://user-images.githubusercontent.com/6597771/50163452-36a06080-02bf-11e9-89cf-d17d7e19e395.png">



After (demo app on iOS):

<img width="387" alt="screen shot 2018-12-18 at 12 19 03" src="https://user-images.githubusercontent.com/6597771/50163461-3d2ed800-02bf-11e9-88c1-a178b9cfb7bb.png">
