### PR TITLE
[iOS]Update heading placeholder size on heading level change

### DIFF
--- a/react-native-aztec/ios/RNTAztecView/HeadingBlockFormatHandler.swift
+++ b/react-native-aztec/ios/RNTAztecView/HeadingBlockFormatHandler.swift
@@ -16,11 +16,13 @@ struct HeadingBlockFormatHandler: BlockFormatHandler {
     func forceTypingFormat(on textView: RCTAztecView) {
         var attributes = textView.typingAttributes
 
-
         attributes = paragraphFormatter.remove(from: textView.typingAttributes)
         attributes = headerFormatter.apply(to: textView.typingAttributes, andStore: nil)
 
         textView.typingAttributes = attributes
+        if let font = attributes[.font] as? UIFont {
+            textView.placeholderLabel.font = font
+        }
     }
 
     private static func headerLevel(from levelString: String) -> Header.HeaderType? {

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -49,7 +49,7 @@ class RCTAztecView: Aztec.TextView {
         return reactLayoutDirection == .rightToLeft
     }
 
-    private lazy var placeholderLabel: UILabel = {
+    private(set) lazy var placeholderLabel: UILabel = {
         let label = UILabel(frame: .zero)
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textAlignment = .natural


### PR DESCRIPTION
Fix: https://github.com/wordpress-mobile/gutenberg-mobile/issues/671

WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/11258

This PR fixes the issue about heading placeholder not adjusting itself due to heading level.

After the fix:
![heading-placeholder-size](https://user-images.githubusercontent.com/5032900/54276454-70bb8e80-459e-11e9-8103-321cb484d25f.gif)

**To Test**

Checkout branch on WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/11258

- Add heading block
- Change heading level on toolbar
- Verify that placeholder size adjusts accordingly
