### PR TITLE
Only send events if observing

### DIFF
--- a/ios/gutenberg/MediaUploadCoordinator.swift
+++ b/ios/gutenberg/MediaUploadCoordinator.swift
@@ -62,7 +62,7 @@ class MediaUploadCoordinator: NSObject {
     } else if progress.fractionCompleted >= 1 {
       timer.invalidate()
       if successfull {
-        gutenberg.mediaUploadUpdate(id: mediaID, state: .failed, progress: 1, url: mediaURL, serverID: 123)
+        gutenberg.mediaUploadUpdate(id: mediaID, state: .succeeded, progress: 1, url: mediaURL, serverID: 123)
         activeUploads[mediaID] = nil
       } else {
         progress.setUserInfoObject("Network upload failed", forKey: .mediaError)

--- a/react-native-gutenberg-bridge/ios/Gutenberg.swift
+++ b/react-native-gutenberg-bridge/ios/Gutenberg.swift
@@ -79,7 +79,7 @@ public class Gutenberg: NSObject {
         if let serverID = serverID {
             data["mediaServerId"] = serverID
         }
-        bridgeModule.sendEvent(withName: EventName.mediaUpload, body: data)
+        bridgeModule.sendEventIfNeeded(name: EventName.mediaUpload, body: data)
     }
 }
 

--- a/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -2,7 +2,7 @@
 public class RNReactNativeGutenbergBridge: RCTEventEmitter {
     weak var delegate: GutenbergBridgeDelegate?
     private var isJSLoading = true
-
+    private var hasObservers = false
     // MARK: - Messaging methods
 
     @objc
@@ -52,6 +52,28 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
     func editorDidLayout() {
         DispatchQueue.main.async {
             self.delegate?.gutenbergDidLayout()
+        }
+    }
+
+    override public func startObserving() {
+        super.startObserving()
+        hasObservers = true
+    }
+
+    override public func stopObserving() {
+        super.stopObserving()
+        hasObservers = false
+    }
+
+
+    /// Sends events to the JS side only if there is observers listening
+    ///
+    /// - Parameters:
+    ///   - name: name of the event
+    ///   - body: data for the event
+    public func sendEventIfNeeded(name: String, body: Any!) {
+        if ( hasObservers ) {
+            self.sendEvent(withName: name, body: body)
         }
     }
 }


### PR DESCRIPTION
This PR makes sure that in iOS we only send events when someone is observing on the JS side.