### PR TITLE
[wp-android] Fix crash starting writing new post

### DIFF
--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -122,7 +122,7 @@ public class WPAndroidGlueCode {
         mReactRootView.setAppProperties(initialProps);
 
         if (isNewPost) {
-            initContent("");
+            setContent("");
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/9099  by using `setContent` instead of `initContent` when initializing WPAndroidGlue code.

`setContent` has a guard to prevent the double init of the React Application.