### PR TITLE
Avoid sending invalid caret rect information.

### DIFF
--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -258,8 +258,11 @@ class RCTAztecView: Aztec.TextView {
         
         if let selectedTextRange = selectedTextRange {
             let caretEndRect = caretRect(for: selectedTextRange.end)
-            result["selectionEndCaretX"] = caretEndRect.origin.x
-            result["selectionEndCaretY"] = caretEndRect.origin.y
+            // Sergio Estevao: Sometimes the carectRect can be invalid so we need to check before sending this to JS.
+            if !(caretEndRect.isInfinite || caretEndRect.isEmpty || caretEndRect.isNull) {
+                result["selectionEndCaretX"] = caretEndRect.origin.x
+                result["selectionEndCaretY"] = caretEndRect.origin.y
+            }
         }
 
         return result


### PR DESCRIPTION
Refs #559 

This PR adds a fix to avoid sending invalid caret information that was breaking JS conversion.