### PR TITLE
Media upload progress reattach android

### DIFF
--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
@@ -19,4 +19,6 @@ public interface GutenbergBridgeJS2Parent {
     void onUploadMediaPressed(MediaUploadCallback mediaUploadCallback);
     
     void onCapturePhotoPressed(MediaUploadCallback mediaUploadCallback);
+
+    void onImageQueryReattach(MediaUploadCallback mediaUploadCallback);
 }

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -83,36 +83,25 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
     }
 
     @ReactMethod
-    public void onUploadMediaPressed(final Callback onUploadMediaSelected) {
-        mGutenbergBridgeJS2Parent.onUploadMediaPressed(new GutenbergBridgeJS2Parent.MediaUploadCallback() {
-            @Override
-            public void onUploadMediaFileSelected(int mediaId, String mediaUri) {
-                onUploadMediaSelected.invoke(mediaId, mediaUri, 0);
-            }
-
-            @Override
-            public void onMediaFileUploadProgress(int mediaId, float progress) {
-                setMediaFileUploadDataInJS(MEDIA_UPLOAD_STATE_UPLOADING, mediaId, null, progress);
-            }
-
-            @Override
-            public void onMediaFileUploadSucceeded(int mediaId, String mediaUrl, int mediaServerId) {
-                setMediaFileUploadDataInJS(MEDIA_UPLOAD_STATE_SUCCEEDED, mediaId, mediaUrl, 1, mediaServerId);
-            }
-
-            @Override
-            public void onMediaFileUploadFailed(int mediaId) {
-                setMediaFileUploadDataInJS(MEDIA_UPLOAD_STATE_FAILED, mediaId, null, 0 );
-            }
-        });
+    public void onImageQueryReattach(final Callback onImageQueryReattached) {
+        mGutenbergBridgeJS2Parent.onImageQueryReattach(getNewUploadMediaCallback(onImageQueryReattached));
     }
 
     @ReactMethod
-    public void onCapturePhotoPressed(final Callback onUploadMediaSelected) {
-        mGutenbergBridgeJS2Parent.onCapturePhotoPressed(new GutenbergBridgeJS2Parent.MediaUploadCallback() {
+    public void onUploadMediaPressed(final Callback onUploadMediaSelected) {
+        mGutenbergBridgeJS2Parent.onUploadMediaPressed(getNewUploadMediaCallback(onUploadMediaSelected));
+    }
+
+    @ReactMethod
+    public void onCapturePhotoPressed(final Callback onPhotoCaptured) {
+        mGutenbergBridgeJS2Parent.onCapturePhotoPressed(getNewUploadMediaCallback(onPhotoCaptured));
+    }
+
+    private GutenbergBridgeJS2Parent.MediaUploadCallback getNewUploadMediaCallback(final Callback jsCallback) {
+        return new GutenbergBridgeJS2Parent.MediaUploadCallback() {
             @Override
             public void onUploadMediaFileSelected(int mediaId, String mediaUri) {
-                onUploadMediaSelected.invoke(mediaId, mediaUri, 0);
+                jsCallback.invoke(mediaId, mediaUri, 0);
             }
 
             @Override
@@ -129,7 +118,7 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
             public void onMediaFileUploadFailed(int mediaId) {
                 setMediaFileUploadDataInJS(MEDIA_UPLOAD_STATE_FAILED, mediaId, null, 0);
             }
-        });
+        };
     }
 
     private void setMediaFileUploadDataInJS(int state, int mediaId, String mediaUrl, float progress) {

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -98,6 +98,10 @@ public class WPAndroidGlueCode {
                 mPendingMediaUploadCallback = mediaUploadCallback;
                 onMediaLibraryButtonListener.onCapturePhotoButtonClicked();
             }
+
+            @Override public void onImageQueryReattach(MediaUploadCallback mediaUploadCallback) {
+                mPendingMediaUploadCallback = mediaUploadCallback;
+            }
         });
         return Arrays.asList(
                 new MainReactPackage(),

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -70,7 +70,12 @@ public class WPAndroidGlueCode {
         void onCapturePhotoButtonClicked();
     }
 
-    protected List<ReactPackage> getPackages(final OnMediaLibraryButtonListener onMediaLibraryButtonListener) {
+    public interface OnReattachQueryListener {
+        void onQueryCurrentProgressForUploadingMedia();
+    }
+
+    protected List<ReactPackage> getPackages(final OnMediaLibraryButtonListener onMediaLibraryButtonListener,
+                                             final OnReattachQueryListener onReattachQueryListener) {
         mRnReactNativeGutenbergBridgePackage = new RNReactNativeGutenbergBridgePackage(new GutenbergBridgeJS2Parent() {
             @Override
             public void responseHtml(String title, String html, boolean changed) {
@@ -101,6 +106,7 @@ public class WPAndroidGlueCode {
 
             @Override public void onImageQueryReattach(MediaUploadCallback mediaUploadCallback) {
                 mPendingMediaUploadCallback = mediaUploadCallback;
+                onReattachQueryListener.onQueryCurrentProgressForUploadingMedia();
             }
         });
         return Arrays.asList(
@@ -113,6 +119,7 @@ public class WPAndroidGlueCode {
 
     public void onCreateView(View reactRootView, boolean htmlModeEnabled,
                              OnMediaLibraryButtonListener onMediaLibraryButtonListener,
+                             OnReattachQueryListener onReattachQueryListener,
                              Application application, boolean isDebug, boolean buildGutenbergFromSource,
                              boolean isNewPost) {
         mReactRootView = (ReactRootView) reactRootView;
@@ -121,7 +128,7 @@ public class WPAndroidGlueCode {
                 ReactInstanceManager.builder()
                                     .setApplication(application)
                                     .setJSMainModulePath("index")
-                                    .addPackages(getPackages(onMediaLibraryButtonListener))
+                                    .addPackages(getPackages(onMediaLibraryButtonListener, onReattachQueryListener))
                                     .setUseDeveloperSupport(isDebug)
                                     .setInitialLifecycleState(LifecycleState.RESUMED);
         if (!buildGutenbergFromSource) {

--- a/react-native-gutenberg-bridge/index.js
+++ b/react-native-gutenberg-bridge/index.js
@@ -52,4 +52,8 @@ export function onCapturePhotoPressed( callback ) {
 	return RNReactNativeGutenbergBridge.onCapturePhotoPressed( callback );
 }
 
+export function onImageQueryReattach( callback ) {
+	return RNReactNativeGutenbergBridge.onImageQueryReattach( callback );
+}
+
 export default RNReactNativeGutenbergBridge;


### PR DESCRIPTION
This PR adds the needed interfaces to make Gutenberg start receiving upload progress updates when it's shown on the screen, for images that exist within the open Post that are currently being uploaded.

This can be tested with the WPAndroid PR https://github.com/wordpress-mobile/WordPress-Android/pull/9129

Related Gutenberg PR:
https://github.com/WordPress/gutenberg/pull/13516


#### Notes:
- refactored the `MediaUploadCallback` implementation a bit as it's needed to be passed to 3 interfaces  (`onCapturePhotoPressed`, `onUploadMediaPressed`, and now also `onImageQueryReattach`)
- this new interface allows the listener to be set on the bridge, updates were already being listened to
- also, the hosting app can start sending latest max progress updates once the Image component calls the new interface  from `componentDidUpdate()` in https://github.com/WordPress/gutenberg/pull/13516 instead of waiting for the next update (this is useful for slow connections where there would be a gap between the time the user opens the Editor and an update is actually seen)