### PR TITLE
only show Add Block Here indicator when block is not replaceable

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -3,6 +3,11 @@
  * @flow
  */
 
+ /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
 import React from 'react';
 import { isEqual } from 'lodash';
 
@@ -306,10 +311,11 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 	}
 
 	renderItem( value: { item: BlockType, index: number } ) {
+		const titleForAddPlaceIndicator = __( 'ADD BLOCK HERE' );
 		const insertHere = (
 			<View style={ styles.containerStyleAddHere } >
 				<View style={ styles.lineStyleAddHere }></View>
-				<Text style={ styles.labelStyleAddHere } >ADD BLOCK HERE</Text>
+				<Text style={ styles.labelStyleAddHere } > {titleForAddPlaceIndicator } </Text>
 				<View style={ styles.lineStyleAddHere }></View>
 			</View>
 		);
@@ -332,7 +338,7 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 					onReplace={ ( block ) => this.onReplace( value.item.clientId, block ) }
 					{ ...value.item }
 				/>
-				{ this.state.blockTypePickerVisible && value.item.focused && insertHere }
+				{ this.state.blockTypePickerVisible && value.item.focused && ( ! this.isReplaceable( value.item ) ) && insertHere }
 			</View>
 		);
 	}

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -3,7 +3,7 @@
  * @flow
  */
 
- /**
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -315,7 +315,7 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 		const insertHere = (
 			<View style={ styles.containerStyleAddHere } >
 				<View style={ styles.lineStyleAddHere }></View>
-				<Text style={ styles.labelStyleAddHere } > {titleForAddPlaceIndicator } </Text>
+				<Text style={ styles.labelStyleAddHere } > { titleForAddPlaceIndicator } </Text>
 				<View style={ styles.lineStyleAddHere }></View>
 			</View>
 		);


### PR DESCRIPTION
Fix #439 

This PR checks whether the selected block is replaceable and only shows the ADD BLOCK HERE when it is _not_ going to be replaced.

Also, we're using the i18n API now for the `ADD BLOCK HERE` string.

![addblockhere](https://user-images.githubusercontent.com/6597771/50400683-59bb8c00-0767-11e9-9522-4149a0966cd6.gif)
