### PR TITLE
Bump Aztec Android to v1.3.17

### DIFF
--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = 'v1.3.14'
+        aztecVersion = 'v1.3.17'
     }
 
     repositories {


### PR DESCRIPTION
Pointing to the latest released Aztec-Android version.