### PR TITLE
Removes border from title and changes the placeholder text.

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -167,9 +167,7 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 					style={ styles.title }
 					title={ this.props.title }
 					onUpdate={ this.props.setTitleAction }
-					placeholder={ 'Pick a title...' } />
-				<View
-					style={ styles.titleSeparator } />
+					placeholder={ 'Add a Title' } />
 			</View>
 		);
 	}

--- a/src/block-management/block-manager.scss
+++ b/src/block-management/block-manager.scss
@@ -18,12 +18,6 @@
 	padding-bottom: 12;
 }
 
-.titleSeparator {
-	// greyLighten30
-	border-bottom-color: #E9EFF3;
-	border-bottom-width: 2;
-}
-
 .list {
 	flex: 1;
 }


### PR DESCRIPTION
## Description:

Removes the border from the title and changes the placeholder text to match what's described [here](
https://github.com/wordpress-mobile/WordPress-iOS/pull/10794#issuecomment-455329479).

Closes https://github.com/wordpress-mobile/gutenberg-mobile/issues/372

## Testing:

### Test 1:

Make sure the title has no bottom border.

### Test 2:

Remove the title from the demo and make sure the placeholder reads "Add a Title".

### Test 3:

1. Edit the title
2. Switch to HTML and back.

Make sure the edits are properly persisted.