### PR TITLE
Fix title padding on Android

### DIFF
--- a/src/variables.android.scss
+++ b/src/variables.android.scss
@@ -3,3 +3,5 @@
 // Fonts
 $default-monospace-font: monospace;
 $default-regular-font: serif;
+$title-block-padding-top: 0;
+$title-block-padding-bottom: 0;

--- a/src/variables.ios.scss
+++ b/src/variables.ios.scss
@@ -3,3 +3,5 @@
 // Fonts
 $default-monospace-font: courier;
 $default-regular-font: 'Noto Serif';
+$title-block-padding-top: 12;
+$title-block-padding-bottom: 12;


### PR DESCRIPTION
This PR separates the title padding styles of iOS and Android and removes the vertical paddings of post title on Android because Android handles the paddings on native side.

Changes reside in gutenberg PR https://github.com/WordPress/gutenberg/pull/14057