### PR TITLE
Fix placeholder position for RTL layout

### DIFF
--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -33,7 +33,7 @@ class RCTAztecView: Aztec.TextView {
         return contentInset.left + textContainerInset.left + textContainer.lineFragmentPadding
     }
 
-    var isRTLLayout: Bool {
+    var hasRTLLayout: Bool {
         return reactLayoutDirection == .rightToLeft
     }
 
@@ -48,7 +48,7 @@ class RCTAztecView: Aztec.TextView {
     // RCTScrollViews are flipped horizontally on RTL. This messes up competelly horizontal layout contraints
     // on views inserted after the transformation.
     var placeholderPreferedHorizontalAnchor: NSLayoutXAxisAnchor {
-        return isRTLLayout ? placeholderLabel.rightAnchor : placeholderLabel.leftAnchor
+        return hasRTLLayout ? placeholderLabel.rightAnchor : placeholderLabel.leftAnchor
     }
 
     // This constraint is created from the prefered horizontal anchor (analog to "leading")
@@ -117,7 +117,7 @@ class RCTAztecView: Aztec.TextView {
     }
 
     private func fixLabelPositionForRTLLayout() {
-        if isRTLLayout {
+        if hasRTLLayout {
             // RCTScrollViews are flipped horizontally on RTL layout.
             // This fixes the position of the label after "fixing" (partially) the constraints.
             placeholderHorizontalConstraint.constant = bounds.width - textHorizontalInset

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -29,8 +29,12 @@ class RCTAztecView: Aztec.TextView {
 
     private var previousContentSize: CGSize = .zero
 
-    var textHorizontalInset: CGFloat {
+    var leftTextInset: CGFloat {
         return contentInset.left + textContainerInset.left + textContainer.lineFragmentPadding
+    }
+
+    var leftTextInsetInRTLLayout: CGFloat {
+        return bounds.width - leftTextInset
     }
 
     var hasRTLLayout: Bool {
@@ -58,7 +62,7 @@ class RCTAztecView: Aztec.TextView {
     private lazy var placeholderHorizontalConstraint: NSLayoutConstraint = {
         return placeholderPreferedHorizontalAnchor.constraint(
             equalTo: leftAnchor,
-            constant: textHorizontalInset
+            constant: leftTextInset
         )
     }()
     
@@ -120,7 +124,7 @@ class RCTAztecView: Aztec.TextView {
         if hasRTLLayout {
             // RCTScrollViews are flipped horizontally on RTL layout.
             // This fixes the position of the label after "fixing" (partially) the constraints.
-            placeholderHorizontalConstraint.constant = bounds.width - textHorizontalInset
+            placeholderHorizontalConstraint.constant = leftTextInsetInRTLLayout
         }
     }
 


### PR DESCRIPTION
This PR fixes an issue on RTL layout with the position of placeholders:

iOS doesn't manage RTL layout automatically on scroll views, so React Native will flip horizontally RCTScrollViews on RTL layout to get the Right to Left effect.

The problem is that we are inserting an view into an already flipped tree of views, and this created all sort of weird layout behavior, braking the `leading` and `trailing` anchored constraints:
<img width="502" alt="screen shot 2019-02-12 at 7 55 09 pm" src="https://user-images.githubusercontent.com/9772967/52672011-d9223c00-2f1c-11e9-9d5b-29ac7003ea63.png">

```
<RCTCustomScrollView: 0x7f99a3839c00; baseClass = UIScrollView; frame = (0 0; 375 646); transform = [-1, 0, 0, 1, 0, 0]; 
```
Note: `transform = [-1, 0, 0, 1, 0, 0]; `

The solution is a non-conventional horizontal constraint on RTL layout, since `rn-aztec`'s left is logically at the right and right is at the left, but visually they are positioned "correctly.

Since this solution is non-conventional, I added plenty of explanation in the code itself, please let me know if it is clear enough.

The result of this is a correct placement of the placeholder at the right:
(Tested with `right-to-left pseudolanguage`)
![rtl-placeholder](https://user-images.githubusercontent.com/9772967/52672262-a298f100-2f1d-11e9-8f57-2db072c72257.gif)

**To test:**
- Checkout the corresponding [WPiOS PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/11018)
- `rake dependencies`
- Holding `options ⌥` key, click on the `Play (build and run)` button on Xcode.
- On Run -> Options -> Application Language, choose: `Right-To-Left Pseudolanguage`
- Run the app.
- Do your best to open an instance of Gutenberg with everything flipped :)
- Check that the Aztec placeholders show properly as in the attached gif.