### PR TITLE
Fix dictation issue on iOS

### DIFF
--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -152,6 +152,7 @@ class RCTAztecView: Aztec.TextView {
         }
 
         super.insertText(text)
+        updatePlaceholderVisibility()
     }
 
     open override func deleteBackward() {
@@ -160,6 +161,7 @@ class RCTAztecView: Aztec.TextView {
         }
         
         super.deleteBackward()
+        updatePlaceholderVisibility()
     }
 
     // MARK: - Dictation
@@ -460,8 +462,9 @@ extension RCTAztecView: UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
 
         guard isInsertingDictationResult == false else {
-            // Dictation refreshes the TextView with an empty string when the dictation finishes
-            // This avoid propagating that unwanted empty string to RN.
+            // If a dictation start with an empty UITextView,
+            // the dictation engine refreshes the TextView with an empty string when the dictation finishes.
+            // This avoid propagating that unwanted empty string to RN. (Solving #606)
             return
         }
 

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -164,17 +164,16 @@ class RCTAztecView: Aztec.TextView {
 
     // MARK: - Dictation
 
+    override func dictationRecordingDidEnd() {
+        isInsertingDictationResult = true
+    }
+
     public override func insertDictationResult(_ dictationResult: [UIDictationPhrase]) {
         let text = dictationResult.reduce("") { $0 + $1.text }
         insertText(text)
         isInsertingDictationResult = false
     }
 
-    override func removeDictationResultPlaceholder(_ placeholder: Any, willInsertResult: Bool) {
-        super.removeDictationResultPlaceholder(placeholder, willInsertResult: willInsertResult)
-        isInsertingDictationResult = true
-    }
-    
     // MARK: - Custom Edit Intercepts
     
     private func interceptEnter(_ text: String) -> Bool {


### PR DESCRIPTION
fixes #606 

This PR fixes the dictation content disappearing from Paragraph blocks on iOS.

This is why the issue happens:
1. This happened just on empty TextViews (then explanation will assume that).
2. When the person is dictating, just `textViewDidChange` is called with the new text. (No `insertText`) is called.
3. When dictation finishes, `textViewDidChange` is called first with the text existing previous the dictation (an empty string in this case).
4. RNAztec propagates to the JS side the new content with that empty string.
5. The new text from dictation is inserted and `textViewDidChange` is called again with the full new text. (and RNAztec informs again the JS side)
6. RNAztec receives a `setContents` message from JS from the previous propagation of the empty string. Since JS resets `eventCount` to zero (undefined) when the string is empty, RNAztec refresh its state to an empty string, and the dictation string is lost.
7. RNAztec receives a `setContents` message from JS with the dictation string, but it's ignored since it has `eventCount == 1`

To fix the issue, I noticed that the step **3** is always called between `dictationRecordingDidEnd` and `insertDictationResult`.
Activating a flag in between those method calls to avoid propagating the empty string fixed the issue.


![dictation](https://user-images.githubusercontent.com/9772967/52957948-3c83f200-3393-11e9-9024-0711a921cbf9.gif)


**To test:** 
- Build and run the project.
- Create an empty paragraph block.
- Test the iOS dictation feature.
- Check that it behaves properly.