### PR TITLE
[Alpha] Hide the keyboard when tapping on non-inputField block

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -72,6 +72,7 @@ node_modules/react-native/Libraries/react-native/react-native-interface.js
 node_modules/react-native/flow/
 node_modules/expo/flow/
 libdefs.js
+flow-typed
 
 [options]
 emoji=true

--- a/flow-typed/TextInputState.js
+++ b/flow-typed/TextInputState.js
@@ -1,0 +1,4 @@
+// @flow
+declare module 'react-native/lib/TextInputState' {
+    declare module.exports: any;
+}

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -110,12 +110,12 @@ export default compose( [
 		return {
 			onSelect: (event) => {
 				if ( event ) {
-					// This fix an issue with the way we are handling focus on TextIput fields and handling the keyboard state.
-					// When moving from a TextInput field to another kind of field the call that hides the keyboard was not invoked properly,
-					// resulting in keyboard up when it should not be there.
+					// == Hack for the Alpha ==
+					// When moving the focus from a TextInput field to another kind of field the call that hides the keyboard is not invoked 
+					// properly, resulting in keyboard up when it should not be there.
+					// The code below dismisses the keyboard (calling blur on the last TextInput field) when the field that now gets the focus is a non-textual field
 					const currentlyFocusedTextInput = TextInputState.currentlyFocusedField();
 					if ( event.nativeEvent.target !== currentlyFocusedTextInput && ! TextInputState.isTextInput( event.nativeEvent.target ) ) {
-						// This check that the current TextInputState "focused" field is the one that has the focus.
 						TextInputState.blurTextInput( currentlyFocusedTextInput );
 					}
 				}

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -108,10 +108,10 @@ export default compose( [
 		} = dispatch( 'core/editor' );
 
 		return {
-			onSelect: (event) => {
+			onSelect: ( event ) => {
 				if ( event ) {
 					// == Hack for the Alpha ==
-					// When moving the focus from a TextInput field to another kind of field the call that hides the keyboard is not invoked 
+					// When moving the focus from a TextInput field to another kind of field the call that hides the keyboard is not invoked
 					// properly, resulting in keyboard up when it should not be there.
 					// The code below dismisses the keyboard (calling blur on the last TextInput field) when the field that now gets the focus is a non-textual field
 					const currentlyFocusedTextInput = TextInputState.currentlyFocusedField();

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -17,6 +17,8 @@ import styles from './block-holder.scss';
 // Gutenberg imports
 import { BlockEdit } from '@wordpress/editor';
 
+import TextInputState from 'react-native/lib/TextInputState';
+
 type PropsType = BlockType & {
 	isSelected: boolean,
 	showTitle: boolean,
@@ -106,7 +108,17 @@ export default compose( [
 		} = dispatch( 'core/editor' );
 
 		return {
-			onSelect: () => {
+			onSelect: (event) => {
+				if ( event ) {
+					// This fix an issue with the way we are handling focus on TextIput fields and handling the keyboard state.
+					// When moving from a TextInput field to another kind of field the call that hides the keyboard was not invoked properly,
+					// resulting in keyboard up when it should not be there.
+					const currentlyFocusedTextInput = TextInputState.currentlyFocusedField();
+					if ( event.nativeEvent.target !== currentlyFocusedTextInput && ! TextInputState.isTextInput( event.nativeEvent.target ) ) {
+						// This check that the current TextInputState "focused" field is the one that has the focus.
+						TextInputState.blurTextInput( currentlyFocusedTextInput );
+					}
+				}
 				clearSelectedBlock();
 				selectBlock( clientId );
 			},


### PR DESCRIPTION
This PR fixes #308 for the Alpha, by dismissing the keyboard (calling blur on the last TextInput field) when the field that now gets the focus is a non-textual field.

Please test extensively on iOS, and Android.