### PR TITLE
Add 'update-bintray-repo.sh' to upload react-native/jsc-android to Bintray

### DIFF
--- a/bin/update-bintray-repo.sh
+++ b/bin/update-bintray-repo.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+# Check for jfrog-cli-go
+command -v jfrog > /dev/null || ( echo "jfrog-cli-go is required to update the repo. Install it with 'brew install jfrog-cli-go'"; exit 1 )
+# Check for xmlstarlet
+command -v xmlstarlet > /dev/null || ( echo "xmlstarlet is required to update the repo. Install it with 'brew install xmlstarlet'"; exit 1 )
+
+# Exit if any command fails
+set -e
+
+# Change to the expected directory.
+cd "$( dirname $0 )"
+cd ..
+
+BINTRAY_REPO="wordpress-mobile/react-native-mirror"
+PACKAGE_PATHS=("node_modules/react-native/android/com/facebook/react/react-native" "node_modules/jsc-android/dist/org/webkit/android-jsc")
+
+package_name () {
+    local PACKAGE_PATH="$1"
+    xmlstarlet sel -t -v "/metadata/artifactId" "$PACKAGE_PATH/maven-metadata.xml"
+}
+
+package_version () {
+    local PACKAGE_PATH="$1"
+    xmlstarlet sel -t -v "/metadata/versioning/versions/version" "$PACKAGE_PATH/maven-metadata.xml"
+}
+
+check_bintray_version () {
+    local PACKAGE_NAME="$1"
+    local PACKAGE_VERSION="$2"
+
+    jfrog bt version-show "${BINTRAY_REPO}/${PACKAGE_NAME}/${PACKAGE_VERSION}" &> /dev/null && echo "0" || echo "1"
+}
+
+create_bintray_version () {
+    local PACKAGE_NAME="$1"
+    local PACKAGE_VERSION="$2"
+    local PACKAGE_PATH="$3"
+
+    local BINTRAY_VERSION="${BINTRAY_REPO}/${PACKAGE_NAME}/${PACKAGE_VERSION}"
+    local GROUP_PATH=$(xmlstarlet sel -t -v "/metadata/groupId" "$PACKAGE_PATH/maven-metadata.xml" | tr "." "/")
+
+    jfrog bt version-create "${BINTRAY_VERSION}"
+    jfrog bt upload "${PACKAGE_PATH}/${PACKAGE_VERSION}/*" "${BINTRAY_VERSION}" "${GROUP_PATH}/${PACKAGE_NAME}/${PACKAGE_VERSION}/"
+    jfrog bt version-publish "${BINTRAY_VERSION}"
+}
+
+# Sign into Bintray
+echo "Please sign into Bintray..."
+echo "You can find your Bintray API key here: https://bintray.com/profile/edit"
+jfrog bt config
+
+# Find local packages in node_modules/
+echo "Getting local package details..."
+for PACKAGE_PATH in "${PACKAGE_PATHS[@]}"; do
+    PACKAGE_NAME=$(package_name "${PACKAGE_PATH}")
+    PACKAGE_VERSION=$(package_version "${PACKAGE_PATH}")
+
+    echo "Checking ${PACKAGE_NAME}@${PACKAGE_VERSION} on Bintray..."
+    NEEDS_UPDATE=$(check_bintray_version "${PACKAGE_NAME}" "${PACKAGE_VERSION}")
+    if [ "$NEEDS_UPDATE" == "0" ]; then
+        echo "${PACKAGE_NAME}@${PACKAGE_VERSION} is already up to date on Bintray"
+    else
+        echo "Uploading ${PACKAGE_NAME}@${PACKAGE_VERSION} to Bintray..."
+        create_bintray_version "${PACKAGE_NAME}" "${PACKAGE_VERSION}" "${PACKAGE_PATH}"
+    fi
+done


### PR DESCRIPTION
Recently we started using our our Bintray repo as a mirror for React Native and its dependencies for non source builds (since they are only disributed through npm). This PR is here: https://github.com/wordpress-mobile/gutenberg-mobile/pull/400.

This PR adds a script that allows the repo to be easily updated when we upgrade these dependencies. It checks the current versions in `node_modules/` and uploads them if they are not already present on Bintray.

## Test

### With up to date repo

1. Run `./binupdate-bintray-repo.sh`
2. Provide your Bintray username and API key when prompted.
3. You will see that nothing is done since the repo is up to date. Output will look like this:
```
Checking react-native@0.57.5 on Bintray...
react-native@0.57.5 is already up to date on Bintray
Checking android-jsc@r224109 on Bintray...
android-jsc@r224109 is already up to date on Bintray
```

### With a new version

1. Update `react-native` in `package.json` to something else (perhaps `0.57.8`). Run `yarn`.
2. Run `./binupdate-bintray-repo.sh` as above (it will remember your credentials).
3. This time you will see it uploading the new version to Bintray. You can see that the version was created here: https://bintray.com/wordpress-mobile/react-native-mirror/react-native