### PR TITLE
Fix for node.rel crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "jed": "^1.1.1",
     "js-beautify": "^1.7.5",
     "jsc-android": "224109.x.x",
-    "jsdom-jscore": "git+https://github.com/wordpress-mobile/jsdom-jscore-rn.git#b1f06050503fc3a145d179188384d09583865043",
+    "jsdom-jscore": "git+https://github.com/iamcco/jsdom-jscore-rn.git#a562f3d57c27c13e5bfc8cf82d496e69a3ba2800",
     "jsx-to-string": "^1.3.1",
     "memize": "^1.0.5",
     "moment": "^2.22.1",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "jed": "^1.1.1",
     "js-beautify": "^1.7.5",
     "jsc-android": "224109.x.x",
-    "jsdom-jscore": "git+https://github.com/iamcco/jsdom-jscore-rn.git#6eac88dd5d5e7c21ce6382abde7dbc376d7f7f59",
+    "jsdom-jscore": "git+https://github.com/wordpress-mobile/jsdom-jscore-rn.git#b1f06050503fc3a145d179188384d09583865043",
     "jsx-to-string": "^1.3.1",
     "memize": "^1.0.5",
     "moment": "^2.22.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5153,9 +5153,9 @@ jsc-android@224109.x.x:
   resolved "https://registry.yarnpkg.com/jsc-android/-/jsc-android-224109.1.0.tgz#9749ec92f1e284b3c09befe7c47cc6e60b1f0cdf"
   integrity sha512-mhALFynePc/wJsUt9BJuH13mSK/dGWtBO/pcYwVV1I0A7iduyqy3fSoAt1b0yI+/B3TzlGyue/gqjPxsqG1HRQ==
 
-"jsdom-jscore@git+https://github.com/wordpress-mobile/jsdom-jscore-rn.git#b1f06050503fc3a145d179188384d09583865043":
+"jsdom-jscore@git+https://github.com/iamcco/jsdom-jscore-rn.git#a562f3d57c27c13e5bfc8cf82d496e69a3ba2800":
   version "0.1.7"
-  resolved "git+https://github.com/wordpress-mobile/jsdom-jscore-rn.git#b1f06050503fc3a145d179188384d09583865043"
+  resolved "git+https://github.com/iamcco/jsdom-jscore-rn.git#a562f3d57c27c13e5bfc8cf82d496e69a3ba2800"
   dependencies:
     htmlparser2-without-node-native "^3.9.2"
     querystring "^0.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5153,9 +5153,9 @@ jsc-android@224109.x.x:
   resolved "https://registry.yarnpkg.com/jsc-android/-/jsc-android-224109.1.0.tgz#9749ec92f1e284b3c09befe7c47cc6e60b1f0cdf"
   integrity sha512-mhALFynePc/wJsUt9BJuH13mSK/dGWtBO/pcYwVV1I0A7iduyqy3fSoAt1b0yI+/B3TzlGyue/gqjPxsqG1HRQ==
 
-"jsdom-jscore@git+https://github.com/iamcco/jsdom-jscore-rn.git#6eac88dd5d5e7c21ce6382abde7dbc376d7f7f59":
+"jsdom-jscore@git+https://github.com/wordpress-mobile/jsdom-jscore-rn.git#b1f06050503fc3a145d179188384d09583865043":
   version "0.1.7"
-  resolved "git+https://github.com/iamcco/jsdom-jscore-rn.git#6eac88dd5d5e7c21ce6382abde7dbc376d7f7f59"
+  resolved "git+https://github.com/wordpress-mobile/jsdom-jscore-rn.git#b1f06050503fc3a145d179188384d09583865043"
   dependencies:
     htmlparser2-without-node-native "^3.9.2"
     querystring "^0.2.0"


### PR DESCRIPTION
Addresses at least one case of "Pasting from some sources causes a red screen ([related comment](https://github.com/wordpress-mobile/gutenberg-mobile/pull/617#pullrequestreview-205427915))" from #624

To test:

0. On the mobile, open the browser and copy the "Gravity Forms" text (it's a link) from https://designsbytierney.com/2010/01/how-to-add-edit-format-text-in-a-wordpress-post-or-page/
1. Run the demo app
2. In a paragraph block, paste
3. It should work and the link be available in the block