### PR TITLE
Add 2px left and right margins to inline toolbar

### DIFF
--- a/src/block-management/inline-toolbar/style.scss
+++ b/src/block-management/inline-toolbar/style.scss
@@ -6,6 +6,8 @@
     flex-direction: row;
     height: 44px;
     align-items: flex-start;
+    margin-left: 2px;
+    margin-right: 2px;
 }
 
 .spacer {


### PR DESCRIPTION
Fixes #409 

#### Before

<img width="354" alt="screen shot 2018-12-19 at 18 57 08" src="https://user-images.githubusercontent.com/6597771/50250617-199f8680-03c0-11e9-85e4-eb4a948bb333.png">

#### After
<img width="356" alt="screen shot 2018-12-19 at 18 56 30" src="https://user-images.githubusercontent.com/6597771/50250622-1f956780-03c0-11e9-8db9-89c198dabda2.png">
