### PR TITLE
Fix text becoming invisible in HTML editor

### DIFF
--- a/src/components/html-text-input.js
+++ b/src/components/html-text-input.js
@@ -53,7 +53,7 @@ export class HTMLInputView extends React.Component<PropsType, StateType> {
 			onMoveShouldSetPanResponderCapture: ( ) => true,
 
 			onPanResponderMove: ( e, gestureState ) => {
-				if ( gestureState.dy > 100 && gestureState.dy < 110 ) {
+				if ( Platform.OS === 'ios' && ( gestureState.dy > 100 && gestureState.dy < 110 ) ) {
 					//Keyboard.dismiss() and this.textInput.blur() is not working here
 					//They require to know the currentlyFocusedID under the hood but
 					//during this gesture there's no currentlyFocusedID

--- a/src/components/html-text-input.js
+++ b/src/components/html-text-input.js
@@ -34,7 +34,6 @@ type StateType = {
 
 export class HTMLInputView extends React.Component<PropsType, StateType> {
 	isIOS: boolean = Platform.OS === 'ios';
-	textInput: TextInput;
 	edit: string => mixed;
 	stopEditing: () => mixed;
 	panResponder: PanResponder;

--- a/src/components/html-text-input.js
+++ b/src/components/html-text-input.js
@@ -9,7 +9,7 @@
 import { __ } from '@wordpress/i18n';
 
 import React from 'react';
-import { Platform, TextInput, View, UIManager, PanResponder } from 'react-native';
+import { Platform, TextInput, UIManager, PanResponder } from 'react-native';
 import styles from './html-text-input.scss';
 import KeyboardAvoidingView from './keyboard-avoiding-view';
 
@@ -30,7 +30,6 @@ type PropsType = {
 type StateType = {
 	isDirty: boolean,
 	value: string,
-	contentHeight: number,
 };
 
 export class HTMLInputView extends React.Component<PropsType, StateType> {
@@ -47,10 +46,7 @@ export class HTMLInputView extends React.Component<PropsType, StateType> {
 		this.stopEditing = this.stopEditing.bind( this );
 
 		this.panResponder = PanResponder.create( {
-			onStartShouldSetPanResponder: ( ) => true,
 			onStartShouldSetPanResponderCapture: ( ) => true,
-			onMoveShouldSetPanResponder: ( ) => true,
-			onMoveShouldSetPanResponderCapture: ( ) => true,
 
 			onPanResponderMove: ( e, gestureState ) => {
 				if ( this.isIOS && ( gestureState.dy > 100 && gestureState.dy < 110 ) ) {
@@ -65,7 +61,6 @@ export class HTMLInputView extends React.Component<PropsType, StateType> {
 		this.state = {
 			isDirty: false,
 			value: '',
-			contentHeight: 0,
 		};
 	}
 
@@ -99,31 +94,29 @@ export class HTMLInputView extends React.Component<PropsType, StateType> {
 
 	render() {
 		return (
-			<KeyboardAvoidingView style={ styles.container } parentHeight={ this.props.parentHeight }>
-				<View
-					{ ...( this.isIOS ? { ...this.panResponder.panHandlers } : {} ) }
-					style={ { flex: 1 } } >
-					<TextInput
-						autoCorrect={ false }
-						textAlignVertical="center"
-						numberOfLines={ 1 }
-						style={ styles.htmlViewTitle }
-						value={ this.props.title }
-						placeholder={ __( 'Add title' ) }
-						onChangeText={ this.props.setTitleAction }
-					/>
-					<TextInput
-						autoCorrect={ false }
-						ref={ ( textInput ) => this.textInput = textInput }
-						textAlignVertical="top"
-						multiline
-						style={ { ...styles.htmlView } }
-						value={ this.state.value }
-						onChangeText={ this.edit }
-						onBlur={ this.stopEditing }
-						placeholder={ __( 'Start writing…' ) }
-					/>
-				</View>
+			<KeyboardAvoidingView
+				style={ styles.container }
+				{ ...( this.isIOS ? { ...this.panResponder.panHandlers } : {} ) }
+				parentHeight={ this.props.parentHeight }>
+				<TextInput
+					autoCorrect={ false }
+					textAlignVertical="center"
+					numberOfLines={ 1 }
+					style={ styles.htmlViewTitle }
+					value={ this.props.title }
+					placeholder={ __( 'Add title' ) }
+					onChangeText={ this.props.setTitleAction }
+				/>
+				<TextInput
+					autoCorrect={ false }
+					textAlignVertical="top"
+					multiline
+					style={ { ...styles.htmlView } }
+					value={ this.state.value }
+					onChangeText={ this.edit }
+					onBlur={ this.stopEditing }
+					placeholder={ __( 'Start writing…' ) }
+				/>
 			</KeyboardAvoidingView>
 		);
 	}

--- a/src/components/html-text-input.js
+++ b/src/components/html-text-input.js
@@ -98,10 +98,8 @@ export class HTMLInputView extends React.Component<PropsType, StateType> {
 	}
 
 	render() {
-		const { height: titleHeight } = styles.htmlViewTitle;
-
 		return (
-			<KeyboardAvoidingView style={ styles.container } parentHeight={ this.props.parentHeight - titleHeight }>
+			<KeyboardAvoidingView style={ styles.container } parentHeight={ this.props.parentHeight }>
 				<View
 					{ ...( this.isIOS ? { ...this.panResponder.panHandlers } : {} ) }
 					style={ { flex: 1 } } >

--- a/src/components/html-text-input.js
+++ b/src/components/html-text-input.js
@@ -9,7 +9,7 @@
 import { __ } from '@wordpress/i18n';
 
 import React from 'react';
-import { Platform, TextInput, View } from 'react-native';
+import { Platform, TextInput, View, UIManager, PanResponder } from 'react-native';
 import styles from './html-text-input.scss';
 import KeyboardAvoidingView from './keyboard-avoiding-view';
 
@@ -38,12 +38,26 @@ export class HTMLInputView extends React.Component<PropsType, StateType> {
 	textInput: TextInput;
 	edit: string => mixed;
 	stopEditing: () => mixed;
+	panResponder: PanResponder;
 
 	constructor() {
 		super( ...arguments );
 
 		this.edit = this.edit.bind( this );
 		this.stopEditing = this.stopEditing.bind( this );
+
+		this.panResponder = PanResponder.create( {
+			onStartShouldSetPanResponder: ( ) => true,
+			onStartShouldSetPanResponderCapture: ( ) => true,
+			onMoveShouldSetPanResponder: ( ) => true,
+			onMoveShouldSetPanResponderCapture: ( ) => true,
+
+			onPanResponderMove: ( e, gestureState ) => {
+				if ( gestureState.dy > 100 && gestureState.dy < 110 ) {
+					UIManager.blur( e.target );
+				}
+			},
+		} );
 
 		this.state = {
 			isDirty: false,
@@ -86,8 +100,8 @@ export class HTMLInputView extends React.Component<PropsType, StateType> {
 		return (
 			<KeyboardAvoidingView style={ styles.container } parentHeight={ this.props.parentHeight - titleHeight }>
 				<View
-					style={ { flex: 1 } }
-					keyboardDismissMode="interactive" >
+					{ ...this.panResponder.panHandlers }
+					style={ { flex: 1 } } >
 					<TextInput
 						autoCorrect={ false }
 						textAlignVertical="center"

--- a/src/components/html-text-input.js
+++ b/src/components/html-text-input.js
@@ -53,7 +53,7 @@ export class HTMLInputView extends React.Component<PropsType, StateType> {
 			onMoveShouldSetPanResponderCapture: ( ) => true,
 
 			onPanResponderMove: ( e, gestureState ) => {
-				if ( Platform.OS === 'ios' && ( gestureState.dy > 100 && gestureState.dy < 110 ) ) {
+				if ( this.isIOS && ( gestureState.dy > 100 && gestureState.dy < 110 ) ) {
 					//Keyboard.dismiss() and this.textInput.blur() is not working here
 					//They require to know the currentlyFocusedID under the hood but
 					//during this gesture there's no currentlyFocusedID
@@ -103,7 +103,7 @@ export class HTMLInputView extends React.Component<PropsType, StateType> {
 		return (
 			<KeyboardAvoidingView style={ styles.container } parentHeight={ this.props.parentHeight - titleHeight }>
 				<View
-					{ ...this.panResponder.panHandlers }
+					{ ...( this.isIOS ? { ...this.panResponder.panHandlers } : {} ) }
 					style={ { flex: 1 } } >
 					<TextInput
 						autoCorrect={ false }

--- a/src/components/html-text-input.js
+++ b/src/components/html-text-input.js
@@ -54,6 +54,9 @@ export class HTMLInputView extends React.Component<PropsType, StateType> {
 
 			onPanResponderMove: ( e, gestureState ) => {
 				if ( gestureState.dy > 100 && gestureState.dy < 110 ) {
+					//Keyboard.dismiss() and this.textInput.blur() is not working here
+					//They require to know the currentlyFocusedID under the hood but
+					//during this gesture there's no currentlyFocusedID
 					UIManager.blur( e.target );
 				}
 			},

--- a/src/components/html-text-input.js
+++ b/src/components/html-text-input.js
@@ -9,7 +9,7 @@
 import { __ } from '@wordpress/i18n';
 
 import React from 'react';
-import { Platform, TextInput, ScrollView } from 'react-native';
+import { Platform, TextInput, View } from 'react-native';
 import styles from './html-text-input.scss';
 import KeyboardAvoidingView from './keyboard-avoiding-view';
 
@@ -81,9 +81,11 @@ export class HTMLInputView extends React.Component<PropsType, StateType> {
 	}
 
 	render() {
+		const { height: titleHeight } = styles.htmlViewTitle;
+
 		return (
-			<KeyboardAvoidingView style={ styles.container } parentHeight={ this.props.parentHeight }>
-				<ScrollView
+			<KeyboardAvoidingView style={ styles.container } parentHeight={ this.props.parentHeight - titleHeight }>
+				<View
 					style={ { flex: 1 } }
 					keyboardDismissMode="interactive" >
 					<TextInput
@@ -100,17 +102,13 @@ export class HTMLInputView extends React.Component<PropsType, StateType> {
 						ref={ ( textInput ) => this.textInput = textInput }
 						textAlignVertical="top"
 						multiline
-						style={ { ...styles.htmlView, height: this.state.contentHeight + 16 } }
+						style={ { ...styles.htmlView } }
 						value={ this.state.value }
 						onChangeText={ this.edit }
 						onBlur={ this.stopEditing }
 						placeholder={ __( 'Start writing…' ) }
-						scrollEnabled={ false }
-						onContentSizeChange={ ( event ) => {
-							this.setState( { contentHeight: event.nativeEvent.contentSize.height } );
-						} }
 					/>
-				</ScrollView>
+				</View>
 			</KeyboardAvoidingView>
 		);
 	}

--- a/src/components/html-text-input.scss
+++ b/src/components/html-text-input.scss
@@ -1,12 +1,13 @@
 /** @format */
 
+$title-height: 32;
+
 .htmlView {
 	font-family: $default-monospace-font;
 	background-color: white;
 	padding-left: 8;
 	padding-right: 8;
-	padding-top: 8;
-	padding-bottom: 8;
+	padding-bottom: $title-height + 8;
 }
 
 .htmlViewTitle {
@@ -16,7 +17,8 @@
 	padding-right: 8;
 	padding-top: 8;
 	padding-bottom: 8;
-	height: 30;
+	height: $title-height;
+	
 }
 
 .container {

--- a/src/components/html-text-input.scss
+++ b/src/components/html-text-input.scss
@@ -16,6 +16,7 @@
 	padding-right: 8;
 	padding-top: 8;
 	padding-bottom: 8;
+	height: 30;
 }
 
 .container {


### PR DESCRIPTION
To Fix: https://github.com/wordpress-mobile/gutenberg-mobile/issues/744

Root cause analysis and the solution proposal can be found in the issue. ^^^ 

To fix the anomalies we are removing the outer ScrollView and letting the TextView scroll in its own bounds, thus, letting iOS system make the required optimizations.

After the fix:

iOS:
![ios-longtext-html-mode-after](https://user-images.githubusercontent.com/5032900/54525898-3f6c0580-4986-11e9-8bab-a96bba7a09ab.gif)

Android:
![android-longtext-html-mode-after](https://user-images.githubusercontent.com/5032900/54525911-4430b980-4986-11e9-923b-11ebdf20dba9.gif)

**Implementation Details**

Since we can not use keyboardDismissMode prop anymore I've added a pan gesture to detect when the user drags down and close the keyboard with it. This is active for iOS only, keyboardDismissMode='interactive' was also an iOS only behavior.

**To Test**

- Open the iOS example app with `yarn ios`
- Switch to html mode
- Verify that text is visible
- Scroll down to the bottom
- Verify that the whole content is visible
- Drag down to close the keyboard (iOS only)

Repeat tests for following platforms:

WPiOS
WPAndroid(Except for draggin down to close the keyboard)

Try using also a non iPhone X series device like iPhone 8.

cc @daniloercoli 
