### PR TITLE
Fix/Set focus on title for new posts on Android

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -5,6 +5,7 @@ jest.mock( '../react-native-gutenberg-bridge', () => {
 		subscribeParentGetHtml: jest.fn(),
 		subscribeParentToggleHTMLMode: jest.fn(),
 		subscribeSetTitle: jest.fn(),
+		subscribeSetFocusOnTitle: jest.fn(),
 		subscribeUpdateHtml: jest.fn(),
 		editorDidMount: jest.fn(),
 	};

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -19,6 +19,7 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
     private static final String EVENT_NAME_REQUEST_GET_HTML = "requestGetHtml";
     private static final String EVENT_NAME_UPDATE_HTML = "updateHtml";
     private static final String EVENT_NAME_UPDATE_TITLE = "setTitle";
+    private static final String EVENT_NAME_FOCUS_TITLE = "setFocusOnTitle";
     private static final String EVENT_NAME_MEDIA_UPLOAD = "mediaUpload";
 
     private static final String MAP_KEY_UPDATE_HTML = "html";
@@ -72,6 +73,12 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
         writableMap.putString(MAP_KEY_UPDATE_TITLE, title);
         emitToJS(EVENT_NAME_UPDATE_TITLE, writableMap);
     }
+
+    public void setFocusOnTitleInJS() {
+        WritableMap writableMap = new WritableNativeMap();
+        emitToJS(EVENT_NAME_FOCUS_TITLE, writableMap);
+    }
+
 
     @ReactMethod
     public void provideToNative_Html(String html, String title, boolean changed) {

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -8,6 +8,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.v4.app.Fragment;
+import android.text.TextUtils;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout.LayoutParams;
@@ -142,7 +143,9 @@ public class WPAndroidGlueCode {
             @Override
             public void editorDidMount(boolean hasUnsupportedBlocks) {
                 mOnEditorMountListener.onEditorDidMount(hasUnsupportedBlocks);
-                setFocusOnTitle();
+                if (TextUtils.isEmpty(mTitle) && TextUtils.isEmpty(mContentHtml)) {
+                    setFocusOnTitle();
+                }
             }
         });
         return Arrays.asList(

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -142,6 +142,7 @@ public class WPAndroidGlueCode {
             @Override
             public void editorDidMount(boolean hasUnsupportedBlocks) {
                 mOnEditorMountListener.onEditorDidMount(hasUnsupportedBlocks);
+                setFocusOnTitle();
             }
         });
         return Arrays.asList(
@@ -265,6 +266,10 @@ public class WPAndroidGlueCode {
 
     public void showDevOptionsDialog() {
         mReactInstanceManager.showDevOptionsDialog();
+    }
+
+    public void setFocusOnTitle() {
+        mRnReactNativeGutenbergBridgePackage.getRNReactNativeGutenbergBridgeModule().setFocusOnTitleInJS();
     }
 
     public void setTitle(String title) {

--- a/react-native-gutenberg-bridge/index.js
+++ b/react-native-gutenberg-bridge/index.js
@@ -28,6 +28,10 @@ export function subscribeParentToggleHTMLMode( callback ) {
 	return gutenbergBridgeEvents.addListener( 'toggleHTMLMode', callback );
 }
 
+export function subscribeSetFocusOnTitle( callback ) {
+	return gutenbergBridgeEvents.addListener( 'setFocusOnTitle', callback );
+}
+
 export function subscribeSetTitle( callback ) {
 	return gutenbergBridgeEvents.addListener( 'setTitle', callback );
 }

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -29,7 +29,7 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { createBlock, isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { DefaultBlockAppender, PostTitle } from '@wordpress/editor';
-import { sendNativeEditorDidLayout } from 'react-native-gutenberg-bridge';
+import { sendNativeEditorDidLayout, subscribeSetFocusOnTitle } from 'react-native-gutenberg-bridge';
 
 type PropsType = {
 	rootClientId: ?string,
@@ -56,6 +56,8 @@ type StateType = {
 
 export class BlockManager extends React.Component<PropsType, StateType> {
 	scrollViewRef: Object;
+	titleViewRef: Object;
+	subscriptionParentSetFocusOnTitle: ?Object;
 
 	constructor( props: PropsType ) {
 		super( props );
@@ -126,12 +128,21 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 		Keyboard.addListener( 'keyboardDidShow', this.keyboardDidShow );
 		Keyboard.addListener( 'keyboardDidHide', this.keyboardDidHide );
 		SafeArea.addEventListener( 'safeAreaInsetsForRootViewDidChange', this.onSafeAreaInsetsUpdate );
+		this.subscriptionParentSetFocusOnTitle = subscribeSetFocusOnTitle( ( ) => {
+			const focusTitle = this.props.title === '' && this.props.blockCount === 0;
+			if ( this.titleViewRef && focusTitle ) {
+				this.titleViewRef.focus();
+			}
+		} );
 	}
 
 	componentWillUnmount() {
 		Keyboard.removeListener( 'keyboardDidShow', this.keyboardDidShow );
 		Keyboard.removeListener( 'keyboardDidHide', this.keyboardDidHide );
 		SafeArea.removeEventListener( 'safeAreaInsetsForRootViewDidChange', this.onSafeAreaInsetsUpdate );
+		if ( this.subscriptionParentSetFocusOnTitle ) {
+			this.subscriptionParentSetFocusOnTitle.remove();
+		}
 	}
 
 	keyboardDidShow() {
@@ -169,6 +180,7 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 					setRef={ ( ref ) => {
 						if ( focusTitle && ref ) {
 							ref.focus();
+							this.titleViewRef = ref;
 						}
 					} }
 					title={ this.props.title }

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -129,8 +129,7 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 		Keyboard.addListener( 'keyboardDidHide', this.keyboardDidHide );
 		SafeArea.addEventListener( 'safeAreaInsetsForRootViewDidChange', this.onSafeAreaInsetsUpdate );
 		this.subscriptionParentSetFocusOnTitle = subscribeSetFocusOnTitle( ( ) => {
-			const focusTitle = this.props.title === '' && this.props.blockCount === 0;
-			if ( this.titleViewRef && focusTitle ) {
+			if ( this.titleViewRef ) {
 				this.titleViewRef.focus();
 			}
 		} );


### PR DESCRIPTION
This PR fixes [wordpress-mobile/WordPress-iOS#10594](https://github.com/wordpress-mobile/WordPress-iOS/issues/10594) for Android. 

Initially we've made a fully JS version of it [here](https://github.com/wordpress-mobile/gutenberg-mobile/pull/599), but does't seem to work fine on Android, due to probably the way Android handle the focus. 
I've spent some hrs trying to fix the issue on the Android side (native) without much luck, then added to the bridge the ability to send an event `focus on title` and used it in the android app.

In this PR we wait until the editor is mounted, listen for `editorDidMount`, and emit an event to set the focus on title when both content and title are empty.

**Test 1**
- Use `wp-android`
- Check out this branch and build the app from code
- Start the app
- Tap on the New Post button in the home screen
- When the editor is mounted the keyboard should appear and the focus should be on the title

**Test 2**
- Go to posts list
- Edit a post made in GB
- The editor should start but no focus on the title

Not sure if something is required on the iOS side. Tests are passing.
