### PR TITLE
Implementing InspectorControls.Slot for inline toolbar buttons.

### DIFF
--- a/src/block-management/inline-toolbar/index.js
+++ b/src/block-management/inline-toolbar/index.js
@@ -6,6 +6,7 @@ import { View } from 'react-native';
 import InlineToolbarActions from './actions';
 import { ToolbarButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { InspectorControls } from '@wordpress/editor';
 
 type PropsType = {
 	clientId: string,
@@ -58,6 +59,8 @@ export default class InlineToolbar extends React.Component<PropsType> {
 				/>
 
 				<View style={ styles.spacer } />
+
+				<InspectorControls.Slot />
 
 				<ToolbarButton
 					label={ __( 'Remove content' ) }


### PR DESCRIPTION
This PR implements the changes made on https://github.com/WordPress/gutenberg/pull/13597 to display inline toolbar buttons declared by each block.

On this particular PR, the `Images settings` button will be displayed, towards the task described here: 
https://github.com/wordpress-mobile/gutenberg-mobile/issues/202

![simulator screen shot - iphone x - 2019-01-30 at 14 47 46](https://user-images.githubusercontent.com/9772967/51988552-32ae5380-24a5-11e9-8a0a-9e3f5f9d03b1.png)

To test:

- Run the project.
- Select an Image block with an image.
- Check that the settings button is displayed like in the screenshot.
- Select an empty image block.
- Check that the settings button is not there.