### PR TITLE
Android - Add post title to Gutenberg Mobile

### DIFF
--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
@@ -1,7 +1,7 @@
 package org.wordpress.mobile.ReactNativeGutenbergBridge;
 
 public interface GutenbergBridgeJS2Parent {
-    void responseHtml(String html, boolean changed);
+    void responseHtml(String title, String html, boolean changed);
 
     interface MediaSelectedCallback {
         void onMediaSelected(String mediaUrl);

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -18,8 +18,10 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
 
     private static final String EVENT_NAME_REQUEST_GET_HTML = "requestGetHtml";
     private static final String EVENT_NAME_UPDATE_HTML = "updateHtml";
+    private static final String EVENT_NAME_UPDATE_TITLE = "setTitle";
 
     private static final String MAP_KEY_UPDATE_HTML = "html";
+    private static final String MAP_KEY_UPDATE_TITLE = "title";
 
     public RNReactNativeGutenbergBridgeModule(ReactApplicationContext reactContext,
             GutenbergBridgeJS2Parent gutenbergBridgeJS2Parent) {
@@ -47,9 +49,15 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
         emitToJS(EVENT_NAME_UPDATE_HTML, writableMap);
     }
 
+    public void setTitleInJS(String title) {
+        WritableMap writableMap = new WritableNativeMap();
+        writableMap.putString(MAP_KEY_UPDATE_TITLE, title);
+        emitToJS(EVENT_NAME_UPDATE_TITLE, writableMap);
+    }
+
     @ReactMethod
-    public void provideToNative_Html(String html, boolean changed) {
-        mGutenbergBridgeJS2Parent.responseHtml(html, changed);
+    public void provideToNative_Html(String html, String title, boolean changed) {
+        mGutenbergBridgeJS2Parent.responseHtml(title, html, changed);
     }
 
     @ReactMethod

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -37,11 +37,13 @@ public class WPAndroidGlueCode {
     private MediaSelectedCallback mPendingMediaSelectedCallback;
 
     private String mContentHtml = "";
+    private String mTitle = "";
     private boolean mContentChanged;
     private boolean mShouldUpdateContent;
     private CountDownLatch mGetContentCountDownLatch;
 
     private static final String PROP_NAME_INITIAL_DATA = "initialData";
+    private static final String PROP_NAME_INITIAL_TITLE = "initialTitle";
     private static final String PROP_NAME_INITIAL_HTML_MODE_ENABLED = "initialHtmlModeEnabled";
 
     public void onCreate(Context context) {
@@ -67,8 +69,9 @@ public class WPAndroidGlueCode {
     protected List<ReactPackage> getPackages(final OnMediaLibraryButtonListener onMediaLibraryButtonListener) {
         mRnReactNativeGutenbergBridgePackage = new RNReactNativeGutenbergBridgePackage(new GutenbergBridgeJS2Parent() {
             @Override
-            public void responseHtml(String html, boolean changed) {
+            public void responseHtml(String title, String html, boolean changed) {
                 mContentHtml = html;
+                mTitle = title;
                 mContentChanged = changed;
                 mGetContentCountDownLatch.countDown();
             }
@@ -107,6 +110,8 @@ public class WPAndroidGlueCode {
             @Override
             public void onReactContextInitialized(ReactContext context) {
                 mReactContext = context;
+                // The React Context is now initialized. Update title and content.
+                WPAndroidGlueCode.this.setContent(mTitle, mContentHtml);
             }
         });
         Bundle initialProps = mReactRootView.getAppProperties();
@@ -114,6 +119,7 @@ public class WPAndroidGlueCode {
             initialProps = new Bundle();
         }
         initialProps.putString(PROP_NAME_INITIAL_DATA, "");
+        initialProps.putString(PROP_NAME_INITIAL_TITLE, "");
         initialProps.putBoolean(PROP_NAME_INITIAL_HTML_MODE_ENABLED, htmlModeEnabled);
 
 
@@ -122,7 +128,7 @@ public class WPAndroidGlueCode {
         mReactRootView.setAppProperties(initialProps);
 
         if (isNewPost) {
-            initContent("");
+            setContent("", "");
         }
     }
 
@@ -164,7 +170,7 @@ public class WPAndroidGlueCode {
         mReactInstanceManager.showDevOptionsDialog();
     }
 
-    public void setContent(String postContent) {
+    public void setContent(String title, String postContent) {
         if (mReactRootView == null) {
             return;
         }
@@ -173,25 +179,43 @@ public class WPAndroidGlueCode {
         // because we don't want to bootstrap the whole Gutenberg state.
         // Otherwise it should be done through module interface
         if (mShouldUpdateContent) {
-            updateContent(postContent);
+            updateContent(title, postContent);
         } else {
             mShouldUpdateContent = true;
-            initContent(postContent);
+            initContent(title, postContent);
         }
     }
 
-    private void initContent(String content) {
+    private void initContent(String title, String content) {
         Bundle appProps = mReactRootView.getAppProperties();
         if (appProps == null) {
             appProps = new Bundle();
         }
-        appProps.putString(PROP_NAME_INITIAL_DATA, content);
+        if (content != null) {
+            appProps.putString(PROP_NAME_INITIAL_DATA, content);
+            mContentHtml = content;
+        }
+        if (title != null) {
+            appProps.putString(PROP_NAME_INITIAL_TITLE, title);
+            mTitle = title;
+        }
         mReactRootView.startReactApplication(mReactInstanceManager, "gutenberg", appProps);
     }
 
-    private void updateContent(String content) {
+    private void updateContent(String title, String content) {
+        if (content != null) {
+            mContentHtml = content;
+        }
+        if (title != null) {
+            mTitle = title;
+        }
         if (mReactContext != null) {
-            mRnReactNativeGutenbergBridgePackage.getRNReactNativeGutenbergBridgeModule().setHtmlInJS(content);
+            if (content != null) {
+                mRnReactNativeGutenbergBridgePackage.getRNReactNativeGutenbergBridgeModule().setHtmlInJS(content);
+            }
+            if (title != null) {
+                mRnReactNativeGutenbergBridgePackage.getRNReactNativeGutenbergBridgeModule().setTitleInJS(title);
+            }
         }
     }
 
@@ -217,6 +241,26 @@ public class WPAndroidGlueCode {
         }
 
         return originalContent;
+    }
+
+    public CharSequence getTitle(OnGetContentTimeout onGetContentTimeout) {
+        if (mReactContext != null) {
+            mGetContentCountDownLatch = new CountDownLatch(1);
+
+            mRnReactNativeGutenbergBridgePackage.getRNReactNativeGutenbergBridgeModule().getHtmlFromJS();
+
+            try {
+                mGetContentCountDownLatch.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException ie) {
+                onGetContentTimeout.onGetContentTimeout(ie);
+            }
+
+            return mTitle == null ? "" : mTitle;
+        } else {
+            // TODO: Add app logging here
+        }
+
+        return "";
     }
 
     public void appendMediaFile(final String mediaUrl) {


### PR DESCRIPTION
Adds the required additions to implement the title in RN for Gutenberg in Android.

The base branch of this PR is the main feature branch `issue/372-add-title-to-gutenberg-mobile`.

## Related PRs:

Parent PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/450
WPAndroid: https://github.com/wordpress-mobile/WordPress-Android/pull/9027


## Testing: 

### Test 1:

1. Run the app.
2. Edit the title and make sure the state is properly maintained.
3. Tap save.

Check the console log that the title is properly retrieved.

### Test 2:

1. Run the app.
2. Delete the title and make sure the placeholder is shown.