### PR TITLE
Update react-native-keyboard-aware-scroll-view in 3rd party podpecs

### DIFF
--- a/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
+++ b/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-keyboard-aware-scroll-view",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "homepage": "https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view",
   "summary": "React Native module to arrange scroll poisition according to keyboard on input fields.",
   "license": "MIT",
@@ -10,7 +10,7 @@
   },
   "source": {
     "git": "https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git",
-    "tag": "gb-v0.8.3"
+    "tag": "gb-v0.8.4"
   },
   "source_files": "ios/RNKeyboardAwareScrollView/*.{h,m}",
   "preserve_paths": "**/*.js",


### PR DESCRIPTION
This change updates react-native-keyboard-aware-scroll-view version in 3rd party podpecs.

Can be tested with PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/10968 Actually it'd be enough if that PR passed buddybuild

This should have been a part of PR https://github.com/wordpress-mobile/gutenberg-mobile/pull/554 but it was forgotten.