### PR TITLE
Fix warning about calling measureSelectionInWindow via UIManager

### DIFF
--- a/ios/gutenberg.xcodeproj/project.pbxproj
+++ b/ios/gutenberg.xcodeproj/project.pbxproj
@@ -37,7 +37,6 @@
 		7EC7328F21907E3F00FED2E6 /* GutenbergViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC7328E21907E3F00FED2E6 /* GutenbergViewController.swift */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
 		8C666FF0C9224FB88C2C0447 /* libRNSVG-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9BFAFEB337654221B2F14D03 /* libRNSVG-tvOS.a */; };
-		91C7517C21DE3A2400106645 /* libRNKeyboardAwareScrollView.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 91C7517721DE393000106645 /* libRNKeyboardAwareScrollView.a */; };
 		ADBDB9381DFEBF1600ED6528 /* libRCTBlob.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ADBDB9271DFEBF0700ED6528 /* libRCTBlob.a */; };
 		CF45443564B845C8BDCFBAB6 /* libRNTAztecView.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3ADEFEC092CF4D00BEF1019E /* libRNTAztecView.a */; };
 		DD2AE937473A49B2B5A0E7B6 /* libRNSVG.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0EB766FE2F6D446A80AC6E6A /* libRNSVG.a */; };
@@ -315,12 +314,12 @@
 			remoteGlobalIDString = 6DA7B8031F692C4C00FD1D50;
 			remoteInfo = RNSafeArea;
 		};
-		91C7517621DE393000106645 /* PBXContainerItemProxy */ = {
+		91C2E1B222422C9F00D5E1F5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 91C7514D21DE393000106645 /* RNKeyboardAwareScrollView.xcodeproj */;
+			containerPortal = 91C2E1AE22422C9F00D5E1F5 /* RNTKeyboardAwareScrollView.xcodeproj */;
 			proxyType = 2;
-			remoteGlobalIDString = 6DA7B8031F692C4C00FD1D50;
-			remoteInfo = RNKeyboardAwareScrollView;
+			remoteGlobalIDString = 134814201AA4EA6300B7C361;
+			remoteInfo = RNTKeyboardAwareScrollView;
 		};
 		ADBDB9261DFEBF0700ED6528 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -422,7 +421,7 @@
 		7EA30CF021AC8CDA0092F894 /* libxml2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libxml2.tbd; path = usr/lib/libxml2.tbd; sourceTree = SDKROOT; };
 		7EC7328E21907E3F00FED2E6 /* GutenbergViewController.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; name = GutenbergViewController.swift; path = gutenberg/GutenbergViewController.swift; sourceTree = "<group>"; tabWidth = 1; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
-		91C7514D21DE393000106645 /* RNKeyboardAwareScrollView.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNKeyboardAwareScrollView.xcodeproj; path = "../node_modules/react-native-keyboard-aware-scroll-view/ios/RNKeyboardAwareScrollView.xcodeproj"; sourceTree = "<group>"; };
+		91C2E1AE22422C9F00D5E1F5 /* RNTKeyboardAwareScrollView.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNTKeyboardAwareScrollView.xcodeproj; path = "../node_modules/react-native-keyboard-aware-scroll-view/ios/RNTKeyboardAwareScrollView.xcodeproj"; sourceTree = "<group>"; };
 		9B18D59B9364468890D0E546 /* RNSVG.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNSVG.xcodeproj; path = "../node_modules/react-native-svg/ios/RNSVG.xcodeproj"; sourceTree = "<group>"; };
 		9BFAFEB337654221B2F14D03 /* libRNSVG-tvOS.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = "libRNSVG-tvOS.a"; sourceTree = "<group>"; };
 		ADBDB91F1DFEBF0600ED6528 /* RCTBlob.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTBlob.xcodeproj; path = "../node_modules/react-native/Libraries/Blob/RCTBlob.xcodeproj"; sourceTree = "<group>"; };
@@ -473,7 +472,6 @@
 				DD2AE937473A49B2B5A0E7B6 /* libRNSVG.a in Frameworks */,
 				CF45443564B845C8BDCFBAB6 /* libRNTAztecView.a in Frameworks */,
 				7E45CC5B218B42E000C0B2AB /* libRNReactNativeGutenbergBridge.a in Frameworks */,
-				91C7517C21DE3A2400106645 /* libRNKeyboardAwareScrollView.a in Frameworks */,
 				16AEBAC87CB24520ADA106D7 /* libRNSafeArea.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -665,6 +663,7 @@
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
+				91C2E1AE22422C9F00D5E1F5 /* RNTKeyboardAwareScrollView.xcodeproj */,
 				7E45CC55218B42C000C0B2AB /* RNReactNativeGutenbergBridge.xcodeproj */,
 				5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */,
 				146833FF1AC3E56700842450 /* React.xcodeproj */,
@@ -672,7 +671,6 @@
 				ADBDB91F1DFEBF0600ED6528 /* RCTBlob.xcodeproj */,
 				00C302B51ABCB90400DB3ED1 /* RCTGeolocation.xcodeproj */,
 				00C302BB1ABCB91800DB3ED1 /* RCTImage.xcodeproj */,
-				91C7514D21DE393000106645 /* RNKeyboardAwareScrollView.xcodeproj */,
 				78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */,
 				00C302D31ABCB9D200DB3ED1 /* RCTNetwork.xcodeproj */,
 				139105B61AF99BAD00B5F7CC /* RCTSettings.xcodeproj */,
@@ -730,10 +728,10 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		91C7514E21DE393000106645 /* Products */ = {
+		91C2E1AF22422C9F00D5E1F5 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				91C7517721DE393000106645 /* libRNKeyboardAwareScrollView.a */,
+				91C2E1B322422C9F00D5E1F5 /* libRNTKeyboardAwareScrollView.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -961,10 +959,6 @@
 					ProjectRef = 146833FF1AC3E56700842450 /* React.xcodeproj */;
 				},
 				{
-					ProductGroup = 91C7514E21DE393000106645 /* Products */;
-					ProjectRef = 91C7514D21DE393000106645 /* RNKeyboardAwareScrollView.xcodeproj */;
-				},
-				{
 					ProductGroup = 7E45CC56218B42C000C0B2AB /* Products */;
 					ProjectRef = 7E45CC55218B42C000C0B2AB /* RNReactNativeGutenbergBridge.xcodeproj */;
 				},
@@ -979,6 +973,10 @@
 				{
 					ProductGroup = F1B3E7B920FFA99B0042D8C3 /* Products */;
 					ProjectRef = F619623252704B46A619C33C /* RNTAztecView.xcodeproj */;
+				},
+				{
+					ProductGroup = 91C2E1AF22422C9F00D5E1F5 /* Products */;
+					ProjectRef = 91C2E1AE22422C9F00D5E1F5 /* RNTKeyboardAwareScrollView.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -1230,11 +1228,11 @@
 			remoteRef = 9161EFC721D277D300314043 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		91C7517721DE393000106645 /* libRNKeyboardAwareScrollView.a */ = {
+		91C2E1B322422C9F00D5E1F5 /* libRNTKeyboardAwareScrollView.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = libRNKeyboardAwareScrollView.a;
-			remoteRef = 91C7517621DE393000106645 /* PBXContainerItemProxy */;
+			path = libRNTKeyboardAwareScrollView.a;
+			remoteRef = 91C2E1B222422C9F00D5E1F5 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		ADBDB9271DFEBF0700ED6528 /* libRCTBlob.a */ = {

--- a/ios/gutenberg.xcodeproj/project.pbxproj
+++ b/ios/gutenberg.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		7EC7328F21907E3F00FED2E6 /* GutenbergViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC7328E21907E3F00FED2E6 /* GutenbergViewController.swift */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
 		8C666FF0C9224FB88C2C0447 /* libRNSVG-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9BFAFEB337654221B2F14D03 /* libRNSVG-tvOS.a */; };
+		91C2E1B42242321F00D5E1F5 /* libRNTKeyboardAwareScrollView.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 91C2E1B322422C9F00D5E1F5 /* libRNTKeyboardAwareScrollView.a */; };
 		ADBDB9381DFEBF1600ED6528 /* libRCTBlob.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ADBDB9271DFEBF0700ED6528 /* libRCTBlob.a */; };
 		CF45443564B845C8BDCFBAB6 /* libRNTAztecView.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3ADEFEC092CF4D00BEF1019E /* libRNTAztecView.a */; };
 		DD2AE937473A49B2B5A0E7B6 /* libRNSVG.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0EB766FE2F6D446A80AC6E6A /* libRNSVG.a */; };
@@ -469,6 +470,7 @@
 				832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */,
 				00C302EA1ABCBA2D00DB3ED1 /* libRCTVibration.a in Frameworks */,
 				139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */,
+				91C2E1B42242321F00D5E1F5 /* libRNTKeyboardAwareScrollView.a in Frameworks */,
 				DD2AE937473A49B2B5A0E7B6 /* libRNSVG.a in Frameworks */,
 				CF45443564B845C8BDCFBAB6 /* libRNTAztecView.a in Frameworks */,
 				7E45CC5B218B42E000C0B2AB /* libRNReactNativeGutenbergBridge.a in Frameworks */,

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "react": "16.8.3",
     "react-native": "0.59.0",
     "react-native-hr": "git+https://github.com/Riglerr/react-native-hr.git#2d01a5cf77212d100e8b99e0310cce5234f977b3",
-    "react-native-keyboard-aware-scroll-view": "git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#gb-v0.8.6",
+    "react-native-keyboard-aware-scroll-view": "git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#8ec179ef3678c751582ae3c56089328c4e49264a",
     "react-native-modal": "^6.5.0",
     "react-native-recyclerview-list": "git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#v1.0.0",
     "react-native-safe-area": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "react": "16.8.3",
     "react-native": "0.59.0",
     "react-native-hr": "git+https://github.com/Riglerr/react-native-hr.git#2d01a5cf77212d100e8b99e0310cce5234f977b3",
-    "react-native-keyboard-aware-scroll-view": "git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#064d4ce04f5fd757a8530eedd4c0abedb71139f9",
+    "react-native-keyboard-aware-scroll-view": "git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#f8fa3a3372ae46fe798bb6c843a5475b8f080673",
     "react-native-modal": "^6.5.0",
     "react-native-recyclerview-list": "git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#v1.0.0",
     "react-native-safe-area": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "react": "16.8.3",
     "react-native": "0.59.0",
     "react-native-hr": "git+https://github.com/Riglerr/react-native-hr.git#2d01a5cf77212d100e8b99e0310cce5234f977b3",
-    "react-native-keyboard-aware-scroll-view": "git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#8ec179ef3678c751582ae3c56089328c4e49264a",
+    "react-native-keyboard-aware-scroll-view": "git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#064d4ce04f5fd757a8530eedd4c0abedb71139f9",
     "react-native-modal": "^6.5.0",
     "react-native-recyclerview-list": "git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#v1.0.0",
     "react-native-safe-area": "^0.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7960,9 +7960,9 @@ react-native-iphone-x-helper@^1.0.3:
   resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.0.tgz#9f8a376eb00bc712115abff4420318a0063fa796"
   integrity sha512-xIeTo4s77wwKgBZLVRIZC9tM9/PkXS46Ul76NXmvmixEb3ZwqGdQesR3zRiLMOoIdfOURB6N9bba9po7+x9Bag==
 
-"react-native-keyboard-aware-scroll-view@git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#gb-v0.8.6":
+"react-native-keyboard-aware-scroll-view@git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#8ec179ef3678c751582ae3c56089328c4e49264a":
   version "0.8.6"
-  resolved "git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#f8fa3a3372ae46fe798bb6c843a5475b8f080673"
+  resolved "git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#8ec179ef3678c751582ae3c56089328c4e49264a"
   dependencies:
     prop-types "^15.6.2"
     react-native-iphone-x-helper "^1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7960,9 +7960,9 @@ react-native-iphone-x-helper@^1.0.3:
   resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.0.tgz#9f8a376eb00bc712115abff4420318a0063fa796"
   integrity sha512-xIeTo4s77wwKgBZLVRIZC9tM9/PkXS46Ul76NXmvmixEb3ZwqGdQesR3zRiLMOoIdfOURB6N9bba9po7+x9Bag==
 
-"react-native-keyboard-aware-scroll-view@git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#8ec179ef3678c751582ae3c56089328c4e49264a":
+"react-native-keyboard-aware-scroll-view@git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#064d4ce04f5fd757a8530eedd4c0abedb71139f9":
   version "0.8.6"
-  resolved "git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#8ec179ef3678c751582ae3c56089328c4e49264a"
+  resolved "git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#064d4ce04f5fd757a8530eedd4c0abedb71139f9"
   dependencies:
     prop-types "^15.6.2"
     react-native-iphone-x-helper "^1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7960,9 +7960,9 @@ react-native-iphone-x-helper@^1.0.3:
   resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.0.tgz#9f8a376eb00bc712115abff4420318a0063fa796"
   integrity sha512-xIeTo4s77wwKgBZLVRIZC9tM9/PkXS46Ul76NXmvmixEb3ZwqGdQesR3zRiLMOoIdfOURB6N9bba9po7+x9Bag==
 
-"react-native-keyboard-aware-scroll-view@git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#064d4ce04f5fd757a8530eedd4c0abedb71139f9":
+"react-native-keyboard-aware-scroll-view@git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#f8fa3a3372ae46fe798bb6c843a5475b8f080673":
   version "0.8.6"
-  resolved "git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#064d4ce04f5fd757a8530eedd4c0abedb71139f9"
+  resolved "git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#f8fa3a3372ae46fe798bb6c843a5475b8f080673"
   dependencies:
     prop-types "^15.6.2"
     react-native-iphone-x-helper "^1.0.3"


### PR DESCRIPTION
To fix: https://github.com/wordpress-mobile/gutenberg-mobile/issues/760

We are updating keyboard-aware-scroll-view reference to fix warning about calling measureSelectionInWindow via UIManager.

**TO TEST**

- run `yarn install`, `yarn start`, `yarn ios`

And then follow the steps on https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view/pull/6