### PR TITLE
Reset the focused field state if a paragraph gets replaced with a non-editable block

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -115,7 +115,7 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 			// now remove focus if what we're going to replace is any of our handled editables, otherwise we end up having a wrong state
 			// https://github.com/wordpress-mobile/WordPress-Android/issues/8838#issuecomment-448978736
 			if ( this.isEditableBlock( this.props.selectedBlock ) && ! this.isEditableBlock( newBlock ) ) {
-				TextInputState.blurTextInput(TextInputState.currentlyFocusedField());
+				TextInputState.blurTextInput( TextInputState.currentlyFocusedField() );
 			}
 		} else {
 			this.props.createBlockAction( newBlock.clientId, newBlock );
@@ -317,7 +317,7 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 		if ( ! block ) {
 			return false;
 		}
-		return ( block.name == "core/paragraph" ) || ( block.name == "core/heading" ) || ( block.name == "core/code" )
+		return ( block.name === 'core/paragraph' ) || ( block.name === 'core/heading' ) || ( block.name === 'core/code' );
 	}
 
 	renderItem( value: { item: BlockType, index: number } ) {


### PR DESCRIPTION
Fixes #415 

The problem was that when we were replacing a Paragraph block, the `TextInputState.focusedField` member would still keep track of the now gone block, and thus the next time we tried to blur the supposedly "focused field" by calling [`TextInputState.blurTextInput( currentlyFocusedTextInput )`](https://github.com/wordpress-mobile/gutenberg-mobile/blob/master/src/block-management/block-holder.js#L119)  the app would run into an error.

This PR fixes that by resetting the focus  (clearing it with `blur`) when doing the replace, so there's no longer a reference to a node that doesn't exist anymore.

To test:
1. tap the + inserter icon and choose a paragraph block
2. once the paragraph block appears and gets the focus (keyboard is up as well), tap the + inserter icon again
3. now choose an Image block
4. observe the Paragraph block gets replaced with the new Image block
5. now tap on the image block
6. it should not crash

Test the same with content, without content, in different parts, and also try the page break block.
