### PR TITLE
Remove JS handling of title focus

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -171,16 +171,11 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 	}
 
 	renderHeader() {
-		const focusTitle = this.props.title === '' && this.props.blockCount === 0;
-
 		return (
 			<View style={ styles.titleContainer }>
 				<PostTitle
 					setRef={ ( ref ) => {
-						if ( focusTitle && ref ) {
-							ref.focus();
-							this.titleViewRef = ref;
-						}
+						this.titleViewRef = ref;
 					} }
 					title={ this.props.title }
 					onUpdate={ this.props.setTitleAction }


### PR DESCRIPTION
There is a bridge message in place to let the parent app tell `gutenberg` when it should focus the title. Android seems to be using that mechanism to focus the title.
(Is that correct @daniloercoli ?)

This PR implement the title focus feature using this message from the parent app instead of letting the JS side do it by itself.

The main reason of this change is a glitch on the toolbar + SafeAreas.
Check the WPiOS related PR to see the native side implementation.

**Before:**
![focus-bug](https://user-images.githubusercontent.com/9772967/53126166-d9938600-355f-11e9-90e0-c9d74cad2951.gif)


**Now:**
![focus-fix](https://user-images.githubusercontent.com/9772967/53126142-ca143d00-355f-11e9-8c35-3e84f4c6483f.gif)

**To test:**
- Check out WPAndroid with this branch, and check that the autofocus on new posts still works.
- Checkout the [WPiOS related PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/11097) running **metro on this branch**.
- Check that the autofocus on new posts works properly.
- Check that the toolbar is properly positioned.

cc @pinarol - This might also fix the title border issue on the initial autofocus mentioned here: https://github.com/wordpress-mobile/gutenberg-mobile/pull/622#pullrequestreview-205884150