### PR TITLE
Remap font names for iOS for PR 372.

### DIFF
--- a/src/block-management/block-holder.scss
+++ b/src/block-management/block-holder.scss
@@ -70,7 +70,7 @@
 	padding-top: 24;
 	padding-bottom: 24;
 	font-size: 16px;
-	font-family: serif;
+	font-family: 'NotoSerif';
 }
 
 .aztec_container {


### PR DESCRIPTION
## Description:

This PR simply remaps some font names for an open PR so that the work for iOS as well.

iOS unfortunately doesn't support font families `serif` and `monospace`.

Other changes will be needed but these are the basic changes before implementing the iOS native font properties.

## Testing:

The only testing needed is to make sure the font are good for Android too.