### PR TITLE
Bring Code and More back for the prod build

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -7,7 +7,7 @@ import React from 'react';
 
 // Gutenberg imports
 import { registerCoreBlocks } from '@wordpress/block-library';
-import { registerBlockType, setUnregisteredTypeHandlerName, unregisterBlockType } from '@wordpress/blocks';
+import { registerBlockType, setUnregisteredTypeHandlerName } from '@wordpress/blocks';
 
 import AppContainer from './AppContainer';
 import initialHtml from './initial-html';
@@ -17,12 +17,6 @@ import * as UnsupportedBlock from '../block-types/unsupported-block/';
 registerCoreBlocks();
 registerBlockType( UnsupportedBlock.name, UnsupportedBlock.settings );
 setUnregisteredTypeHandlerName( UnsupportedBlock.name );
-
-// disable Code and More blocks for release
-if ( ! __DEV__ ) {
-	unregisterBlockType( 'core/code' );
-	unregisterBlockType( 'core/more' );
-}
 
 type PropsType = {
 	initialData: string,


### PR DESCRIPTION
This PR "re-registers" Code and More for the prod build. 
Those blocks were disabled in https://github.com/wordpress-mobile/gutenberg-mobile/pull/406 

We can re-enable them back since https://github.com/WordPress/gutenberg/pull/13089 does handle `Enter.key` detection better, and does not introduce the UI lag of the previous approach.

To test:

- Start the mobile demo app
- Put the caret somewhere in the more block
- Tap enter on the soft keyboard, or on the hw keyboard
- It should add a new empty (para) block after the current

