### PR TITLE
Fix for disappearing block on paste

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         gradlePluginVersion = '3.1.0'
         kotlinVersion = '1.2.31'
         supportLibVersion = '27.1.1'
-        tagSoupVersion = '1.2.2'
+        tagSoupVersion = '1.2.1'
         glideVersion = '3.7.0'
         picassoVersion = '2.5.2'
         robolectricVersion = '3.5.1'


### PR DESCRIPTION
### Fixes #430

Aztec was sending a "backspace" as part of process of cleaning up the text to paste a new one, but that triggered the merge logic in the context of Gutenberg.

This PR points to the fix. PR on the react-native-aztec side: https://github.com/wordpress-mobile/react-native-aztec/pull/107

To test:
1. In the demo app, select and copy some text from a paragraph block (e.g. select the "World" from the `Hello World` paragraph block
2. Place the cursor at the end of the paragraph block and tap "Enter" to create a new block
3. Long tap and paste the text. It should work.

This PR will get updated when the react-native-aztec PR gets merged.