### PR TITLE
Update aztec to 1.4.4

### DIFF
--- a/react-native-aztec/ios/Cartfile
+++ b/react-native-aztec/ios/Cartfile
@@ -1,2 +1,2 @@
-github "wordpress-mobile/AztecEditor-iOS" "a61fb769c1e0c8cabd0ff46234f0f1c72740faac"
+github "wordpress-mobile/AztecEditor-iOS" ~> 1.4.4
 

--- a/react-native-aztec/ios/Cartfile
+++ b/react-native-aztec/ios/Cartfile
@@ -1,2 +1,2 @@
-github "wordpress-mobile/AztecEditor-iOS" ~> 1.4.3
+github "wordpress-mobile/AztecEditor-iOS" "a61fb769c1e0c8cabd0ff46234f0f1c72740faac"
 

--- a/react-native-aztec/ios/Cartfile.resolved
+++ b/react-native-aztec/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.4.3"
+github "wordpress-mobile/AztecEditor-iOS" "a61fb769c1e0c8cabd0ff46234f0f1c72740faac"

--- a/react-native-aztec/ios/Cartfile.resolved
+++ b/react-native-aztec/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "a61fb769c1e0c8cabd0ff46234f0f1c72740faac"
+github "wordpress-mobile/AztecEditor-iOS" "1.4.4"

--- a/react-native-aztec/ios/RNTAztecView.xcodeproj/project.pbxproj
+++ b/react-native-aztec/ios/RNTAztecView.xcodeproj/project.pbxproj
@@ -360,6 +360,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
+				HEADER_SEARCH_PATHS = /usr/include/libxml2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -370,7 +371,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "RNTAztecView/RCTAztecView-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -385,6 +386,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
+				HEADER_SEARCH_PATHS = /usr/include/libxml2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -394,7 +396,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "RNTAztecView/RCTAztecView-Bridging-Header.h";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/react-native-aztec/ios/RNTAztecView/HeadingBlockFormatHandler.swift
+++ b/react-native-aztec/ios/RNTAztecView/HeadingBlockFormatHandler.swift
@@ -14,12 +14,13 @@ struct HeadingBlockFormatHandler: BlockFormatHandler {
     }
 
     func forceTypingFormat(on textView: RCTAztecView) {
-        var attributes = textView.typingAttributesSwifted
+        var attributes = textView.typingAttributes
 
-        attributes = paragraphFormatter.remove(from: attributes)
-        attributes = headerFormatter.apply(to: attributes, andStore: nil)
 
-        textView.typingAttributesSwifted = attributes
+        attributes = paragraphFormatter.remove(from: textView.typingAttributes)
+        attributes = headerFormatter.apply(to: textView.typingAttributes, andStore: nil)
+
+        textView.typingAttributes = attributes
     }
 
     private static func headerLevel(from levelString: String) -> Header.HeaderType? {

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -54,6 +54,7 @@ class RCTAztecView: Aztec.TextView {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textAlignment = .natural
         label.font = font
+
         return label
     }()
 
@@ -409,10 +410,10 @@ class RCTAztecView: Aztec.TextView {
     /// This method should not be called directly.  Call `refreshFont()` instead.
     ///
     private func refreshTypingAttributesAndPlaceholderFont() {
-        let oldFont = font(from: typingAttributesSwifted)
+        let oldFont = font(from: typingAttributes)
         let newFont = applyFontConstraints(to: oldFont)
         
-        typingAttributesSwifted[.font] = newFont
+        typingAttributes[.font] = newFont
         placeholderLabel.font = newFont
     }
 

--- a/react-native-aztec/package.json
+++ b/react-native-aztec/package.json
@@ -4,6 +4,7 @@
   "license": "GPL-2.0",
   "scripts": {
     "install-aztec-ios": "cd ./ios && carthage bootstrap --platform iOS --cache-builds",
+    "update-aztec-ios": "cd ./ios && carthage update --platform iOS --cache-builds",
     "clean": "yarn clean-watchman; yarn clean-node; yarn clean-react; yarn clean-metro; yarn clean-jest;",
     "clean-jest": "rm -rf $TMPDIR/jest_*;",
     "clean-metro": "rm -rf $TMPDIR/metro-cache-*; rm -rf $TMPDIR/metro-bundler-cache-*;",


### PR DESCRIPTION
This PR updates Aztec to 1.4.4.

Referencing a hash for testing before the formal Aztec release.
I also added a yarn (`update-aztec-ios`) command on `react-native-aztec` to update the dependency easier.

Some changes were necessary to incorporate the Aztec update to Swift 4.2
