### PR TITLE
Update Aztec to 1.5.0

### DIFF
--- a/react-native-aztec/ios/Cartfile
+++ b/react-native-aztec/ios/Cartfile
@@ -1,2 +1,2 @@
-github "wordpress-mobile/AztecEditor-iOS" ~> 1.4.4
+github "wordpress-mobile/AztecEditor-iOS" ~> 1.5.0
 

--- a/react-native-aztec/ios/Cartfile.resolved
+++ b/react-native-aztec/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.4.4"
+github "wordpress-mobile/AztecEditor-iOS" "1.5.0"


### PR DESCRIPTION
This PR updates Aztec to 1.5.0

**To Test:**

- Run `yarn install` `yarn start` and `yarn ios` and verify that example app runs successfully.