### PR TITLE
Adding KeyboardHideButton component.

### DIFF
--- a/src/block-management/block-toolbar.js
+++ b/src/block-management/block-toolbar.js
@@ -10,6 +10,7 @@ import { compose } from '@wordpress/compose';
 import { Toolbar, ToolbarButton } from '@wordpress/components';
 import { BlockFormatControls, BlockControls } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
+import KeyboardHideButton from '../components/keyboard-hide-button';
 
 import styles from './block-toolbar.scss';
 
@@ -63,10 +64,8 @@ export class BlockToolbar extends Component<PropsType> {
 						/>
 					</Toolbar>
 					{ showKeyboardHideButton && ( <Toolbar>
-						<ToolbarButton
-							label={ __( 'Keyboard hide' ) }
-							icon="arrow-down"
-							onClick={ onKeyboardHide }
+						<KeyboardHideButton
+							onPress={ onKeyboardHide }
 						/>
 					</Toolbar> ) }
 					<BlockControls.Slot />

--- a/src/components/keyboard-hide-button.js
+++ b/src/components/keyboard-hide-button.js
@@ -7,7 +7,11 @@ import React from 'react';
 import Svg, { G, Rect, Path } from 'react-native-svg';
 import { TouchableOpacity } from 'react-native';
 
-const KeyboardHideButton = ( props ) => (
+type PropsType = {
+	onPress: void => void,
+};
+
+const KeyboardHideButton = ( props: PropsType ) => (
 	<TouchableOpacity
 		style={ { justifyContent: 'center', alignItems: 'center', width: 44 } }
 		onPress={ props.onPress }

--- a/src/components/keyboard-hide-button.js
+++ b/src/components/keyboard-hide-button.js
@@ -1,0 +1,28 @@
+/**
+ * @format
+ * @flow
+ */
+
+import React from 'react';
+import Svg, { G, Rect, Path } from 'react-native-svg';
+import { TouchableOpacity } from 'react-native';
+
+const KeyboardHideButton = ( props ) => (
+	<TouchableOpacity
+		style={ { justifyContent: 'center', alignItems: 'center', width: 44 } }
+		onPress={ props.onPress }
+	>
+		<Svg width={ 20 } height={ 20 } >
+			<G fillRule="nonzero" fill="none">
+				<Rect fill="#7b9ab1" width={ 20 } height={ 14 } rx={ 2 } />
+				<Path fill="#FFF" d="M2 2h16v10H2z" />
+				<Path
+					fill="#7b9ab1"
+					d="M3 3h2v2H3zM6 3h2v2H6zM9 3h2v2H9zM12 3h2v2h-2zM15 3h2v2h-2zM3 6h2v2H3zM5 9h9v2H5zM6 6h2v2H6zM9 6h2v2H9zM12 6h2v2h-2zM15 6h2v2h-2zM10 20l4-4H6z"
+				/>
+			</G>
+		</Svg>
+	</TouchableOpacity>
+);
+
+export default KeyboardHideButton;


### PR DESCRIPTION
This PR creates a `KeyboardHideButton` component that renders the proper hide-button icon using the RNSVG library.

This is a temporary change since we should ultimately use `dash-icons` with the `ToolbarButton` component.

**Notes:**
The original .svg file for the icon seems to be too complex for RNSVG, so I redrew it with simple shapes.

![hide-keyboard](https://user-images.githubusercontent.com/9772967/50280568-857ffe80-0455-11e9-8c97-8fb59cf62fa5.gif)

To test:
- Run the example app.
- Tap on a textual block to show the keyboard.
- Check that the new icon shows correctly.
- Tap on the hide-keyboard button.
- Check that the keyboard hides.

cc @koke 