### PR TITLE
Support for the bridge in the android demo app

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -167,6 +167,7 @@ dependencies {
     implementation project(':react-native-svg')
 	implementation project(':react-native-aztec')
 	implementation project(':react-native-recyclerview-list')
+    implementation project(':react-native-gutenberg-bridge')
     // compile fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.android.support:appcompat-v7:$supportLibVersion"
     implementation "org.wordpress:utils:$wordpressUtilsVersion"

--- a/android/app/src/main/java/com/gutenberg/MainApplication.java
+++ b/android/app/src/main/java/com/gutenberg/MainApplication.java
@@ -5,6 +5,10 @@ import android.app.Application;
 import com.facebook.react.ReactApplication;
 import com.horcrux.svg.SvgPackage;
 import org.wordpress.mobile.ReactNativeAztec.ReactAztecPackage;
+import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent;
+import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.MediaSelectedCallback;
+import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.MediaUploadCallback;
+import org.wordpress.mobile.ReactNativeGutenbergBridge.RNReactNativeGutenbergBridgePackage;
 import com.github.godness84.RNRecyclerViewList.RNRecyclerviewListPackage;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
@@ -28,7 +32,32 @@ public class MainApplication extends Application implements ReactApplication {
           new MainReactPackage(),
             new SvgPackage(),
             new ReactAztecPackage(),
-            new RNRecyclerviewListPackage()
+            new RNRecyclerviewListPackage(),
+            new RNReactNativeGutenbergBridgePackage(new GutenbergBridgeJS2Parent() {
+                @Override
+                public void responseHtml(String title, String html, boolean changed) {}
+
+                @Override
+                public void requestMediaPickFromMediaLibrary(MediaSelectedCallback mediaSelectedCallback) {}
+
+                @Override
+                public void requestMediaPickFromDeviceLibrary(MediaUploadCallback mediaUploadCallback) {}
+
+                @Override
+                public void requestMediaPickerFromDeviceCamera(MediaUploadCallback mediaUploadCallback) {}
+
+                @Override
+                public void mediaUploadSync(MediaUploadCallback mediaUploadCallback) {}
+
+                @Override
+                public void requestImageFailedRetryDialog(int mediaId) {}
+
+                @Override
+                public void requestImageUploadCancelDialog(int mediaId) {}
+
+                @Override
+                public void editorDidMount(boolean hasUnsupportedBlocks) {}
+            })
       );
     }
 

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -5,5 +5,7 @@ include ':react-native-aztec'
 project(':react-native-aztec').projectDir = new File(rootProject.projectDir, '../react-native-aztec/android')
 include ':react-native-recyclerview-list'
 project(':react-native-recyclerview-list').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-recyclerview-list/android')
+include ':react-native-gutenberg-bridge'
+project(':react-native-gutenberg-bridge').projectDir = new File(rootProject.projectDir, '../react-native-gutenberg-bridge/android')
 
 include ':app'


### PR DESCRIPTION
We haven't made an effort to augment the Android demo app to support the bridge interface since that could be tested directly with the main WP app. We avoided having code directly call any of the bridge functions without responding to a request _from_ the bridge anyway.

With #587 though, we have the editor send up an event upon initializing/mounting, and that requires the bridge to be in place to work on Android. This PR adds that support.

Test do fail in this PR because the Jest is missing a mock for `editorDidMount()`. After all, the bridge is still not there for Jest anyway so, we need to mock it. Leaving this change for the parent PR though since it's not related to this PR.

To test:

* Run the demo app. It shouldn't red-screen complaining that `editorDidMount` is missing from the bridge. The demo app should run fine.