### PR TITLE
Bundle the Android JS file inside the bridge lib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,3 @@
-addons:
-  artifacts:
-    debug: true
-    s3_region: "us-west-1"
-    target_paths:
-      - /${TRAVIS_REPO_SLUG}/${TRAVIS_COMMIT}/
-
-env:
-  global:
-  - secure: EUSicS1mBOImgoYHBZJ2ZE0xwNMAkGRYUDetvxcKk0EQrOii1Z/EuYC1IN7mwiI6Ybnm3b2xq51bq/Ro3iQNi+iylA0r20mEjRsSqb8cqy8hXRnl4f7ZI3qUorUvEmsJueve3U2MLu5eYJdSNPbqgdavZDZZxiZIdbHAfA80KMp1RmgeqxkCY9wTfrYEqCtTGEJMJtCHXoDJ0cdYEVDnHQYZrF9SPkkMqmwgfFvHBGcyTPMsRZ9JpggxJltXJFTlHBNn/wLfGPiMsJlNx0oS7SmoZ08W72h2QKBZX5bVZxoNmMeQCZ0FlSHeq8yTGJ5xM8ig6YRzkuK5JiHkTaY9rVQMoU2ozMll9Bb5/A07XDXoutH1/QC1jvvT9eMBhon3uZ7e3qyUiRgCpFWrOW0UXKQqF2hhGWT965mBB5pxWOgGZjxtVIuKpFwMbsPIss44OuzlaFis5YRsKyceBAM+g8gkwxB8r8AT0A6g4jY4fmvrUr0qyaldlcr7LafGvAa73uJHoTUruR2AZQlJmLpO9p5xbuwId8L0alApqoaaR3vPx6LPtl/hTBr+KScs/I8PjdiEaobNi1PT3sNH5KIZEB+WaNZaTkK8gAzwvx7V+V0GaDD/P7L5Qa4mRIsXa1xDxdVM7ne4B5zEK1KCePzbZJuv769IbNgzIqAfELJWmXE=
-  - secure: Axr+U8LHOxmGi8GyeL0pP0+84ucxeET59BUpHgANgro+2jLwoLzpvssguc0RHxftVsQBiz2CFfFBVIR6ol+Hf6yjI310Yqw9znBvJuxO0EbAGclGkWyx8DdoWlCSwz+RgiIfIoa7E6QZWt+CZwFbi3vTFutl6NX5Reu0wdpHZlfLT8xkWP3PP7awgL2g75WsNKNv4A1CvzkF3j/hi6JU/b3QsBMTOCHA1vcdpKhjF8MiS9d7gzdwsTr6MoDGVab/oGVCljiFmIPYTa4+xp/q1MYkSizxBmq1mqjXkn1RrZP25QGqgubfgtiywk8H9kDE8/POPJuoteO2gnz2u9I1AkVrrsxCfU9XJzXXwVfbFxVlyOIfC9gZj5ZI9niOqTdytPUMPOzJw79xUvYMeoS7ydcrm3O8gCs0/fBnSH0KfMq37um8zE8zah90M/8CcJjS5KC8hFO/tZomkUASoTwnJEZh4OdSG8Ys9YnKMKBDCuI8HUR2zlVPrv/8ACO4eSZ4LCaNeXQVWil5NNFgLPzvkElqpywVmQaGY3UD2W2w76AEs5sF4n/naQsi6L6oy61mDP8j+wSooQczx/1enue/hzjxZUles7p3ek0yha6N6fxkt/MyvEYWmw98wQZmsBzEahTGXy9iWfobFu0jUzUPXhSdoMul3Q9fceUSP9f+XV8=
-
 before_script:
   - yarn install
 
@@ -30,16 +18,10 @@ matrix:
         LANE='node'
         CHECK_TESTS='true'
         TEST_RN_PLATFORM='android'
-        ARTIFACTS_BUCKET='gutenberg-mobile-js-bundle'
-        ARTIFACTS_PATHS="./bundle"
       cache:
         yarn: true
       script:
-        - set -e # make sure Travis stops if any of the script lines error
         - ./.travis/travis-checks-js.sh
-        - yarn bundle:android # rebuild the Android JS bundle
-        - rm -Rf bundle/ios # delete the ios bundle since it's not up to date and we don't need to publish to S3
-        - set +e
     - language: node_js
       node_js: 8
       env:

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -2,6 +2,7 @@ before_install:
    - yes | $ANDROID_HOME/tools/bin/sdkmanager "platforms;android-27"
    - yes | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;27.0.3"
 install:
+   - export TMPDIR=`dirname $(mktemp)`
    - echo "Changing into the android folder of the Bridge module"
    - pushd react-native-gutenberg-bridge/android && ./gradlew --stacktrace clean -Pgroup=com.github.wordpress-mobile.gutenberg-mobile -Pversion=$VERSION install && popd
    - pushd react-native-aztec/android && ./gradlew --stacktrace clean -Pgroup=com.github.wordpress-mobile.gutenberg-mobile -Pversion=$VERSION install && popd

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -1,18 +1,67 @@
-
 buildscript {
+    def isJitPack = System.getenv('JITPACK').asBoolean()
+
     repositories {
         jcenter()
         google()
+
+        if (isJitPack) {
+            maven {
+                url "https://plugins.gradle.org/m2/"
+            }
+        }
     }
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
+
+        if (isJitPack) {
+            classpath "com.moowork.gradle:gradle-node-plugin:1.2.0"
+        }
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
+
+def isJitPack = System.getenv('JITPACK').asBoolean()
+
+if (isJitPack) {
+    println 'Building in JitPack'
+
+    apply plugin: 'com.moowork.node'
+
+    node {
+        // Version of node to use.
+        version = '8.11.3'
+
+        // Version of npm to use.
+        npmVersion = '6.3.0'
+
+        // Version of Yarn to use.
+        yarnVersion = '1.10.1'
+
+        // Base URL for fetching node distributions (change if you have a mirror).
+        distBaseUrl = 'https://nodejs.org/dist'
+
+        // If true, it will download node using above parameters.
+        // If false, it will try to use globally installed node.
+        download = true
+
+        // Set the work directory for unpacking node
+        workDir = file("${project.buildDir}/jsbundle/nodejs")
+
+        // Set the work directory for NPM
+        npmWorkDir = file("${project.buildDir}/jsbundle/npm")
+
+        // Set the work directory for Yarn
+        yarnWorkDir = file("${project.buildDir}/jsbundle/yarn")
+
+        // Set the work directory where node_modules should be located
+        nodeModulesDir = file("${project.projectDir}/../../")
+    }
+}
 
 // import the `readReactNativeVersion()` function
 apply from: 'https://gist.githubusercontent.com/hypest/742448b9588b3a0aa580a5e80ae95bdf/raw/8eb62d40ee7a5104d2fcaeff21ce6f29bd93b054/readReactNativeVersion.gradle'
@@ -77,5 +126,34 @@ dependencies {
 
         def rnVersion = readReactNativeVersion('../package.json', 'peerDependencies')
         implementation "com.facebook.react:react-native:${rnVersion}"
+    }
+}
+
+if (isJitPack) {
+    def assetsFolder = 'src/main/assets'
+
+    task buildJSBundle(type: YarnTask) {
+        args = ['bundle:android']
+    }
+
+    task ensureAssetsDirectory << {
+        mkdir assetsFolder
+    }
+
+    task copyJSBundle(type: Copy) {
+        def origFileName = 'App.js'
+        def origWithPath = "../../bundle/android/${origFileName}"
+        def target = 'index.android.bundle'
+        from origWithPath
+        into assetsFolder
+        rename origFileName, target
+    } << {
+        println "Done copying the Android JS bundle to assets folder"
+    }
+
+    if (isJitPack) {
+        preBuild.dependsOn(copyJSBundle)
+        copyJSBundle.dependsOn(buildJSBundle)
+        buildJSBundle.dependsOn(yarn_install, ensureAssetsDirectory)
     }
 }

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -49,14 +49,16 @@ if (isJitPack) {
         // If false, it will try to use globally installed node.
         download = true
 
+        def tmpdir = "${System.getenv('TMPDIR')}/jsbundle/${System.getenv('VERSION')}"
+
         // Set the work directory for unpacking node
-        workDir = file("${project.buildDir}/jsbundle/nodejs")
+        workDir = file("${tmpdir}/nodejs")
 
         // Set the work directory for NPM
-        npmWorkDir = file("${project.buildDir}/jsbundle/npm")
+        npmWorkDir = file("${tmpdir}/npm")
 
         // Set the work directory for Yarn
-        yarnWorkDir = file("${project.buildDir}/jsbundle/yarn")
+        yarnWorkDir = file("${tmpdir}/yarn")
 
         // Set the work directory where node_modules should be located
         nodeModulesDir = file("${project.projectDir}/../../")

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -153,8 +153,13 @@ if (isJitPack) {
         println "Done copying the Android JS bundle to assets folder"
     }
 
+    task cleanupNodeModulesFolder(type: Delete) {
+        delete '../../node_modules'
+    }
+
     if (isJitPack) {
-        preBuild.dependsOn(copyJSBundle)
+        preBuild.dependsOn(cleanupNodeModulesFolder)
+        cleanupNodeModulesFolder.dependsOn(copyJSBundle)
         copyJSBundle.dependsOn(buildJSBundle)
         buildJSBundle.dependsOn(yarn_install, ensureAssetsDirectory)
     }


### PR DESCRIPTION
This PR removes the dependency on Travis+AWS to produce the Android JS bundle and instead, tasks JitPack to produce and include the JS file inside the Bridge library's assets folder. The parent app can then access the file automatically because of resources merging.

h/t to @jtreanor for the assets bundling idea!

To test:

Use this wpandroid side PR: https://github.com/wordpress-mobile/WordPress-Android/pull/9156
