### PR TITLE
RTL layout fixes

### DIFF
--- a/src/block-management/block-toolbar.js
+++ b/src/block-management/block-toolbar.js
@@ -44,6 +44,7 @@ export class BlockToolbar extends Component<PropsType> {
 					showsHorizontalScrollIndicator={ false }
 					keyboardShouldPersistTaps={ 'always' }
 					alwaysBounceHorizontal={ false }
+					contentContainerStyle={ styles.scrollableContent }
 				>
 					<Toolbar>
 						<ToolbarButton

--- a/src/block-management/block-toolbar.scss
+++ b/src/block-management/block-toolbar.scss
@@ -6,6 +6,10 @@
     border-top-width: 1;
 }
 
+.scrollableContent {
+    min-width: 100%; // Fixes RTL issue on Android.
+}
+
 .keyboardHideContainer {
     padding-right: 0px;
     padding-left: 0px;

--- a/src/block-management/block-toolbar.scss
+++ b/src/block-management/block-toolbar.scss
@@ -7,7 +7,7 @@
 }
 
 .scrollableContent {
-    min-width: 100%; // Fixes RTL issue on Android.
+    flex-grow: 1; // Fixes RTL issue on Android.
 }
 
 .keyboardHideContainer {

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const gutenbergSetup = () => {
 	const apiFetch = require( '@wordpress/api-fetch' ).default;
 	const wpData = require( '@wordpress/data' );
 
-	I18nManager.forceRTL(false); // Change to `true` to debug RTL layout easily.
+	I18nManager.forceRTL( false ); // Change to `true` to debug RTL layout easily.
 
 	// wp-api-fetch
 	apiFetch.use( apiFetch.createRootURLMiddleware( 'https://public-api.wordpress.com/' ) );

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 // External dependencies
-import { AppRegistry } from 'react-native';
+import { AppRegistry, I18nManager } from 'react-native';
 
 // Setting up environment
 import './globals';
@@ -7,6 +7,8 @@ import './globals';
 const gutenbergSetup = () => {
 	const apiFetch = require( '@wordpress/api-fetch' ).default;
 	const wpData = require( '@wordpress/data' );
+
+	I18nManager.forceRTL(false);
 
 	// wp-api-fetch
 	apiFetch.use( apiFetch.createRootURLMiddleware( 'https://public-api.wordpress.com/' ) );

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const gutenbergSetup = () => {
 	const apiFetch = require( '@wordpress/api-fetch' ).default;
 	const wpData = require( '@wordpress/data' );
 
-	I18nManager.forceRTL(true); // Change to `false` to debug RTL layout easily.
+	I18nManager.forceRTL(false); // Change to `true` to debug RTL layout easily.
 
 	// wp-api-fetch
 	apiFetch.use( apiFetch.createRootURLMiddleware( 'https://public-api.wordpress.com/' ) );

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const gutenbergSetup = () => {
 	const apiFetch = require( '@wordpress/api-fetch' ).default;
 	const wpData = require( '@wordpress/data' );
 
-	I18nManager.forceRTL(false);
+	I18nManager.forceRTL(true); // Change to `false` to debug RTL layout easily.
 
 	// wp-api-fetch
 	apiFetch.use( apiFetch.createRootURLMiddleware( 'https://public-api.wordpress.com/' ) );


### PR DESCRIPTION
Fixes #380 

This PR fixes two issues related to RTL layout.

![rtl](https://user-images.githubusercontent.com/9772967/52572812-f837a580-2e18-11e9-9643-ff72ba1aa8da.png)

**1. The block Toolbar on Android:**

The content of the scroll view on Android was aligned left, while on iOS it was correctly aligned right. Probably the issue has little to do with alignment itself but on how each platform rotate scroll view for RTL support.

This was fix by forcing the content to grow as big as the scroll view itself (allowing it to grow bigger if necessary).

**2. BottomSheet text input:**

Fixed in the `gutenberg` related PR (https://github.com/WordPress/gutenberg/pull/13815)

This was an issue since we are inverting the natural alignment for text inputs, so we had to express this intention on RTL layout too. Sadly `text-align: end` didn't work (it's not allowed).

---

I added a helper to test RTL layout, but I'm unsure if we should keep for continue testing RTL in the future. Ideally we would have a switch in the UI or use the RN Dev Menu, but this last option requires native development.

**To test:**

- Run the project.
- Go to `src/index.js` and switch `I18nManager.forceRTL(false);` to `true`.
- Reload the app (you might need to reload more than once for some reason)
  - Now the layout should look mirrored horizontally (RTL)
  - Note that elements like images and icons are not inverted 👍
- Check that the ToolBar displays correctly.
- Edit a Header block and check that the content of the ToolBar is still scrollable.
- Display the Image Settings BottomSheet. (Wheel icon on a non-empty image block)
- Check that the TextInputs are displayed properly.