### PR TITLE
Fix `min-height-title` to avoid little but still noticeable glitch

### DIFF
--- a/src/variables.android.scss
+++ b/src/variables.android.scss
@@ -6,6 +6,6 @@ $default-regular-font: serif;
 $title-block-padding-top: 0;
 $title-block-padding-bottom: 0;
 
-$min-height-title: 53;
+$min-height-title: 55;
 $min-height-paragraph: 50;
 $min-height-heading: 50;


### PR DESCRIPTION
When #664 was merged I wasn't available to properly test but now I saw a small glitch still happening, by following the instructions to test given in https://github.com/wordpress-mobile/WordPress-Android/pull/9324:

> 2. Notice the post title not having this glitch: https://github.com/wordpress-mobile/gutenberg-mobile/issues/666

Currently, the glitch can be seen in [`v1.0.1` tag](https://github.com/wordpress-mobile/gutenberg-mobile/releases/tag/v1.0.1) (for future reference, current commit being pointed by `v1.0.1` is https://github.com/wordpress-mobile/gutenberg-mobile/commit/44f1d996f6a679b9d6197763979eb0b65f7fbea4)

![glitch](https://user-images.githubusercontent.com/6597771/53308281-1503bc80-38a0-11e9-9d05-7f078ba69872.gif)

The glitch is hardly noticeable but the solution seemed to go on the right path, so just changing the value a bit made it go away:

![no_glitch](https://user-images.githubusercontent.com/6597771/53308299-319ff480-38a0-11e9-9a86-9dabfba88128.gif)

So, effectively changed the `min-height-title` in 2fdfed3, and added a new release branch `release/1.0.2` to be able to create the PR against. Note we can effectively just merge [this branch](https://github.com/wordpress-mobile/gutenberg-mobile/tree/fix/min-height-glitch-minor) to `develop` and then re-tag `v1.0.1` on that one for the sake of simplicity (it's just a value change after all, not affecting other functionality), but needed to make a new branch in order to be able to create the PR, which is needed for documenting purposes to the least.



