### PR TITLE
Fix/upload media file media

### DIFF
--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -31,6 +31,8 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
     private static final int MEDIA_UPLOAD_STATE_SUCCEEDED = 2;
     private static final int MEDIA_UPLOAD_STATE_FAILED = 3;
 
+    private static final int MEDIA_SERVER_ID_UNKNOWN = 0;
+
 
     public RNReactNativeGutenbergBridgeModule(ReactApplicationContext reactContext,
             GutenbergBridgeJS2Parent gutenbergBridgeJS2Parent) {
@@ -97,13 +99,17 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
         });
     }
 
+    private void setMediaFileUploadDataInJS(int state, int mediaId, String mediaUrl, float progress) {
+        setMediaFileUploadDataInJS(state, mediaId, mediaUrl, progress, MEDIA_SERVER_ID_UNKNOWN);
+    }
+
     private void setMediaFileUploadDataInJS(int state, int mediaId, String mediaUrl, float progress, int mediaServerId) {
         WritableMap writableMap = new WritableNativeMap();
         writableMap.putInt(MAP_KEY_MEDIA_FILE_UPLOAD_STATE, state);
         writableMap.putInt(MAP_KEY_MEDIA_FILE_UPLOAD_MEDIA_ID, mediaId);
         writableMap.putString(MAP_KEY_MEDIA_FILE_UPLOAD_MEDIA_URL, mediaUrl);
         writableMap.putDouble(MAP_KEY_MEDIA_FILE_UPLOAD_MEDIA_PROGRESS, progress);
-        if ( mediaServerId > 0 ) {
+        if (mediaServerId != MEDIA_SERVER_ID_UNKNOWN) {
             writableMap.putInt(MAP_KEY_MEDIA_FILE_UPLOAD_MEDIA_SERVER_ID, mediaServerId);
         }
         emitToJS(EVENT_NAME_MEDIA_UPLOAD, writableMap);

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -258,9 +258,9 @@ public class WPAndroidGlueCode {
         }
     }
 
-    public void mediaFileUploadSucceeded(final int mediaId, final String mediaUrl) {
+    public void mediaFileUploadSucceeded(final int mediaId, final String mediaUrl, final int serverMediaId) {
         if (isMediaUploadCallbackRegistered()) {
-            mPendingMediaUploadCallback.onMediaFileUploadSucceeded(mediaId, mediaUrl);
+            mPendingMediaUploadCallback.onMediaFileUploadSucceeded(mediaId, mediaUrl, serverMediaId);
             mPendingMediaUploadCallback = null;
         }
     }


### PR DESCRIPTION
This PR just tidies up the passing of `mediaServerId`, making it clear that it's only known and used at the end of the upload, rather than passing a magic value of 0 it introduces a constant to make it more readable.

Side note: we should also rename that to `serverMediaId` to actually  mean what it carries, but this needs be done in coordination with iOS.