### PR TITLE
Allow gutenberg bridge to add custom modules.

### DIFF
--- a/ios/CustomImageLoader.swift
+++ b/ios/CustomImageLoader.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+class CustomImageLoader: NSObject, RCTImageURLLoader {
+
+  static func moduleName() -> String! {
+    return "CustomImageLoader"
+  }
+
+  func canLoadImageURL(_ requestURL: URL!) -> Bool {
+    return !requestURL.isFileURL
+  }
+
+  func loadImage(for imageURL: URL!, size: CGSize, scale: CGFloat, resizeMode: RCTResizeMode, progressHandler: RCTImageLoaderProgressBlock!, partialLoadHandler: RCTImageLoaderPartialLoadBlock!, completionHandler: RCTImageLoaderCompletionBlock!) -> RCTImageLoaderCancellationBlock! {
+    let task = URLSession.shared.dataTask(with: imageURL) { (data, response, error) in
+      if let error = error {
+        completionHandler(error, nil)
+        return
+      }
+      guard let data = data,
+        let image = UIImage.init(data: data) else {
+        completionHandler?(NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo: nil), nil)
+        return;
+      }
+      completionHandler?(nil, image)
+    }
+    task.resume()
+    return { () in
+      task.cancel()
+    }
+  }
+
+  func loaderPriority() -> Float {
+    return 100
+  }
+  
+}

--- a/ios/gutenberg.xcodeproj/project.pbxproj
+++ b/ios/gutenberg.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		F1EE6F7A21E7F0A500241744 /* NotoSerif-Italic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F1EE6F7621E7F0A500241744 /* NotoSerif-Italic.ttf */; };
 		F1EE6F7B21E7F0A500241744 /* NotoSerif-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F1EE6F7721E7F0A500241744 /* NotoSerif-Bold.ttf */; };
 		FF6836C822035EAB00A0C562 /* MediaUploadCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6836C722035EAB00A0C562 /* MediaUploadCoordinator.swift */; };
+		FF83DAA92226905A00A34C93 /* CustomImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF83DAA82226905A00A34C93 /* CustomImageLoader.swift */; };
 		FF9A6F4121FA8E2500D36D14 /* MediaPickCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9A6F1621FA8E2500D36D14 /* MediaPickCoordinator.swift */; };
 /* End PBXBuildFile section */
 
@@ -435,6 +436,7 @@
 		F1EE6F7721E7F0A500241744 /* NotoSerif-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSerif-Bold.ttf"; sourceTree = "<group>"; };
 		F619623252704B46A619C33C /* RNTAztecView.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNTAztecView.xcodeproj; path = "../react-native-aztec/ios/RNTAztecView.xcodeproj"; sourceTree = "<group>"; };
 		FF6836C722035EAB00A0C562 /* MediaUploadCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MediaUploadCoordinator.swift; path = gutenberg/MediaUploadCoordinator.swift; sourceTree = "<group>"; };
+		FF83DAA82226905A00A34C93 /* CustomImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomImageLoader.swift; sourceTree = "<group>"; };
 		FF9A6F1621FA8E2500D36D14 /* MediaPickCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MediaPickCoordinator.swift; path = gutenberg/MediaPickCoordinator.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -592,6 +594,7 @@
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				13B07FB11A68108700A75B9A /* LaunchScreen.xib */,
+				FF83DAA82226905A00A34C93 /* CustomImageLoader.swift */,
 			);
 			name = gutenberg;
 			sourceTree = "<group>";
@@ -1371,6 +1374,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F151983C2100DC3D000F6E97 /* AppDelegate.swift in Sources */,
+				FF83DAA92226905A00A34C93 /* CustomImageLoader.swift in Sources */,
 				FF9A6F4121FA8E2500D36D14 /* MediaPickCoordinator.swift in Sources */,
 				F151983D2100DC3D000F6E97 /* MediaProvider.swift in Sources */,
 				FF6836C822035EAB00A0C562 /* MediaUploadCoordinator.swift in Sources */,

--- a/ios/gutenberg/GutenbergViewController.swift
+++ b/ios/gutenberg/GutenbergViewController.swift
@@ -5,7 +5,7 @@ import Aztec
 
 class GutenbergViewController: UIViewController {
 
-    fileprivate lazy var gutenberg = Gutenberg(dataSource: self)
+    fileprivate lazy var gutenberg = Gutenberg(dataSource: self, extraModules: [CustomImageLoader()])
     fileprivate var htmlMode = false
     fileprivate var mediaPickCoordinator: MediaPickCoordinator?
     fileprivate lazy var mediaUploadCoordinator: MediaUploadCoordinator = {

--- a/react-native-gutenberg-bridge/ios/Gutenberg.swift
+++ b/react-native-gutenberg-bridge/ios/Gutenberg.swift
@@ -9,6 +9,9 @@ import RNTAztecView
 
 @objc
 public class Gutenberg: NSObject {
+
+    private var extraModules: [RCTBridgeModule];
+
     public lazy var rootView: UIView = {
         return RCTRootView(bridge: bridge, moduleName: "gutenberg", initialProperties: initialProps)
     }()
@@ -55,8 +58,9 @@ public class Gutenberg: NSObject {
         return initialProps
     }
 
-    public init(dataSource: GutenbergBridgeDataSource) {
+    public init(dataSource: GutenbergBridgeDataSource, extraModules: [RCTBridgeModule] = []) {
         self.dataSource = dataSource
+        self.extraModules = extraModules
     }
 
     public func invalidate() {
@@ -104,8 +108,9 @@ extension Gutenberg: RCTBridgeDelegate {
     public func extraModules(for bridge: RCTBridge!) -> [RCTBridgeModule]! {
         let aztecManager = RCTAztecViewManager()
         aztecManager.attachmentDelegate = dataSource.aztecAttachmentDelegate()
-
-        return [bridgeModule, aztecManager]
+        var modules:[RCTBridgeModule] = [bridgeModule, aztecManager]
+        modules.append(contentsOf: extraModules)
+        return modules
     }
 }
 

--- a/react-native-gutenberg-bridge/ios/Gutenberg.swift
+++ b/react-native-gutenberg-bridge/ios/Gutenberg.swift
@@ -108,9 +108,8 @@ extension Gutenberg: RCTBridgeDelegate {
     public func extraModules(for bridge: RCTBridge!) -> [RCTBridgeModule]! {
         let aztecManager = RCTAztecViewManager()
         aztecManager.attachmentDelegate = dataSource.aztecAttachmentDelegate()
-        var modules:[RCTBridgeModule] = [bridgeModule, aztecManager]
-        modules.append(contentsOf: extraModules)
-        return modules
+        let baseModules:[RCTBridgeModule] = [bridgeModule, aztecManager]
+        return baseModules + extraModules
     }
 }
 

--- a/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge-Bridging-Header.h
+++ b/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge-Bridging-Header.h
@@ -7,3 +7,4 @@
 #import <React/RCTViewManager.h>
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
+#import <React/RCTImageLoader.h>


### PR DESCRIPTION
Refs: #376 

This PR changes the GB bridge class to support the customization of the bridge with extra modules. It also implements on the custom a sample custom image loader, to allow testing of loading of images.

How to test:
 - Start the demo app
 - Check that images are being loaded.