### PR TITLE
Update react-native-keyboard-aware-scroll-view version on iOS example app

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "react": "16.6.1",
     "react-native": "0.57.5",
     "react-native-hr": "git+https://github.com/Riglerr/react-native-hr.git#2d01a5cf77212d100e8b99e0310cce5234f977b3",
-    "react-native-keyboard-aware-scroll-view": "git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#gb-v0.8.4",
+    "react-native-keyboard-aware-scroll-view": "git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#gb-v0.8.5",
     "react-native-modal": "^6.5.0",
     "react-native-recyclerview-list": "git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#v1.0.0",
     "react-native-safe-area": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "react": "16.6.1",
     "react-native": "0.57.5",
     "react-native-hr": "git+https://github.com/Riglerr/react-native-hr.git#2d01a5cf77212d100e8b99e0310cce5234f977b3",
-    "react-native-keyboard-aware-scroll-view": "git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#gb-v0.8.5",
+    "react-native-keyboard-aware-scroll-view": "git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#gb-v0.8.6",
     "react-native-modal": "^6.5.0",
     "react-native-recyclerview-list": "git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#v1.0.0",
     "react-native-safe-area": "^0.5.0",

--- a/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
+++ b/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-keyboard-aware-scroll-view",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "homepage": "https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view",
   "summary": "React Native module to arrange scroll poisition according to keyboard on input fields.",
   "license": "MIT",
@@ -10,7 +10,7 @@
   },
   "source": {
     "git": "https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git",
-    "tag": "gb-v0.8.4"
+    "tag": "gb-v0.8.5"
   },
   "source_files": "ios/RNKeyboardAwareScrollView/*.{h,m}",
   "preserve_paths": "**/*.js",

--- a/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
+++ b/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-keyboard-aware-scroll-view",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "homepage": "https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view",
   "summary": "React Native module to arrange scroll poisition according to keyboard on input fields.",
   "license": "MIT",
@@ -10,7 +10,7 @@
   },
   "source": {
     "git": "https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git",
-    "tag": "gb-v0.8.5"
+    "tag": "gb-v0.8.6"
   },
   "source_files": "ios/RNKeyboardAwareScrollView/*.{h,m}",
   "preserve_paths": "**/*.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7316,9 +7316,9 @@ react-native-iphone-x-helper@^1.0.3:
   resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.0.tgz#9f8a376eb00bc712115abff4420318a0063fa796"
   integrity sha512-xIeTo4s77wwKgBZLVRIZC9tM9/PkXS46Ul76NXmvmixEb3ZwqGdQesR3zRiLMOoIdfOURB6N9bba9po7+x9Bag==
 
-"react-native-keyboard-aware-scroll-view@git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#gb-v0.8.5":
-  version "0.8.5"
-  resolved "git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#c8230129a4a7c028ba18645bcc7e604e0e0c31b1"
+"react-native-keyboard-aware-scroll-view@git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#gb-v0.8.6":
+  version "0.8.6"
+  resolved "git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#f8fa3a3372ae46fe798bb6c843a5475b8f080673"
   dependencies:
     prop-types "^15.6.2"
     react-native-iphone-x-helper "^1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7316,9 +7316,9 @@ react-native-iphone-x-helper@^1.0.3:
   resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.0.tgz#9f8a376eb00bc712115abff4420318a0063fa796"
   integrity sha512-xIeTo4s77wwKgBZLVRIZC9tM9/PkXS46Ul76NXmvmixEb3ZwqGdQesR3zRiLMOoIdfOURB6N9bba9po7+x9Bag==
 
-"react-native-keyboard-aware-scroll-view@git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#gb-v0.8.4":
-  version "0.8.4"
-  resolved "git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#589873f90f75d1362eac6f2dd1f27893368bf1b7"
+"react-native-keyboard-aware-scroll-view@git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#gb-v0.8.5":
+  version "0.8.5"
+  resolved "git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#c8230129a4a7c028ba18645bcc7e604e0e0c31b1"
   dependencies:
     prop-types "^15.6.2"
     react-native-iphone-x-helper "^1.0.3"


### PR DESCRIPTION
Bumping up react-native-keyboard-aware-scroll-view version on iOS example app.

**To Test**

- yarn install & yarn ios
- check that this fix is included by the test case described there https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view/pull/5