### PR TITLE
Added a minimal delay to call setSelection() to enforce special focus handling cases

### DIFF
--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecArrowKeyMovementMethod.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecArrowKeyMovementMethod.java
@@ -30,14 +30,23 @@ public class ReactAztecArrowKeyMovementMethod extends ArrowKeyMovementMethod {
         if ((dir & (View.FOCUS_FORWARD | View.FOCUS_DOWN)) != 0) {
             if (view.getLayout() == null) {
                 // This shouldn't be null, but do something sensible if it is.
-                Selection.setSelection(text, 0); // <-- setting caret to start of text
+                handleSelectionOnEnd(view, text);
             }
             else if (!reactAztecText.isTouched()) {
-                Selection.setSelection(text, text.length()); // <-- setting caret to end of text after two blocks are merged
+                handleSelectionOnEnd(view, text);  // <-- setting caret to end of text after two blocks are merged
             }
         } else {
             Selection.setSelection(text, text.length());  // <-- same as original Android implementation. Not sure if we should change this too
         }
+    }
+
+    private void handleSelectionOnEnd(TextView view, final Spannable text) {
+        view.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                Selection.setSelection(text, text.length()); // <-- setting caret to end of text
+            }
+        }, 20);
     }
 
     @Override


### PR DESCRIPTION
The title has it, when we want to override the caret selection (as in the case of deleting a block and coming back to the block above) we should do it _last_ to make sure any other positioning work has finished. Taking into account chained events would be super complex so, adding a delay seems to do the job while easy to understand. This is a try to improve and fix issue A described in https://github.com/wordpress-mobile/gutenberg-mobile/pull/756#issuecomment-474824104, stating here again for clarity:

**Issue A:** After two blocks are merged, a cursor will be placed on the last remembered position in the block. (Affected both iOS and Android platform)

Steps to reproduce:

1. Create a new Gutenberg post with 2 simple paragraph blocks
2. Put the cursor somewhere in the first block except its end
3. Go to the end of the second block and start backspacing to delete characters. Delete up until the very first character of the second block
4. Notice that the "Start writing" placeholder text appears
5. (PREVIOUSLY) Notice the caret is placed at the position set in step 2
5. (NOW) Observe the caret is correctly placed at the end of block as expected.

This was still happening for me on a Pixel 2, Android 8.1, but this change in code made it work for me.

cc @marecar3  @daniloercoli  interested in hearing your thoughts

