### PR TITLE
Fix - HTML Editor - Keyboard can not be closed

### DIFF
--- a/src/components/html-text-input.js
+++ b/src/components/html-text-input.js
@@ -85,7 +85,7 @@ export class HTMLInputView extends React.Component<PropsType, StateType> {
 			<KeyboardAvoidingView style={ styles.container } parentHeight={ this.props.parentHeight }>
 				<ScrollView
 					style={ { flex: 1 } }
-					keyboardDismissMode='interactive' >
+					keyboardDismissMode="interactive" >
 					<TextInput
 						autoCorrect={ false }
 						textAlignVertical="center"

--- a/src/components/html-text-input.js
+++ b/src/components/html-text-input.js
@@ -83,7 +83,9 @@ export class HTMLInputView extends React.Component<PropsType, StateType> {
 	render() {
 		return (
 			<KeyboardAvoidingView style={ styles.container } parentHeight={ this.props.parentHeight }>
-				<ScrollView style={ { flex: 1 } } >
+				<ScrollView
+					style={ { flex: 1 } }
+					keyboardDismissMode='interactive' >
 					<TextInput
 						autoCorrect={ false }
 						textAlignVertical="center"


### PR DESCRIPTION
Fix https://github.com/wordpress-mobile/gutenberg-mobile/issues/428

On iOS there was no way of closing the keyboard on HTML mode, now we are adding keyboardDismissMode option, so user can drag down to close the keyboard. 

Android behavior doesn't change. On Android there's already a keyboard down button. The 'interactive' option is supported for iOS only, so Android will continue having the default value: https://facebook.github.io/react-native/docs/scrollview#keyboarddismissmode

![keyboard-drag](https://user-images.githubusercontent.com/5032900/54279741-e4fa3000-45a6-11e9-876d-0fc2df7f9ea8.gif)

**To Test**

- Run metro on this branch
- Go to WPiOS app
- Open a post and switch to HTML mode
- Tap somewhere to open keyboard
- Verify that drag down closes the keyboard
