### PR TITLE
Make Aztec send height information to JS after pasting text

### DIFF
--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -302,6 +302,8 @@ extension RCTAztecView: UITextViewDelegate {
         forceTypingAttributesIfNeeded()
         propagateFormatChanges()
         propagateContentChanges()
+        //Necessary to send height information to JS after pasting text.
+        textView.setNeedsLayout()
     }
 
     func textViewDidBeginEditing(_ textView: UITextView) {


### PR DESCRIPTION
Fixes #438 

This is a small PR that forces layout when the user paste text. I noticed that `layoutSubviews` is called every time `textViewDidChange` is called, except for pasted text. Adding an explicit call to `setNeedsLayout()` solves the issue.

I tested that `layoutSubviews` is not called more than once for every text change, and now it's properly called after pasting text.

![pasting](https://user-images.githubusercontent.com/9772967/51542999-d15f0280-1e5c-11e9-91f7-069d2cae9bca.gif)


**To test:**
- Test pasting a long text in a paragraph block.
- Check that its heights grows accordingly.
