### PR TITLE
Only show toolbar when a block is focused

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -226,7 +226,16 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 		return item.clientId;
 	}
 
+	isAnyBlockSelected() {
+		const focusedItemIndex = this.state.blocks.findIndex( ( block ) => block.focused );
+		if ( focusedItemIndex === -1 ) {
+			return false;
+		}
+		return true;
+	}
+
 	renderList() {
+
 		// TODO: we won't need this. This just a temporary solution until we implement the RecyclerViewList native code for iOS
 		// And fix problems with RecyclerViewList on Android
 		const list = (
@@ -243,6 +252,21 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 				shouldPreventAutomaticScroll={ this.shouldFlatListPreventAutomaticScroll }
 			/>
 		);
+
+		const toolbar = (
+			<BlockToolbar
+				onInsertClick={ () => {
+					this.showBlockTypePicker( true );
+				} }
+				onKeyboardHide={ () => {
+					this.onKeyboardHide();
+				} }
+				showKeyboardHideButton={ this.state.isKeyboardVisible }
+			/>
+		);
+
+		// NOTE: workaround for alpha, toolbar should only be shown when an item is focused
+		// see https://github.com/wordpress-mobile/gutenberg-mobile/issues/405
 		return (
 			<View style={ { flex: 1 } } >
 				<DefaultBlockAppender rootClientId={ this.props.rootClientId } />
@@ -253,15 +277,7 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 				<KeyboardAvoidingView
 					style={ styles.blockToolbarKeyboardAvoidingView }
 					parentHeight={ this.state.rootViewHeight } >
-					<BlockToolbar
-						onInsertClick={ () => {
-							this.showBlockTypePicker( true );
-						} }
-						onKeyboardHide={ () => {
-							this.onKeyboardHide();
-						} }
-						showKeyboardHideButton={ this.state.isKeyboardVisible }
-					/>
+					{ ! this.isAnyBlockSelected() && toolbar }
 				</KeyboardAvoidingView>
 			</View>
 		);


### PR DESCRIPTION
Fixes #405 

Given we only need the toolbar when an item _in the list_ is focused, but not when an item outside it is focused (for example, the Title field in the WPAndroid app), this PR implements a workaround that hides the toolbar when there is no focused item, and renders it otherwise.
While this is not the required functionality, in conjunction with WPAndroid this should effectively workaround the issue.

NOTE: it's not working and I can't figure out why (it shows the toolbar right after loading the demo app regardless of no item being focused), therefore I ask a couple more eyes to check it out

To test (what should happen):
1. load the demo app
2. without selecting anything, the toolbar should not be there.
3. tap on any block, the toolbar should appear.

