### PR TITLE
iOS only - Fix bottom padding of focused block to the keyboard

### DIFF
--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -13,4 +13,7 @@ module.exports = {
 	toolbar: {
 		height: 44,
 	},
+	blockContainerFocused: {
+		paddingBottom: 0,
+	},
 };

--- a/src/components/keyboard-aware-flat-list.ios.js
+++ b/src/components/keyboard-aware-flat-list.ios.js
@@ -5,6 +5,7 @@
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import React from 'react';
 import { FlatList, Dimensions } from 'react-native';
+import styles from '../block-management/block-holder.scss';
 
 type PropsType = {
 	...FlatList.propTypes,
@@ -26,7 +27,7 @@ const KeyboardAwareFlatList = ( props: PropsType ) => {
 	const extraScrollHeight = ( () => {
 		const { height: fullHeight, width: fullWidth } = Dimensions.get( 'window' );
 		const keyboardVerticalOffset = fullHeight - parentHeight;
-		const blockHolderPadding = 8;
+		const blockHolderPadding = styles.blockContainerFocused.paddingBottom;
 
 		if ( fullWidth > fullHeight ) { //landscape mode
 			//we won't try to make inner block visible in landscape mode because there's not enough room for it


### PR DESCRIPTION
This change fixes the bottom padding of the focused block to the keyboard. There was a small extra padding left after this PR https://github.com/wordpress-mobile/gutenberg-mobile/pull/399 so we are fixing that by importing the new value.

Before:
<img width="385" alt="screen shot 2018-12-20 at 11 36 18" src="https://user-images.githubusercontent.com/5032900/50280768-73ef2480-045e-11e9-943c-f78a88d87979.png">

After:
<img width="378" alt="screen shot 2018-12-20 at 13 50 28" src="https://user-images.githubusercontent.com/5032900/50280774-7b163280-045e-11e9-956f-dcd113d4f232.png">

**To Test**

- Run yarn start
- Open WPiOS app in debug mode and open a post
- Add more than 5-6 paragraph blocks so that the content size exceeds the screen size
- Tap one of the block at the bottom of the page
- Verify that the scrolling position doesn't have unnecessary padding between the keyboard and the bottom of the focused block.
