### PR TITLE
Reference the Aztec-Android tag. Code is still the same

### DIFF
--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = 'e02ec1387c739d73645e498a2e5ed1b3916b2587'
+        aztecVersion = 'v1.3.20'
     }
 
     repositories {


### PR DESCRIPTION
Just use the Aztec-Android named release as a reference, in preparation of the v1.0 release of gutenberg-mobile. The pointed to code is exactly the same as before, the only changes are in the README file of Aztec.

This change is trivial and I will self-merge to ease with the release process.