### PR TITLE
Use Bintray mirror of RN when not building from source

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "react-native-keyboard-aware-scroll-view": "^0.8.0",
     "react-native-modal": "^6.5.0",
     "react-native-recyclerview-list": "git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#v1.0.0",
-    "react-native-svg": "git+https://github.com/wordpress-mobile/react-native-svg.git#2b76859a986d35d741c9160aaad54aa46f268c6e",
+    "react-native-svg": "git+https://github.com/wordpress-mobile/react-native-svg.git#8ce1cc8a0d40602850c4c83ef6462af11e654b18",
     "react-redux": "^5.0.7",
     "redux": "^3.7.2",
     "redux-multi": "^0.1.12",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "react-native-keyboard-aware-scroll-view": "^0.8.0",
     "react-native-modal": "^6.5.0",
     "react-native-recyclerview-list": "git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#v1.0.0",
-    "react-native-svg": "git+https://github.com/wordpress-mobile/react-native-svg.git#8ce1cc8a0d40602850c4c83ef6462af11e654b18",
+    "react-native-svg": "git+https://github.com/wordpress-mobile/react-native-svg.git#cd9e20d1a2788e1d2907e1daeefe9d3002cb678e",
     "react-redux": "^5.0.7",
     "redux": "^3.7.2",
     "redux-multi": "^0.1.12",

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     } else {
         implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-svg', readHashedVersion('../../package.json', 'react-native-svg', 'dependencies')))
         implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-aztec', submoduleGitHash('../../', 'react-native-aztec')))
-        implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-recyclerview-list', 'dc8284f995576b3e6289bc4fc33134c962a0902b'))
+        implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-recyclerview-list', 'f845b3c2c4411b8e97db23724bf1a535530c5435'))
     }
 
     def rnVersion = readReactNativeVersion('../package.json', 'peerDependencies')

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -71,12 +71,14 @@ dependencies {
         implementation project(':react-native-svg')
         implementation project(':react-native-aztec')
         implementation project(':react-native-recyclerview-list')
+
+        implementation 'com.facebook.react:react-native:+'
     } else {
         implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-svg', readHashedVersion('../../package.json', 'react-native-svg', 'dependencies')))
         implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-aztec', submoduleGitHash('../../', 'react-native-aztec')))
         implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-recyclerview-list', 'f845b3c2c4411b8e97db23724bf1a535530c5435'))
-    }
 
-    def rnVersion = readReactNativeVersion('../package.json', 'peerDependencies')
-    implementation "com.facebook.react:react-native:${rnVersion}"
+        def rnVersion = readReactNativeVersion('../package.json', 'peerDependencies')
+        implementation "com.facebook.react:react-native:${rnVersion}"
+    }
 }

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -46,32 +46,22 @@ android {
     }
 }
 
-def cdnOrNodeModules(remotePath, localPath) {
-    def url
-    if (rootProject.ext.buildGutenbergFromSource) {
-        url = "${project.buildDir}/../../../node_modules/${localPath}"
-    } else {
-        // if we are the root project, use a remote maven repo so jitpack can build this lib without local RN setup
-        url = "https://cdn.jsdelivr.net/npm/${remotePath}"
-        println "Will use the jsdelivr.net exposed maven repo at ${url}"
-    }
-    return url
-}
-
 repositories {
     google()
     jcenter()
 
     maven { url "https://jitpack.io" }
 
-    maven {
-        // All of React Native (JS, Obj-C sources, Android binaries)
-        def rnVersion = readReactNativeVersion('../package.json', 'peerDependencies')
-        url cdnOrNodeModules("react-native@${rnVersion}/android", "react-native/android")
-    }
-    maven {
-        // Maven repo containing AARs with JSC library built for Android
-        url cdnOrNodeModules("jsc-android@224109.1.0/dist/", "jsc-android/dist")
+    if (rootProject.ext.buildGutenbergFromSource) {
+        // If building from source, use the local sources from node_modules
+        def nodeModulesPath = "${project.buildDir}/../../../node_modules/"
+        maven { url "${nodeModulesPath}/react-native/android" }
+        maven { url "${nodeModulesPath}/jsc-android/dist" }
+    } else {
+        // If not building from source (e.g. Jitpack), use the bintray repo so a local RN setup is not needed
+        def reactNativeRepo = 'https://dl.bintray.com/wordpress-mobile/react-native-mirror/'
+        println "Will use the RN maven repo at ${reactNativeRepo}"
+        maven { url reactNativeRepo }
     }
 }
 
@@ -84,7 +74,9 @@ dependencies {
     } else {
         implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-svg', readHashedVersion('../../package.json', 'react-native-svg', 'dependencies')))
         implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-aztec', submoduleGitHash('../../', 'react-native-aztec')))
-        implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-recyclerview-list', 'a2e8ca550412504c32218fd473c55f696f18f1f7'))
+        implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-recyclerview-list', 'dc8284f995576b3e6289bc4fc33134c962a0902b'))
     }
-    implementation 'com.facebook.react:react-native:+'
+
+    def rnVersion = readReactNativeVersion('../package.json', 'peerDependencies')
+    implementation "com.facebook.react:react-native:${rnVersion}"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7355,9 +7355,9 @@ react-native-sass-transformer@^1.1.1:
     css-to-react-native-transform "^1.7.0"
     semver "^5.5.0"
 
-"react-native-svg@git+https://github.com/wordpress-mobile/react-native-svg.git#8ce1cc8a0d40602850c4c83ef6462af11e654b18":
+"react-native-svg@git+https://github.com/wordpress-mobile/react-native-svg.git#cd9e20d1a2788e1d2907e1daeefe9d3002cb678e":
   version "8.0.9"
-  resolved "git+https://github.com/wordpress-mobile/react-native-svg.git#8ce1cc8a0d40602850c4c83ef6462af11e654b18"
+  resolved "git+https://github.com/wordpress-mobile/react-native-svg.git#cd9e20d1a2788e1d2907e1daeefe9d3002cb678e"
   dependencies:
     color "^2.0.1"
     lodash "^4.16.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7355,9 +7355,9 @@ react-native-sass-transformer@^1.1.1:
     css-to-react-native-transform "^1.7.0"
     semver "^5.5.0"
 
-"react-native-svg@git+https://github.com/wordpress-mobile/react-native-svg.git#2b76859a986d35d741c9160aaad54aa46f268c6e":
+"react-native-svg@git+https://github.com/wordpress-mobile/react-native-svg.git#8ce1cc8a0d40602850c4c83ef6462af11e654b18":
   version "8.0.9"
-  resolved "git+https://github.com/wordpress-mobile/react-native-svg.git#2b76859a986d35d741c9160aaad54aa46f268c6e"
+  resolved "git+https://github.com/wordpress-mobile/react-native-svg.git#8ce1cc8a0d40602850c4c83ef6462af11e654b18"
   dependencies:
     color "^2.0.1"
     lodash "^4.16.6"


### PR DESCRIPTION
Currently we use the jsdelivr.net CDN as a pseudo maven repo to fetch React Native when building form source.  This has caused some issues, including repeated failed builds. An issue for this is here: https://github.com/wordpress-mobile/WordPress-Android/issues/8783

This PR solves this by replacing our usage of the CDN with an actual Maven repo where we are mirroring the React Native dependencies. I will follow up with another PR to automate uploading to that repo when we update React Native.

The maven repo is here: https://bintray.com/wordpress-mobile/react-native-mirror

Related PRs:
- https://github.com/wordpress-mobile/react-native-aztec/pull/100
- https://github.com/wordpress-mobile/react-native-recyclerview-list/pull/13
- https://github.com/wordpress-mobile/react-native-svg/pull/1

Test:

- The build succeeds on Jitpack: https://jitpack.io/com/github/wordpress-mobile/gutenberg-mobile/3823a787c9/build.log
- Building from source still works as expected: `yarn android`