### PR TITLE
Add left/right borders to focused block

### DIFF
--- a/src/block-management/block-holder.scss
+++ b/src/block-management/block-holder.scss
@@ -11,6 +11,8 @@
 	border-color: $gray-lighten-30;
 	border-top-width: 1px;
 	border-bottom-width: 1px;
+	border-left-width: 1px;
+	border-right-width: 1px;
 }
 
 .blockContainer {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/402

Left&Right borders are currently viewable on iPhone X generation devices & landscape modes but other types of devices and portrait mode should also be tested to make sure it doesn't have unwanted consequences.

Left&Right borders should appear on the focused block as below:
<img width="676" alt="screen shot 2018-12-19 at 18 59 21" src="https://user-images.githubusercontent.com/5032900/50231604-3b990900-03c0-11e9-937b-d87a6cdee3d9.png">

Portait mode shouldn't change.

**Testing**

- The borders on the focused block:

- should be visible in iPhone X generation devices in Landscape mode.

- should not be visible in Portrait mode, although they still do exist on Portrait mode we should check that they are hardly noticeable.

- Android side also should be checked to verify right&left borders are hardly noticeable in Portrait mode.
