### PR TITLE
Fix i18n initialization priority

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 /** @flow
  * @format */
 
-import { setupApp } from './src';
+import { registerApp } from './src';
 
-setupApp();
+registerApp();

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -1,19 +1,10 @@
 /** @flow
  * @format */
 
-import { I18nManager } from 'react-native';
 import React from 'react';
-
-// Gutenberg imports
-import apiFetch from '@wordpress/api-fetch';
-import * as data from '@wordpress/data';
-import { registerCoreBlocks } from '@wordpress/block-library';
-import { registerBlockType, setUnregisteredTypeHandlerName, unregisterBlockType } from '@wordpress/blocks';
-import '@wordpress/format-library';
 
 import AppContainer from './AppContainer';
 import initialHtml from './initial-html';
-import * as UnsupportedBlock from '../block-types/unsupported-block';
 
 type PropsType = {
 	initialData: string,
@@ -22,38 +13,6 @@ type PropsType = {
 };
 
 export default class AppProvider extends React.Component<PropsType> {
-	constructor( props: PropsType ) {
-		super( props );
-		this.gutenbergSetup();
-		this.editorSetup();
-	}
-
-	gutenbergSetup() {
-		I18nManager.forceRTL( false ); // Change to `true` to debug RTL layout easily.
-
-		// wp-api-fetch
-		apiFetch.use( apiFetch.createRootURLMiddleware( 'https://public-api.wordpress.com/' ) );
-
-		// wp-data
-		const userId = 1;
-		const storageKey = 'WP_DATA_USER_' + userId;
-		data.use( data.plugins.persistence, { storageKey: storageKey } );
-		data.use( data.plugins.controls );
-	}
-
-	editorSetup() {
-		// register and setup blocks
-		registerCoreBlocks();
-		registerBlockType( UnsupportedBlock.name, UnsupportedBlock.settings );
-		setUnregisteredTypeHandlerName( UnsupportedBlock.name );
-
-		// disable Code and More blocks for release
-		if ( ! __DEV__ ) {
-			unregisterBlockType( 'core/code' );
-			unregisterBlockType( 'core/more' );
-		}
-	}
-
 	render() {
 		const { initialHtmlModeEnabled } = this.props;
 		let initialData = this.props.initialData;

--- a/src/app/App.test.js
+++ b/src/app/App.test.js
@@ -2,13 +2,17 @@
 
 import renderer from 'react-test-renderer';
 
-import { registerApp } from '..';
+import { registerApp, RootComponent } from '..';
 import App from './App';
 import BlockHolder from '../block-management/block-holder';
 import { dispatch, select } from '@wordpress/data';
 
 describe( 'App', () => {
 	beforeAll( registerApp );
+	beforeAll( () => {
+		// Instantiate root component so Gutenberg gets set up
+		new RootComponent( {} );
+	} );
 
 	it( 'renders without crashing', () => {
 		const app = renderer.create( <App /> );

--- a/src/app/App.test.js
+++ b/src/app/App.test.js
@@ -2,13 +2,13 @@
 
 import renderer from 'react-test-renderer';
 
-import { setupApp } from '..';
+import { registerApp } from '..';
 import App from './App';
 import BlockHolder from '../block-management/block-holder';
 import { dispatch, select } from '@wordpress/data';
 
 describe( 'App', () => {
-	beforeAll( setupApp );
+	beforeAll( registerApp );
 
 	it( 'renders without crashing', () => {
 		const app = renderer.create( <App /> );

--- a/src/app/App.test.js
+++ b/src/app/App.test.js
@@ -2,17 +2,13 @@
 
 import renderer from 'react-test-renderer';
 
-import { registerApp, RootComponent } from '..';
+import { setupApp } from '..';
 import App from './App';
 import BlockHolder from '../block-management/block-holder';
 import { dispatch, select } from '@wordpress/data';
 
 describe( 'App', () => {
-	beforeAll( registerApp );
-	beforeAll( () => {
-		// Instantiate root component so Gutenberg gets set up
-		new RootComponent( {} );
-	} );
+	beforeAll( setupApp );
 
 	it( 'renders without crashing', () => {
 		const app = renderer.create( <App /> );

--- a/src/app/App.test.js
+++ b/src/app/App.test.js
@@ -2,13 +2,13 @@
 
 import renderer from 'react-test-renderer';
 
-import { setupApp } from '..';
+import { bootstrapEditor } from '..';
 import App from './App';
 import BlockHolder from '../block-management/block-holder';
 import { dispatch, select } from '@wordpress/data';
 
 describe( 'App', () => {
-	beforeAll( setupApp );
+	beforeAll( bootstrapEditor );
 
 	it( 'renders without crashing', () => {
 		const app = renderer.create( <App /> );

--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ const setupLocale = ( locale, extraTranslations ) => {
 	}
 };
 
-class RootComponent extends React.Component {
+export class RootComponent extends React.Component {
 	constructor( props ) {
 		super( props );
 		setupLocale( props.locale, props.translations );

--- a/src/index.js
+++ b/src/index.js
@@ -64,8 +64,8 @@ const setupLocale = ( locale, extraTranslations ) => {
 export class RootComponent extends React.Component {
 	constructor( props ) {
 		super( props );
-		setupApp();
 		setupLocale( props.locale, props.translations );
+		setupApp();
 	}
 
 	render() {

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ export class RootComponent extends React.Component {
 	constructor( props ) {
 		super( props );
 		setupLocale( props.locale, props.translations );
-		setupApp();
+		bootstrapEditor();
 	}
 
 	render() {
@@ -86,7 +86,7 @@ export function registerApp() {
 	AppRegistry.registerComponent( 'gutenberg', () => RootComponent );
 }
 
-export function setupApp() {
+export function bootstrapEditor() {
 	gutenbergSetup();
 	editorSetup();
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 // External dependencies
-import { AppRegistry, I18nManager } from 'react-native';
+import { AppRegistry, I18nManager, YellowBox } from 'react-native';
 import React from 'react';
 
 // Setting up environment
@@ -81,6 +81,8 @@ class RootComponent extends React.Component {
 }
 
 export function registerApp() {
-	// Making sure the environment is set up before loading any Component
+	// Disable require circle warnings showing up in the app (they will still be visible in the console)
+	YellowBox.ignoreWarnings( [ 'Require cycle:' ] );
+
 	AppRegistry.registerComponent( 'gutenberg', () => RootComponent );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -64,9 +64,8 @@ const setupLocale = ( locale, extraTranslations ) => {
 export class RootComponent extends React.Component {
 	constructor( props ) {
 		super( props );
+		setupApp();
 		setupLocale( props.locale, props.translations );
-		gutenbergSetup();
-		editorSetup();
 	}
 
 	render() {
@@ -85,4 +84,9 @@ export function registerApp() {
 	YellowBox.ignoreWarnings( [ 'Require cycle:' ] );
 
 	AppRegistry.registerComponent( 'gutenberg', () => RootComponent );
+}
+
+export function setupApp() {
+	gutenbergSetup();
+	editorSetup();
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,43 +1,81 @@
 // External dependencies
-import { AppRegistry } from 'react-native';
+import { AppRegistry, I18nManager } from 'react-native';
 import React from 'react';
 
 // Setting up environment
 import './globals';
+import { getTranslation } from '../i18n-cache';
+import { setLocaleData } from '@wordpress/i18n';
+
+const gutenbergSetup = () => {
+	const apiFetch = require( '@wordpress/api-fetch' ).default;
+	const wpData = require( '@wordpress/data' );
+
+	// wp-api-fetch
+	apiFetch.use( apiFetch.createRootURLMiddleware( 'https://public-api.wordpress.com/' ) );
+
+	// wp-data
+	const userId = 1;
+	const storageKey = 'WP_DATA_USER_' + userId;
+	wpData.use( wpData.plugins.persistence, { storageKey: storageKey } );
+	wpData.use( wpData.plugins.controls );
+};
+
+const editorSetup = () => {
+	require( '@wordpress/format-library' );
+	const wpBlockLibrary = require( '@wordpress/block-library' );
+	const wpBlocks = require( '@wordpress/blocks' );
+	const registerCoreBlocks = wpBlockLibrary.registerCoreBlocks;
+	const registerBlockType = wpBlocks.registerBlockType;
+	const setUnregisteredTypeHandlerName = wpBlocks.setUnregisteredTypeHandlerName;
+	const unregisterBlockType = wpBlocks.unregisterBlockType;
+	const UnsupportedBlock = require( './block-types/unsupported-block' );
+
+	// register and setup blocks
+	registerCoreBlocks();
+	registerBlockType( UnsupportedBlock.name, UnsupportedBlock.settings );
+	setUnregisteredTypeHandlerName( UnsupportedBlock.name );
+
+	// disable Code and More blocks for release
+	if ( ! __DEV__ ) {
+		unregisterBlockType( 'core/code' );
+		unregisterBlockType( 'core/more' );
+	}
+};
+
+const setupLocale = ( locale, extraTranslations ) => {
+	I18nManager.forceRTL( false ); // Change to `true` to debug RTL layout easily.
+
+	let gutenbergTranslations = getTranslation( locale );
+	if ( locale && ! gutenbergTranslations ) {
+		// Try stripping out the regional
+		locale = locale.replace( /[-_][A-Za-z]+$/, '' );
+		gutenbergTranslations = getTranslation( locale );
+	}
+	const translations = Object.assign( {}, gutenbergTranslations, extraTranslations );
+	// eslint-disable-next-line no-console
+	console.log( 'locale', locale, translations );
+	// Only change the locale if it's supported by gutenberg
+	if ( gutenbergTranslations || extraTranslations ) {
+		setLocaleData( translations );
+	}
+};
 
 class RootComponent extends React.Component {
 	constructor( props ) {
 		super( props );
-		this.setupLocale();
-	}
-
-	setupLocale() {
-		const translationsFromParentApp = this.props.translations;
-		let locale = this.props.locale;
-
-		const setLocaleData = require( '@wordpress/i18n' ).setLocaleData;
-		const getTranslation = require( '../i18n-cache' ).getTranslation;
-
-		let gutenbergTranslations = getTranslation( locale );
-		if ( locale && ! gutenbergTranslations ) {
-			// Try stripping out the regional
-			locale = locale.replace( /[-_][A-Za-z]+$/, '' );
-			gutenbergTranslations = getTranslation( locale );
-		}
-		const translations = Object.assign( {}, gutenbergTranslations, translationsFromParentApp );
-		// eslint-disable-next-line no-console
-		console.log( 'locale', locale, translations );
-		// Only change the locale if it's supported by gutenberg
-		if ( gutenbergTranslations || translationsFromParentApp ) {
-			setLocaleData( translations );
-		}
+		setupLocale( props.locale, props.translations );
+		gutenbergSetup();
+		editorSetup();
 	}
 
 	render() {
+		// eslint-disable-next-line no-unused-vars
+		const { locale, translations, ...otherProps } = this.props;
+		// Need to wait for everything to be setup before requiring our App
 		const App = require( './app/App' ).default;
-		const initialProps = this.props;
 		return (
-			<App { ...this.props } />
+			<App { ...otherProps } />
 		);
 	}
 }


### PR DESCRIPTION
Before this, the block titles were not being translated because the translation attempt happened before the locale data was set up.

This refactors the initialization process to ensure we setup localization before Gutenberg is imported

![simulator screen shot - iphone xs - 2019-02-22 at 13 40 06](https://user-images.githubusercontent.com/8739/53243188-6432cd00-36a7-11e9-9e30-99cbdae345e7.png)

This was originally implemented as part of #643 but that one isn't ready to merge yet

## To Test

1. Switch your phone/simulator to another language
2. Try to insert a block and verify the title is translated