### PR TITLE
Fix image cropped vertically

### DIFF
--- a/src/app/initial-html.js
+++ b/src/app/initial-html.js
@@ -202,4 +202,8 @@ else:
 <!-- wp:list -->
 <ul><li><a href="https://make.wordpress.org/core/2017/01/17/editor-technical-overview">Gutenberg Editor Technical Overview</a></li><li><a href="https://wordpress.org/gutenberg/handbook/reference/design-principles/">Gutenberg Design Principles</a></li><li><a href="https://make.wordpress.org/core/tag/gutenberg/">Development updates on make.wordpress.org</a></li><li><a href="https://wordpress.tv/?s=gutenberg">WordPress.tv Talks about Gutenberg</a></li><li><a href="https://wordpress.org/gutenberg/handbook/reference/faq/">FAQs</a></li></ul>
 <!-- /wp:list -->
+
+<!-- wp:image -->
+<figure class="wp-block-image"><img src="https://mysitefortestingetoledom.files.wordpress.com/2018/12/96ec6a71-4e54-4d9d-bb77-0d8ea75fdeed-3013-000003565d3632ce_file.jpg" alt=""/></figure>
+<!-- /wp:image -->
 `;


### PR DESCRIPTION
Fixes #444 

Gutenberg side: https://github.com/WordPress/gutenberg/pull/13096

The image size implementations tries to follow closely the web implementation. I tried to share some code from `ImageSize` but most of it is platform specific. I made a small `utils` to share some math calculations.

On a future PR I plan to implement some kind of loading indicator.
cc @iamthomasbishop 

![image_height](https://user-images.githubusercontent.com/9772967/50422102-ada1a000-084f-11e9-973b-12d7d0eb5996.png)

To test:
- Run the example project.
- Scroll down to the last block.
- Check that the image displays correctly as shown in the attached image.