### PR TITLE
HTML Editor - Fix keyboard avoiding behavior on iOS

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -222,7 +222,7 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 
 	renderHTML() {
 		return (
-			<HTMLTextInput { ...this.props } />
+			<HTMLTextInput { ...this.props } parentHeight={ this.state.rootViewHeight } />
 		);
 	}
 }

--- a/src/components/html-text-input.js
+++ b/src/components/html-text-input.js
@@ -4,8 +4,9 @@
  */
 
 import React from 'react';
-import { Platform, TextInput, KeyboardAvoidingView } from 'react-native';
+import { Platform, TextInput, View } from 'react-native';
 import styles from './html-text-input.scss';
+import KeyboardAvoidingView from './keyboard-avoiding-view';
 
 // Gutenberg imports
 import { parse } from '@wordpress/blocks';
@@ -16,6 +17,7 @@ type PropsType = {
 	onChange: string => mixed,
 	onPersist: string => mixed,
 	value: string,
+	parentHeight: number,
 };
 
 type StateType = {
@@ -70,21 +72,21 @@ export class HTMLInputView extends React.Component<PropsType, StateType> {
 	}
 
 	render() {
-		const behavior = this.isIOS ? 'padding' : null;
-
 		return (
-			<KeyboardAvoidingView style={ styles.container } behavior={ behavior }>
-				<TextInput
-					autoCorrect={ false }
-					ref={ ( textInput ) => this.textInput = textInput }
-					textAlignVertical="top"
-					multiline
-					numberOfLines={ 0 }
-					style={ styles.htmlView }
-					value={ this.state.value }
-					onChangeText={ this.edit }
-					onBlur={ this.stopEditing }
-				/>
+			<KeyboardAvoidingView style={ styles.container } parentHeight={ this.props.parentHeight }>
+				<View style={ { flex: 1 } } >
+					<TextInput
+						autoCorrect={ false }
+						ref={ ( textInput ) => this.textInput = textInput }
+						textAlignVertical="top"
+						multiline
+						numberOfLines={ 0 }
+						style={ styles.htmlView }
+						value={ this.state.value }
+						onChangeText={ this.edit }
+						onBlur={ this.stopEditing }
+					/>
+				</View>
 			</KeyboardAvoidingView>
 		);
 	}

--- a/src/components/html-text-input.scss
+++ b/src/components/html-text-input.scss
@@ -13,6 +13,10 @@
 }
 
 .container {
-	flex: 1;
+	position: absolute;
+	top: 0;
+	right: 0;
+	left: 0;
+	bottom: 0;
 }
 


### PR DESCRIPTION
Fix https://github.com/wordpress-mobile/gutenberg-mobile/issues/429

This PR fixes the KeyboardAvoidingView issue on iOS and makes the html editor avoid keyboard. Edge cases aren't tested because this issue is low priority for beta, it is just a fix to make it better than the current version.

![keyboard](https://user-images.githubusercontent.com/5032900/51322272-fc6cdf00-1a75-11e9-8354-44ea355e7f1f.gif)

**To Test**

Testing prerequisites

For WPiOS

Checkout the PRs branch to any arbitrary folder and cd .. to it
run yarn install, yarn start
Open XCode WPiOS on the latest develop
Clean build folder on Xcode, and then run the app

For WPAndroid

open grade.properties at WordPress-Android folder
add wp.BUILD_GUTENBERG_FROM_SOURCE = true to grade.properties
checkout the PRs branch in the subrepo of WordPress-Android repo
cd to WordPress-Android/libs/gutenberg-mobile
run yarn install, yarn start
yarn wpandroid on a separate terminal in the same directory

Test steps

- Open a content which is longer than the viewable area when keyboard is open
- Switch to html mode
- Tap on the bottom of the text
- Verify that the caret is still visible after keyboard is open
- Verify that you can scroll all the way up&down while keyboard is open
