### PR TITLE
Block Picker: remove 'replace block' title, only keep 'add block' title

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -353,7 +353,7 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 					onReplace={ ( block ) => this.onReplace( value.item.clientId, block ) }
 					{ ...value.item }
 				/>
-				{ this.state.blockTypePickerVisible && value.item.focused && addBlockHere }
+				{ this.state.blockTypePickerVisible && value.item.focused && ( ! this.isReplaceable( value.item ) ) && addBlockHere }
 			</View>
 		);
 	}

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -298,7 +298,6 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 				onValueSelected={ ( itemValue ) => {
 					this.onBlockTypeSelected( itemValue );
 				} }
-				isReplacement={ this.isReplaceable( this.props.selectedBlock ) }
 			/>
 		);
 
@@ -328,7 +327,7 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 
 	renderItem( value: { item: BlockType, index: number } ) {
 		const titleForAddPlaceIndicator = __( 'ADD BLOCK HERE' );
-		const insertHere = (
+		const addBlockHere = (
 			<View style={ styles.containerStyleAddHere } >
 				<View style={ styles.lineStyleAddHere }></View>
 				<Text style={ styles.labelStyleAddHere } > { titleForAddPlaceIndicator } </Text>
@@ -354,7 +353,7 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 					onReplace={ ( block ) => this.onReplace( value.item.clientId, block ) }
 					{ ...value.item }
 				/>
-				{ this.state.blockTypePickerVisible && value.item.focused && ( ! this.isReplaceable( value.item ) ) && insertHere }
+				{ this.state.blockTypePickerVisible && value.item.focused && addBlockHere }
 			</View>
 		);
 	}

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -40,7 +40,6 @@ export default class BlockPicker extends Component<PropsType, StateType> {
 
 	render() {
 		const titleForAdd = __( 'ADD BLOCK' );
-		const titleForReplace = __( 'REPLACE BLOCK' );
 		return (
 			<Modal
 				transparent={ true }
@@ -56,7 +55,7 @@ export default class BlockPicker extends Component<PropsType, StateType> {
 					<View style={ styles.shortLineStyle } />
 					<View>
 						<Text style={ styles.title }>
-							{ this.props.isReplacement ? titleForReplace : titleForAdd }
+							{ titleForAdd }
 						</Text>
 					</View>
 					<View style={ styles.lineStyle } />

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -18,7 +18,6 @@ import { getBlockTypes } from '@wordpress/blocks';
 
 type PropsType = {
 	style?: StyleSheet,
-	isReplacement: boolean,
 	onValueSelected: ( itemValue: string, itemIndex: number ) => void,
 	onDismiss: () => void,
 };


### PR DESCRIPTION
Fix #452 

This PR drops the ` isReplacement`  prop from the BlockPicker and always shows:

- block picker title "ADD BLOCK" , dropping "REPLACE BLOCK" 

**IMPORTANT** This PR assumes we will also work on #453

