### PR TITLE
Fix block appended placeholder not matching the paragraph placeholder issue

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -15,6 +15,7 @@ import { Text, View, Keyboard, LayoutChangeEvent, SafeAreaView, Dimensions } fro
 import BlockHolder from './block-holder';
 import type { BlockType } from '../store/types';
 import styles from './block-manager.scss';
+import blockHolderStyles from './block-holder.scss';
 import inlineToolbarStyles from './inline-toolbar/style.scss';
 import toolbarStyles from './block-toolbar.scss';
 import BlockPicker from './block-picker';
@@ -182,7 +183,14 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 
 	renderDefaultBlockAppender() {
 		return (
-			<DefaultBlockAppender rootClientId={ this.props.rootClientId } />
+			<DefaultBlockAppender 
+				rootClientId={ this.props.rootClientId }
+				containerStyle={ [
+					blockHolderStyles.blockContainerFocused,
+					this.blockHolderBorderStyle(),
+					{ borderColor: 'transparent' }
+				] }
+			/>
 		);
 	}
 

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -183,12 +183,12 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 
 	renderDefaultBlockAppender() {
 		return (
-			<DefaultBlockAppender 
+			<DefaultBlockAppender
 				rootClientId={ this.props.rootClientId }
 				containerStyle={ [
 					blockHolderStyles.blockContainerFocused,
 					this.blockHolderBorderStyle(),
-					{ borderColor: 'transparent' }
+					{ borderColor: 'transparent' },
 				] }
 			/>
 		);


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/637

gutenberg PR https://github.com/WordPress/gutenberg/pull/14386

^^^ The issue contains more than 1 issues. 

1. the border makes the text go up/down 1px when it gets and loses focus -> This was already solved with https://github.com/wordpress-mobile/gutenberg-mobile/pull/622

2. When we create a new post the first time block appender's placeholder shows at a slightly different position than the paragraph placeholder so it moves the first time you tap on it. -> This is the problem we are solving in this PR

**Before:**

iOS:
![placeholder-ios-before](https://user-images.githubusercontent.com/5032900/54185140-5b206900-44b9-11e9-8465-f29c4266805d.gif)

Android:
![placeholder-android-before](https://user-images.githubusercontent.com/5032900/54185141-5b206900-44b9-11e9-887e-24f73e0b5bde.gif)

**After:**

iOS:
![placeholder-ios-after](https://user-images.githubusercontent.com/5032900/54185509-40022900-44ba-11e9-84be-12a7c8eedab8.gif)

Android:
![placeholder-android-after](https://user-images.githubusercontent.com/5032900/54185175-6e333900-44b9-11e9-8694-e7c126539c8c.gif)

**TEST**

For WPiOS

Checkout the PRs branch to any arbitrary folder and cd .. to it
run yarn install, yarn start
Open XCode WPiOS on the latest develop
Clean build folder on Xcode, and then run the app

For WPAndroid

open grade.properties at WordPress-Android folder
add wp.BUILD_GUTENBERG_FROM_SOURCE = true to grade.properties
checkout the PRs branch in the subrepo of WordPress-Android repo
cd to WordPress-Android/libs/gutenberg-mobile
run yarn install, yarn start
yarn wpandroid on a separate terminal in the same directory

**Test Steps**

1. Open a new post
2. Tap on "Start writing"
3. Verify that the placeholder doesn't shift after tapping
