### PR TITLE
Media upload reattach on iOS

### DIFF
--- a/ios/gutenberg/GutenbergViewController.swift
+++ b/ios/gutenberg/GutenbergViewController.swift
@@ -62,6 +62,10 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         } )
         mediaPickAndUploadCoordinator?.pickAndUpload(from: .camera)
     }
+
+    func gutenbergDidRequestMediaUploadSync() {
+        print("Gutenberg request for media uploads to be resync")
+    }
 }
 
 extension GutenbergViewController: GutenbergBridgeDataSource {

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -83,8 +83,8 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
     }
 
     @ReactMethod
-    public void onImageQueryReattach(final Callback onImageQueryReattached) {
-        mGutenbergBridgeJS2Parent.onImageQueryReattach(getNewUploadMediaCallback(onImageQueryReattached));
+    public void onImageQueryReattach() {
+        mGutenbergBridgeJS2Parent.onImageQueryReattach(getNewUploadMediaCallback(null));
     }
 
     @ReactMethod
@@ -101,7 +101,9 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
         return new GutenbergBridgeJS2Parent.MediaUploadCallback() {
             @Override
             public void onUploadMediaFileSelected(int mediaId, String mediaUri) {
-                jsCallback.invoke(mediaId, mediaUri, 0);
+                if (jsCallback != null) {
+                    jsCallback.invoke(mediaId, mediaUri, 0);
+                }
             }
 
             @Override

--- a/react-native-gutenberg-bridge/index.js
+++ b/react-native-gutenberg-bridge/index.js
@@ -52,8 +52,8 @@ export function onCapturePhotoPressed( callback ) {
 	return RNReactNativeGutenbergBridge.onCapturePhotoPressed( callback );
 }
 
-export function onImageQueryReattach( callback ) {
-	return RNReactNativeGutenbergBridge.onImageQueryReattach( callback );
+export function onImageQueryReattach() {
+	return RNReactNativeGutenbergBridge.onImageQueryReattach();
 }
 
 export default RNReactNativeGutenbergBridge;

--- a/react-native-gutenberg-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/react-native-gutenberg-bridge/ios/GutenbergBridgeDelegate.swift
@@ -12,21 +12,25 @@ public protocol GutenbergBridgeDelegate: class {
 
     /// Tells the delegate that an image block requested an image from the media picker.
     ///
-    /// - Parameter callback: A callbak block to be called with the selected
+    /// - Parameter callback: A callback block to be called with the selected
     ///                       image Url or nil to signal that the action was canceled.
     func gutenbergDidRequestMediaPicker(with callback: @escaping MediaPickerDidPickMediaCallback)
     
     /// Tells the delegate that an image block requested an image from the device media.
     ///
-    /// - Parameter callback: A callbak block to be called with an upload mediaIdentifier and a placaholder image file url,
+    /// - Parameter callback: A callback block to be called with an upload mediaIdentifier and a placeholder image file url,
     ///                       use nil on both parameters to signal that the action was canceled.
     func gutenbergDidRequestMediaFromDevicePicker(with callback: @escaping MediaPickerDidPickMediaCallback)
 
     /// Tells the delegate that an image block requested an image from the device cameras.
     ///
-    /// - Parameter callback: A callbak block to be called with and temporary
-    ///                       image file url and an mediaIdentifier or nil to signal that the action was canceled.
+    /// - Parameter callback: A callback block to be called with an upload mediaIdentifier and a placeholder image file url,
+    ///                       use nil on both parameters to signal that the action was canceled.
     func gutenbergDidRequestMediaFromCameraPicker(with callback: @escaping MediaPickerDidPickMediaCallback)
+
+    /// Tells the delegate that an image block requested to reconnect with media uploads coordinator.
+    ///
+    func gutenbergDidRequestMediaUploadSync()
 
     /// Tells the delegate that the Gutenberg module has finished loading.
     ///

--- a/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.m
+++ b/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.m
@@ -6,6 +6,7 @@ RCT_EXTERN_METHOD(provideToNative_Html:(NSString *)html title:(NSString *)title 
 RCT_EXTERN_METHOD(onMediaLibraryPressed:(RCTResponseSenderBlock)callback)
 RCT_EXTERN_METHOD(onUploadMediaPressed:(RCTResponseSenderBlock)callback)
 RCT_EXTERN_METHOD(onCapturePhotoPressed:(RCTResponseSenderBlock)callback)
+RCT_EXTERN_METHOD(onImageQueryReattach)
 RCT_EXTERN_METHOD(editorDidLayout)
 
 @end

--- a/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -52,6 +52,13 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
     }
 
     @objc
+    func onImageQueryReattach() {
+        DispatchQueue.main.async {
+            self.delegate?.gutenbergDidRequestMediaUploadSync()
+        }
+    }
+
+    @objc
     func editorDidLayout() {
         DispatchQueue.main.async {
             self.delegate?.gutenbergDidLayout()


### PR DESCRIPTION
This PR implements the interface on GB-mobile for resync of uploads in iOS.

You can test this on the demo app, by switching to HMTL and back to visual. 

On this demo app we don't any need special code because of the simulation of events is done using timers.

@mzorz I will save the renaming of the method for a separate PR, where I will rename other media methods to keep them more consistent.