### PR TITLE
Improve style of inserter UI

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -228,6 +228,7 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 						onDismiss={ () => this.showBlockTypePicker( false ) }
 						onValueSelected={ this.onBlockTypeSelected }
 						isReplacement={ this.isReplaceable( this.props.selectedBlock ) }
+						safeAreaBottomInset={ this.state.safeAreaBottomInset }
 					/>
 				) }
 			</SafeAreaView>

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -30,6 +30,8 @@ export default class BlockPicker extends Component<PropsType> {
 
 	render() {
 		const numberOfColumns = this.calculateNumberOfColumns();
+		const paddingBottom = this.paddingBottom();
+
 		return (
 			<Modal
 				transparent={ true }
@@ -41,7 +43,7 @@ export default class BlockPicker extends Component<PropsType> {
 				backdropColor={ 'lightgrey' }
 				backdropOpacity={ 0.4 }
 				onBackdropPress={ this.props.onDismiss }>
-				<View style={ [ styles.modalContent, { paddingBottom: ( styles.modalContent.paddingBottom + this.props.safeAreaBottomInset ) } ] }>
+				<View style={ [ styles.modalContent, { paddingBottom } ] }>
 					<View style={ styles.shortLineStyle } />
 					<FlatList
 						scrollEnabled={ false }
@@ -70,6 +72,13 @@ export default class BlockPicker extends Component<PropsType> {
 				</View>
 			</Modal>
 		);
+	}
+
+	paddingBottom() {
+		if ( this.props.safeAreaBottomInset > 0 ) {
+			return this.props.safeAreaBottomInset - styles.modalItem.paddingBottom;
+		}
+		return styles.modalContent.paddingBottom;
 	}
 
 	iconWithUpdatedFillColor( color: string, icon: SVG ) {

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -73,12 +73,11 @@ export default class BlockPicker extends Component<PropsType> {
 	}
 
 	iconWithUpdatedFillColor( color: string, icon: SVG ) {
-		return <SVG
-			viewBox={ icon.src.props.viewBox }
-			xmlns={ icon.src.props.xmlns }
-			style={ { fill: color } }>
-			{ icon.src.props.children }
-		</SVG>;
+		return (
+			<SVG viewBox={ icon.src.props.viewBox } xmlns={ icon.src.props.xmlns } style={ { fill: color } }>
+				{ icon.src.props.children }
+			</SVG>
+		);
 	}
 
 	calculateNumberOfColumns() {

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -3,7 +3,9 @@
  * @flow
  */
 
-// WordPress imports
+/**
+ * WordPress dependencies
+ */
 import { SVG } from '@wordpress/components';
 
 import React, { Component } from 'react';

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -3,6 +3,9 @@
  * @flow
  */
 
+// WordPress imports
+import { SVG } from '@wordpress/components';
+
 import React, { Component } from 'react';
 import { FlatList, Text, TouchableHighlight, View, Dimensions } from 'react-native';
 import Modal from 'react-native-modal';
@@ -52,7 +55,7 @@ export default class BlockPicker extends Component<PropsType> {
 								<View style={ styles.modalItem }>
 									<View style={ styles.modalIconWrapper }>
 										<View style={ styles.modalIcon }>
-											{ item.icon.src }
+											{ this.iconWithUpdatedFillColor( styles.modalIcon.fill, item.icon ) }
 										</View>
 									</View>
 									<Text style={ styles.modalItemLabel }>{ item.title }</Text>
@@ -63,6 +66,15 @@ export default class BlockPicker extends Component<PropsType> {
 				</View>
 			</Modal>
 		);
+	}
+
+	iconWithUpdatedFillColor( color: string, icon: SVG ) {
+		return <SVG
+			viewBox={ icon.src.props.viewBox }
+			xmlns={ icon.src.props.xmlns }
+			style={ { fill: color } }>
+			{ icon.src.props.children }
+		</SVG>;
 	}
 
 	calculateNumberOfColumns() {

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -8,7 +8,8 @@
  */
 import { SVG } from '@wordpress/components';
 
-import React, { Component } from 'react';
+import React from 'react';
+import { Component } from '@wordpress/element';
 import { FlatList, Text, TouchableHighlight, View, Dimensions } from 'react-native';
 import Modal from 'react-native-modal';
 import styles from './block-picker.scss';
@@ -21,6 +22,7 @@ type PropsType = {
 	isReplacement: boolean,
 	onValueSelected: ( itemValue: string ) => void,
 	onDismiss: () => void,
+	safeAreaBottomInset: number,
 };
 
 export default class BlockPicker extends Component<PropsType> {
@@ -39,7 +41,7 @@ export default class BlockPicker extends Component<PropsType> {
 				backdropColor={ 'lightgrey' }
 				backdropOpacity={ 0.4 }
 				onBackdropPress={ this.props.onDismiss }>
-				<View style={ styles.modalContent }>
+				<View style={ [ styles.modalContent, { paddingBottom: ( styles.modalContent.paddingBottom + this.props.safeAreaBottomInset ) } ] }>
 					<View style={ styles.shortLineStyle } />
 					<FlatList
 						scrollEnabled={ false }
@@ -89,3 +91,7 @@ export default class BlockPicker extends Component<PropsType> {
 		return Math.floor( containerTotalWidth / itemTotalWidth );
 	}
 }
+
+BlockPicker.defaultProps = {
+	safeAreaBottomInset: 0,
+};

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -3,13 +3,8 @@
  * @flow
  */
 
-/**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
 import React, { Component } from 'react';
-import { FlatList, Text, TouchableHighlight, View } from 'react-native';
+import { FlatList, Text, TouchableHighlight, View, Dimensions } from 'react-native';
 import Modal from 'react-native-modal';
 import styles from './block-picker.scss';
 import { name as unsupportedBlockName } from '../block-types/unsupported-block';
@@ -27,7 +22,7 @@ export default class BlockPicker extends Component<PropsType> {
 	availableBlockTypes = getBlockTypes().filter( ( { name } ) => name !== unsupportedBlockName );
 
 	render() {
-		const titleForAdd = __( 'ADD BLOCK' );
+		const numberOfColumns = this.calculateNumberOfColumns();
 		return (
 			<Modal
 				transparent={ true }
@@ -41,15 +36,11 @@ export default class BlockPicker extends Component<PropsType> {
 				onBackdropPress={ this.props.onDismiss }>
 				<View style={ styles.modalContent }>
 					<View style={ styles.shortLineStyle } />
-					<View>
-						<Text style={ styles.title }>
-							{ titleForAdd }
-						</Text>
-					</View>
-					<View style={ styles.lineStyle } />
 					<FlatList
+						scrollEnabled={ false }
+						key={ `InserterUI-${ numberOfColumns }` } //re-render when numberOfColumns changes
 						keyboardShouldPersistTaps="always"
-						numColumns={ 3 }
+						numColumns={ numberOfColumns }
 						data={ this.availableBlockTypes }
 						keyExtractor={ ( item ) => item.name }
 						renderItem={ ( { item } ) =>
@@ -59,8 +50,10 @@ export default class BlockPicker extends Component<PropsType> {
 								activeOpacity={ .5 }
 								onPress={ () => this.props.onValueSelected( item.name ) }>
 								<View style={ styles.modalItem }>
-									<View style={ styles.modalIcon }>
-										{ item.icon.src }
+									<View style={ styles.modalIconWrapper }>
+										<View style={ styles.modalIcon }>
+											{ item.icon.src }
+										</View>
 									</View>
 									<Text style={ styles.modalItemLabel }>{ item.title }</Text>
 								</View>
@@ -70,5 +63,15 @@ export default class BlockPicker extends Component<PropsType> {
 				</View>
 			</Modal>
 		);
+	}
+
+	calculateNumberOfColumns() {
+		const { width: windowWidth } = Dimensions.get( 'window' );
+		const { paddingLeft: itemPaddingLeft, paddingRight: itemPaddingRight } = styles.modalItem;
+		const { paddingLeft: containerPaddingLeft, paddingRight: containerPaddingRight } = styles.modalContent;
+		const { width: itemWidth } = styles.modalIconWrapper;
+		const itemTotalWidth = itemWidth + itemPaddingLeft + itemPaddingRight;
+		const containerTotalWidth = windowWidth - ( containerPaddingLeft + containerPaddingRight );
+		return Math.floor( containerTotalWidth / itemTotalWidth );
 	}
 }

--- a/src/block-management/block-picker.scss
+++ b/src/block-management/block-picker.scss
@@ -58,6 +58,7 @@
 	height: 32px;
 	justify-content: center;
 	align-items: center;
+	fill: $gray-dark;
 }
 
 .modalItemLabel {
@@ -68,4 +69,5 @@
 	padding-bottom: 0;
 	justify-content: center;
 	font-size: 12;
+	color: $gray-dark;
 }

--- a/src/block-management/block-picker.scss
+++ b/src/block-management/block-picker.scss
@@ -1,25 +1,18 @@
 /** @format */
 
 @import '../variables.scss';
-
-.title {
-	font-family: $default-monospace-font;
-	font-size: 16px;
-	font-weight: bold;
-	margin-bottom: 8px;
-}
-
-.lineStyle {
-	border-bottom-color: lightgray;
-	border-bottom-width: 1px;
-	width: 100%;
-}
+@import './colors.scss';
 
 .shortLineStyle {
-	border-bottom-color: lightgray;
-	border-bottom-width: 2px;
+	border-top-color: #e9eff3;
+	border-top-width: 4px;
+	border-radius: 4px 4px 4px 4px;
 	margin-bottom: 8px;
-	width: 40px;
+	margin-top: 0px;
+	vertical-align: top;
+	width: 36px;
+	height: 4px;
+	align-self: center;
 }
 
 .bottomModal {
@@ -32,45 +25,47 @@
 }
 
 .modalContent {
-	background-color: white;
-	padding-top: 8;
-	padding-bottom: 8;
-	justify-content: center;
+	padding: 6px 0px 12px 0px;
 	align-items: center;
+	justify-content: space-evenly;	
 	border-radius: 10px 10px 0px 0px;
-	border-color: grey;
+	border-color: #e0e1e2;
 	border-width: 1px;
+	background-color: white;
 }
 
 .modalItem {	
-	flex: 1 1 auto;
-	margin: 5px;
-	width: 100px;
-	align-self: stretch;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	padding-left: 8;
+	padding-right: 8;
+	padding-top: 6;
+	padding-bottom: 6;
+}
+
+.modalIconWrapper {
+	width: 104px;
+	height: 64px;
+	background-color: $gray-light; //#f3f6f8
+	border-radius: 4px 4px 4px 4px;
 	justify-content: center;
 	align-items: center;
 }
 
 .modalIcon {
-	flex: 1 1 auto;
-	background-color: lightgray;
-	padding-left: 8;
-	padding-right: 8;
-	padding-top: 8;
-	padding-bottom: 8;
-	margin: 4px;
-	width: 72px;
-	height: 48px;
+	width: 32px;
+	height: 32px;
 	justify-content: center;
 	align-items: center;
-	border-radius: 4px 4px 4px 4px;
 }
 
 .modalItemLabel {
 	background-color: transparent;
 	padding-left: 2;
 	padding-right: 2;
-	padding-top: 2;
-	padding-bottom: 2;
+	padding-top: 4;
+	padding-bottom: 0;
 	justify-content: center;
+	font-size: 12;
 }

--- a/src/block-management/block-picker.scss
+++ b/src/block-management/block-picker.scss
@@ -21,7 +21,7 @@
 }
 
 .touchableArea {
-	border-radius: 4px 4px 4px 4px;
+	border-radius: 8px 8px 8px 8px;
 }
 
 .modalContent {
@@ -48,7 +48,7 @@
 	width: 104px;
 	height: 64px;
 	background-color: $gray-light; //#f3f6f8
-	border-radius: 4px 4px 4px 4px;
+	border-radius: 8px 8px 8px 8px;
 	justify-content: center;
 	align-items: center;
 }


### PR DESCRIPTION
Fix: https://github.com/wordpress-mobile/gutenberg-mobile/issues/349

- Remove the title
- Make column number dynamic
- Update icon/text colors
- Update width/height of icons
- Update Button width/height
- Update justifying to content behavior

Some screenshots to demonstrate portrait/landscape modes for different number of items:

<img width="303" alt="screen shot 2019-02-18 at 13 01 41" src="https://user-images.githubusercontent.com/5032900/52945093-025e2480-3382-11e9-832e-81cca61efcba.png">

<img width="535" alt="screen shot 2019-02-18 at 13 01 33" src="https://user-images.githubusercontent.com/5032900/52945102-05591500-3382-11e9-945f-b292438a2377.png">

<img width="302" alt="screen shot 2019-02-18 at 13 02 18" src="https://user-images.githubusercontent.com/5032900/52945112-0ab65f80-3382-11e9-87d7-8930100c04ec.png">

<img width="531" alt="screen shot 2019-02-18 at 13 02 25" src="https://user-images.githubusercontent.com/5032900/52945117-0ee27d00-3382-11e9-955d-2129f9726564.png">

<img width="627" alt="screen shot 2019-02-18 at 13 15 53" src="https://user-images.githubusercontent.com/5032900/52945154-23267a00-3382-11e9-9d29-9081212c3390.png">

Resepecting Safe Area:

<img width="336" alt="screen shot 2019-02-18 at 14 01 49" src="https://user-images.githubusercontent.com/5032900/52946946-58cd6200-3386-11e9-8d3e-66a2590e1a9c.png">

<img width="719" alt="screen shot 2019-02-18 at 14 01 56" src="https://user-images.githubusercontent.com/5032900/52946947-5965f880-3386-11e9-9b9f-bbc7865cd0bc.png">


Android:

<img width="322" alt="screen shot 2019-02-18 at 13 21 18" src="https://user-images.githubusercontent.com/5032900/52945165-291c5b00-3382-11e9-8216-248a0eb97519.png">


**TO TEST**

For WPiOS

Checkout the PRs branch to any arbitrary folder and cd .. to it
run yarn install, yarn start
Open XCode WPiOS on the latest develop
Clean build folder on Xcode, and then run the app

For WPAndroid

open grade.properties at WordPress-Android folder
add wp.BUILD_GUTENBERG_FROM_SOURCE = true to grade.properties
checkout the PRs branch in the subrepo of WordPress-Android repo
cd to WordPress-Android/libs/gutenberg-mobile
run yarn install, yarn start
yarn wpandroid on a separate terminal in the same directory

Test Steps:

- Check that style matches with the latest designs
- Check that there's no anomaly in the inserter functionality
- Check with different device types and verify nothing looks odd.
