### PR TITLE
Start draft with image block (share media to Gutenberg)

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -7,6 +7,7 @@ jest.mock( '../react-native-gutenberg-bridge', () => {
 		subscribeSetTitle: jest.fn(),
 		subscribeSetFocusOnTitle: jest.fn(),
 		subscribeUpdateHtml: jest.fn(),
+		subscribeMediaAppend: jest.fn(),
 		editorDidMount: jest.fn(),
 	};
 } );

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -21,6 +21,7 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
     private static final String EVENT_NAME_UPDATE_TITLE = "setTitle";
     private static final String EVENT_NAME_FOCUS_TITLE = "setFocusOnTitle";
     private static final String EVENT_NAME_MEDIA_UPLOAD = "mediaUpload";
+    private static final String EVENT_NAME_MEDIA_APPEND = "mediaAppend";
 
     private static final String MAP_KEY_UPDATE_HTML = "html";
     private static final String MAP_KEY_UPDATE_TITLE = "title";
@@ -79,6 +80,12 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
         emitToJS(EVENT_NAME_FOCUS_TITLE, writableMap);
     }
 
+    public void appendNewImageBlock(int mediaId, String mediaUri) {
+        WritableMap writableMap = new WritableNativeMap();
+        writableMap.putString(MAP_KEY_MEDIA_FILE_UPLOAD_MEDIA_URL, mediaUri);
+        writableMap.putInt(MAP_KEY_MEDIA_FILE_UPLOAD_MEDIA_ID, mediaId);
+        emitToJS(EVENT_NAME_MEDIA_APPEND, writableMap);
+    }
 
     @ReactMethod
     public void provideToNative_Html(String html, String title, boolean changed) {

--- a/react-native-gutenberg-bridge/index.js
+++ b/react-native-gutenberg-bridge/index.js
@@ -44,6 +44,10 @@ export function subscribeMediaUpload( callback ) {
 	return gutenbergBridgeEvents.addListener( 'mediaUpload', callback );
 }
 
+export function subscribeMediaAppend( callback ) {
+	return gutenbergBridgeEvents.addListener( 'mediaAppend', callback );
+}
+
 export function requestMediaPickFromMediaLibrary( callback ) {
 	return RNReactNativeGutenbergBridge.requestMediaPickFrom( 'SITE_MEDIA_LIBRARY', callback );
 }

--- a/react-native-gutenberg-bridge/ios/Gutenberg.swift
+++ b/react-native-gutenberg-bridge/ios/Gutenberg.swift
@@ -95,7 +95,7 @@ public class Gutenberg: NSObject {
     }
 
     public func appendMedia(id: Int32, url: URL) {
-        let data: [String: Any] = ["mediaId": id, "mediaUrl": url];
+        let data: [String: Any] = ["mediaId": id, "mediaUrl": url.absoluteString];
         bridgeModule.sendEventIfNeeded(name: EventName.mediaAppend, body: data)
     }
 

--- a/react-native-gutenberg-bridge/ios/Gutenberg.swift
+++ b/react-native-gutenberg-bridge/ios/Gutenberg.swift
@@ -94,6 +94,11 @@ public class Gutenberg: NSObject {
         bridgeModule.sendEventIfNeeded(name: EventName.mediaUpload, body: data)
     }
 
+    public func appendMedia(id: Int32, url: URL) {
+        let data: [String: Any] = ["mediaId": id, "mediaUrl": url];
+        bridgeModule.sendEventIfNeeded(name: EventName.mediaAppend, body: data)
+    }
+
     public func setFocusOnTitle() {
         bridgeModule.sendEventIfNeeded(name: EventName.setFocusOnTitle, body: nil)
     }
@@ -122,6 +127,7 @@ extension Gutenberg {
         static let updateHtml = "updateHtml"
         static let mediaUpload = "mediaUpload"
         static let setFocusOnTitle = "setFocusOnTitle"
+        static let mediaAppend = "mediaAppend"
     }
     
     public enum MediaUploadState: Int {

--- a/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -103,6 +103,7 @@ extension RNReactNativeGutenbergBridge {
             Gutenberg.EventName.updateHtml,
             Gutenberg.EventName.mediaUpload,
             Gutenberg.EventName.setFocusOnTitle,
+            Gutenberg.EventName.mediaAppend
         ]
     }
 

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -31,7 +31,7 @@ import { compose } from '@wordpress/compose';
 import { createBlock, isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { PostTitle } from '@wordpress/editor';
 import { DefaultBlockAppender } from '@wordpress/block-editor';
-import { sendNativeEditorDidLayout, subscribeSetFocusOnTitle } from 'react-native-gutenberg-bridge';
+import { sendNativeEditorDidLayout, subscribeSetFocusOnTitle, subscribeMediaAppend } from 'react-native-gutenberg-bridge';
 
 type PropsType = {
 	rootClientId: ?string,
@@ -61,6 +61,7 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 	scrollViewRef: Object;
 	postTitleRef: ?Object;
 	subscriptionParentSetFocusOnTitle: ?Object;
+	subscriptionParentMediaAppend: ?Object;
 	_isMounted: boolean;
 
 	constructor( props: PropsType ) {
@@ -101,6 +102,10 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 		// create an empty block of the selected type
 		const newBlock = createBlock( itemValue );
 
+		this.finishBlockAppendingOrReplacing( newBlock );
+	}
+
+	finishBlockAppendingOrReplacing( newBlock: Object ) {
 		// now determine whether we need to replace the currently selected block (if it's empty)
 		// or just add a new block as usual
 		if ( this.isReplaceable( this.props.selectedBlock ) ) {
@@ -153,6 +158,18 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 				this.postTitleRef.focus();
 			}
 		} );
+
+		this.subscriptionParentMediaAppend = subscribeMediaAppend( ( payload ) => {
+			// create an empty image block
+			const newImageBlock = createBlock( 'core/image' );
+
+			// now set the url and id
+			newImageBlock.attributes.url = payload.mediaUrl;
+			newImageBlock.attributes.id = payload.mediaId;
+
+			// finally append or replace as appropriate
+			this.finishBlockAppendingOrReplacing( newImageBlock );
+		} );
 	}
 
 	componentWillUnmount() {
@@ -161,6 +178,9 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 		SafeArea.removeEventListener( 'safeAreaInsetsForRootViewDidChange', this.onSafeAreaInsetsUpdate );
 		if ( this.subscriptionParentSetFocusOnTitle ) {
 			this.subscriptionParentSetFocusOnTitle.remove();
+		}
+		if ( this.subscriptionParentMediaAppend ) {
+			this.subscriptionParentMediaAppend.remove();
 		}
 		this._isMounted = false;
 	}


### PR DESCRIPTION
- Reverts wordpress-mobile/gutenberg-mobile#762 (revert of a revert) as I mistakingly merged without having the iOS part ready.

- Original commit history and discussion (changes already tested and approved on Android) in https://github.com/wordpress-mobile/gutenberg-mobile/pull/758

*NEEDS iOS DEV* to implement the bridge parts on that platform.

Copying here for ease of testing and completeness:
==========

This PR brings in the functionality to:

a) start a Post by sharing an image to WordPress app from the outside, and
b) start a Post by inserting an image to WordPress from the Media section's "upload finished" snackbar.

Please note the bridge and changes on Android were implemented, but this needs an iOS dev to take care of the iOS part.

To test:

Follow the description in the WPAndroid PR https://github.com/wordpress-mobile/WordPress-Android/pull/9442.

**Note:** First make sure to have the `Use Block Editor` setting to `ON` in App Settings. Then:

#### CASE A: share from another app

1. open the Photos app
2. pick a picture and tap the share icon
3. select the WordPress app
4. choose a site and tap on `Add to new post`
5. Observe the Gutenberg editor opens up, with a pre-filled `Image Block` and the selected image starts uploading.

![share_media_from_outside](https://user-images.githubusercontent.com/6597771/54575567-4e2cd980-49d3-11e9-8ea6-e95c7ecdd62c.gif)




####  CASE B: start draft from Media Section
1. open the app
2. go to the Media section
3. tap on the `+` icon on the right-top corner of the screen
4. select one option to upload an image to the Media section
5. wait for it to finish uploading
6. once it's uploaded, observe a snackbar appears, with action button `WRITE POST`. Tap on it.
7. observe the Gutenberg editor is fired, with a pre-filled `Image Block` and the selected image starts uploading.

![share_media_from_media_section_snackbar2](https://user-images.githubusercontent.com/6597771/54575813-5c2f2a00-49d4-11e9-8883-d035454c0121.gif)

## EDIT: added test cases for Multiple images

Commits 8e84d41 and 3cc1114 contain changes that allow for multiple images to be shared into a Post, adding the test cases here:

#### CASE C: editor not available right away
1. kill the app
2. go to the Photos app
3. select several photos
4. tap share, select WordPress app
5. observe the Gutenberg editor is fired up, and several image blocks are appended, with the images on each one of them.
6. all should upload successfully, so wait for it to upload
7. also test exiting the editor while things are uploading, etc.

#### CASE D: editor available right away
1. after running CASE C, the app will be available
2. go ahead and repeat the action, this time the code path will be slightly different, but the user experience should be the same: repeat steps 2-7 of CASE C and verify it all works normally.


#### CASE E: multiple shared images uploading, then adding a new image block and picking file from device.
1. go to the Photos app
2. select several photos
3. tap share, select WordPress app
4. observe the Gutenberg editor is fired up, and several image blocks are appended, with the images on each one of them.
5. while this is happening, use the inserter and insert yet another Image block
6. choose a different image (i.e. take a picture)
7. observe all of them get uploaded correctly (even exit the editor and observe they're all uploaded async)
8. open the Editor again and confirm it's all there as expected.


