### PR TITLE
[Android bridge] Start the RN app only after we got the real post content

### DIFF
--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -118,7 +118,7 @@ public class WPAndroidGlueCode {
 
         // The string here (e.g. "MyReactNativeApp") has to match
         // the string in AppRegistry.registerComponent() in index.js
-        mReactRootView.startReactApplication(mReactInstanceManager, "gutenberg", initialProps);
+        mReactRootView.setAppProperties(initialProps);
     }
 
     public void onPause(Activity activity) {
@@ -181,7 +181,7 @@ public class WPAndroidGlueCode {
             appProps = new Bundle();
         }
         appProps.putString(PROP_NAME_INITIAL_DATA, content);
-        mReactRootView.setAppProperties(appProps);
+        mReactRootView.startReactApplication(mReactInstanceManager, "gutenberg", appProps);
     }
 
     private void updateContent(String content) {


### PR DESCRIPTION
It seems that RN doesn't like it when we start early and then re-set the
app props very soon after. So, instead, starting the RN app later, as
soon as we get the post content via `setContent()`.

This PR probably fixes #390 too.

To test:
1. Use the web to create a post that uses the demo content from https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/src/app/initial-html.js
2. Use wpandroid `zalphaRelease` (remember to enable Gutenberg from App settings)
3. Open the post and notice the content loading normally
4. Try going back and opening the post more than a few times. It should always open normally.