### PR TITLE
Use different block minHeight between the platforms

### DIFF
--- a/src/variables.android.scss
+++ b/src/variables.android.scss
@@ -5,3 +5,7 @@ $default-monospace-font: monospace;
 $default-regular-font: serif;
 $title-block-padding-top: 0;
 $title-block-padding-bottom: 0;
+
+$min-height-title: 53;
+$min-height-paragraph: 50;
+$min-height-heading: 50;

--- a/src/variables.ios.scss
+++ b/src/variables.ios.scss
@@ -5,3 +5,7 @@ $default-monospace-font: courier;
 $default-regular-font: 'Noto Serif';
 $title-block-padding-top: 12;
 $title-block-padding-bottom: 12;
+
+$min-height-title: 30;
+$min-height-paragraph: 24;
+$min-height-heading: 24;


### PR DESCRIPTION
Fixes #666 

Currently, each mobile platform has different internal paddings in Aztec so, need to set different block minHeights for each platform.

Gutenberg side PR: https://github.com/WordPress/gutenberg/pull/14070

To test:

1. Run the demo app in both Android and iOS
2. Add a paragraph block. Notice that the block placeholder is fully visible without a glitch.