### PR TITLE
Init Gutenberg for new posts

### DIFF
--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -88,7 +88,8 @@ public class WPAndroidGlueCode {
 
     public void onCreateView(View reactRootView, boolean htmlModeEnabled,
                              OnMediaLibraryButtonListener onMediaLibraryButtonListener,
-                             Application application, boolean isDebug, boolean buildGutenbergFromSource) {
+                             Application application, boolean isDebug, boolean buildGutenbergFromSource,
+                             boolean isNewPost) {
         mReactRootView = (ReactRootView) reactRootView;
 
         ReactInstanceManagerBuilder builder =
@@ -119,6 +120,10 @@ public class WPAndroidGlueCode {
         // The string here (e.g. "MyReactNativeApp") has to match
         // the string in AppRegistry.registerComponent() in index.js
         mReactRootView.setAppProperties(initialProps);
+
+        if (isNewPost) {
+            initContent("");
+        }
     }
 
     public void onPause(Activity activity) {


### PR DESCRIPTION
With #431 a regression was introduced that didn't start the RN app for empty posts. This PR fixes that by allowing the host app to indicate whether this is a `newPost`, and thus Gutenberg is properly initialized with empty content.

