### PR TITLE
2nd Fix for Placeholder on Heading block

### DIFF
--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -517,7 +517,7 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
                             start + before));
 
             // Add the outer tags when the field was started empty, and only the first time the user types in it.
-            if (mPreviousText.length() == 0 && currentEventCount == 1 && !TextUtils.isEmpty(mEditText.getTagName())) {
+            if (mPreviousText.length() == 0 && !TextUtils.isEmpty(newText) && !TextUtils.isEmpty(mEditText.getTagName())) {
                 mEditText.fromHtml('<' + mEditText.getTagName() + '>' + newText + "</" + mEditText.getTagName() + '>', false);
             }
         }


### PR DESCRIPTION
This PR is a second tentative on fixing #707 and uses much of the code introduced in #739 but doesn't relies on `eventCount` , instead it actually checks the previous text if it's empty or not, before wrapping the newly inserted text with default tag.

cc @marecar3 


**To test this PR**

__Test 1__
- Add a new heading block
- The placeholder text should appear
- Start typing in the block
- The styling should be there and the toolbar updated

__Test 2__
- Remove all the text in a Heading block
- The placeholder text should appear again
- Start typing in the block
- The styling should be there and the toolbar updated

__Test 3__
- Add a new heading block
- The placeholder text should appear
- Paste a text in the block
- The styling should be there and the toolbar updated


Make sure to test with Heading block added at the end of the main list.