### PR TITLE
Disable Code and More blocks for release

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,9 @@
     "browser": true,
     "jest/globals": true
   },
+  "globals": {
+    "__DEV__": true
+  },
   "plugins": [
     "react",
     "react-native",

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -7,7 +7,7 @@ import React from 'react';
 
 // Gutenberg imports
 import { registerCoreBlocks } from '@wordpress/block-library';
-import { registerBlockType, setUnregisteredTypeHandlerName } from '@wordpress/blocks';
+import { registerBlockType, setUnregisteredTypeHandlerName, unregisterBlockType } from '@wordpress/blocks';
 
 import AppContainer from './AppContainer';
 import initialHtml from './initial-html';
@@ -17,6 +17,12 @@ import * as UnsupportedBlock from '../block-types/unsupported-block/';
 registerCoreBlocks();
 registerBlockType( UnsupportedBlock.name, UnsupportedBlock.settings );
 setUnregisteredTypeHandlerName( UnsupportedBlock.name );
+
+// disable Code and More blocks for release
+if ( ! __DEV__ ) {
+	unregisterBlockType( 'core/code' );
+	unregisterBlockType( 'core/more' );
+}
 
 type PropsType = {
 	initialData: string,


### PR DESCRIPTION
Addresses https://github.com/wordpress-mobile/gutenberg-mobile/issues/398

This PR unregisters `Code` and `More` for the prod build.

### Testing Instructions
- Run locally using `yarn start` and `yarn android` or `yarn ios` and notice the Code and More blocks are visible
- Run a Release build with `node_modules/.bin/react-native run-ios --configuration Release` and notice the Code and More blocks appear as unsupported blocks.

