### PR TITLE
HTMLInputView refactor to better share code. 

### DIFF
--- a/src/components/html-text-input-ui/html-text-input-ui-common.scss
+++ b/src/components/html-text-input-ui/html-text-input-ui-common.scss
@@ -4,10 +4,14 @@ $padding: 8;
 $backgroundColor:  white;
 $htmlFont: $default-monospace-font;
 
-.container {
+.keyboardAvoidingView {
 	position: absolute;
 	top: 0;
 	right: 0;
 	left: 0;
 	bottom: 0;
+}
+
+.container {
+	flex: 1;
 }

--- a/src/components/html-text-input-ui/html-text-input-ui.android.js
+++ b/src/components/html-text-input-ui/html-text-input-ui.android.js
@@ -7,7 +7,7 @@
  * External dependencies
  */
 import * as React from 'react';
-import { ScrollView } from 'react-native';
+import { ScrollView, NativeSyntheticEvent, TextInputContentSizeChangeEventData } from 'react-native';
 
 /**
  * Internal dependencies
@@ -17,7 +17,10 @@ import KeyboardAvoidingView from '../keyboard-avoiding-view';
 
 type PropsType = {
 	parentHeight: number,
-	content: ( scrollEnabled: boolean, style: mixed, onContentSizeChange: () => void ) => React.Node,
+	content: (
+		scrollEnabled: boolean,
+		style: mixed,
+		onContentSizeChange: ( NativeSyntheticEvent<TextInputContentSizeChangeEventData> ) => void ) => React.Node,
 };
 
 type StateType = {
@@ -33,14 +36,14 @@ export default class HTMLInputViewUI extends React.Component<PropsType, StateTyp
 		};
 	}
 
-	onContentSizeChange = ( event ) => {
+	onContentSizeChange = ( event: NativeSyntheticEvent<TextInputContentSizeChangeEventData> ) => {
 		this.setState( { contentHeight: event.nativeEvent.contentSize.height } );
 	}
 
 	render() {
 		const style = { ...styles.htmlView, height: this.state.contentHeight + 16 };
 		return (
-			<KeyboardAvoidingView style={ styles.container } parentHeight={ this.props.parentHeight }>
+			<KeyboardAvoidingView style={ styles.keyboardAvoidingView } parentHeight={ this.props.parentHeight }>
 				<ScrollView
 					style={ { flex: 1 } }
 					keyboardDismissMode="interactive"

--- a/src/components/html-text-input-ui/html-text-input-ui.android.js
+++ b/src/components/html-text-input-ui/html-text-input-ui.android.js
@@ -7,7 +7,7 @@
  * External dependencies
  */
 import * as React from 'react';
-import { ScrollView, NativeSyntheticEvent, TextInputContentSizeChangeEventData } from 'react-native';
+import { ScrollView, View } from 'react-native';
 
 /**
  * Internal dependencies
@@ -17,17 +17,16 @@ import KeyboardAvoidingView from '../keyboard-avoiding-view';
 
 type PropsType = {
 	parentHeight: number,
-	content: (
-		scrollEnabled: boolean,
-		style: mixed,
-		onContentSizeChange: ( NativeSyntheticEvent<TextInputContentSizeChangeEventData> ) => void ) => React.Node,
+	children: React.Node,
 };
 
 type StateType = {
 	contentHeight: number,
 };
 
-export default class HTMLInputViewUI extends React.Component<PropsType, StateType> {
+class HTMLInputViewUI extends React.Component<PropsType, StateType> {
+	static scrollEnabled: boolean;
+
 	constructor() {
 		super( ...arguments );
 
@@ -41,16 +40,20 @@ export default class HTMLInputViewUI extends React.Component<PropsType, StateTyp
 	}
 
 	render() {
-		const style = { ...styles.htmlView, height: this.state.contentHeight + 16 };
 		return (
 			<KeyboardAvoidingView style={ styles.keyboardAvoidingView } parentHeight={ this.props.parentHeight }>
 				<ScrollView
 					style={ { flex: 1 } }
 					keyboardDismissMode="interactive"
 				>
-					{ this.props.content( false, style, this.onContentSizeChange ) }
+					{ this.props.children }
+					<View style={ { height: 16 } } />
 				</ScrollView>
 			</KeyboardAvoidingView>
 		);
 	}
 }
+
+HTMLInputViewUI.scrollEnabled = false;
+
+export default HTMLInputViewUI;

--- a/src/components/html-text-input-ui/html-text-input-ui.android.js
+++ b/src/components/html-text-input-ui/html-text-input-ui.android.js
@@ -47,7 +47,6 @@ class HTMLInputContainer extends React.Component<PropsType, StateType> {
 					keyboardDismissMode="interactive"
 				>
 					{ this.props.children }
-					<View style={ { height: 16 } } />
 				</ScrollView>
 			</KeyboardAvoidingView>
 		);

--- a/src/components/html-text-input-ui/html-text-input-ui.android.js
+++ b/src/components/html-text-input-ui/html-text-input-ui.android.js
@@ -6,7 +6,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import * as React from 'react';
 import { TextInput, ScrollView } from 'react-native';
 
 /**
@@ -16,14 +16,8 @@ import styles from './html-text-input-ui.scss';
 import KeyboardAvoidingView from '../keyboard-avoiding-view';
 
 type PropsType = {
-    setTitleAction: string => void,
-	value: string,
-	title: string,
-    parentHeight: number,
-    onChangeHTMLText: string => mixed,
-    onBlurHTMLText: () => mixed,
-    titlePlaceholder: string,
-    htmlPlaceholder: string,
+	parentHeight: number,
+	content: (scrollEnabled: boolean, style: mixed, onContentSizeChange: () => void) => React.Node,
 };
 
 type StateType = {

--- a/src/components/html-text-input-ui/html-text-input-ui.android.js
+++ b/src/components/html-text-input-ui/html-text-input-ui.android.js
@@ -7,7 +7,7 @@
  * External dependencies
  */
 import * as React from 'react';
-import { TextInput, ScrollView } from 'react-native';
+import { ScrollView } from 'react-native';
 
 /**
  * Internal dependencies
@@ -17,11 +17,11 @@ import KeyboardAvoidingView from '../keyboard-avoiding-view';
 
 type PropsType = {
 	parentHeight: number,
-	content: (scrollEnabled: boolean, style: mixed, onContentSizeChange: () => void) => React.Node,
+	content: ( scrollEnabled: boolean, style: mixed, onContentSizeChange: () => void ) => React.Node,
 };
 
 type StateType = {
-    contentHeight: number,
+	contentHeight: number,
 };
 
 export default class HTMLInputViewUI extends React.Component<PropsType, StateType> {
@@ -38,14 +38,14 @@ export default class HTMLInputViewUI extends React.Component<PropsType, StateTyp
 	}
 
 	render() {
-		const style = { ...styles.htmlView, height: this.state.contentHeight + 16 }
+		const style = { ...styles.htmlView, height: this.state.contentHeight + 16 };
 		return (
 			<KeyboardAvoidingView style={ styles.container } parentHeight={ this.props.parentHeight }>
 				<ScrollView
 					style={ { flex: 1 } }
 					keyboardDismissMode="interactive"
 				>
-					{ this.props.content( false, style, this.onContentSizeChange) }
+					{ this.props.content( false, style, this.onContentSizeChange ) }
 				</ScrollView>
 			</KeyboardAvoidingView>
 		);

--- a/src/components/html-text-input-ui/html-text-input-ui.android.js
+++ b/src/components/html-text-input-ui/html-text-input-ui.android.js
@@ -39,35 +39,19 @@ export default class HTMLInputViewUI extends React.Component<PropsType, StateTyp
 		};
 	}
 
+	onContentSizeChange = ( event ) => {
+		this.setState( { contentHeight: event.nativeEvent.contentSize.height } );
+	}
+
 	render() {
+		const style = { ...styles.htmlView, height: this.state.contentHeight + 16 }
 		return (
 			<KeyboardAvoidingView style={ styles.container } parentHeight={ this.props.parentHeight }>
 				<ScrollView
 					style={ { flex: 1 } }
-					keyboardDismissMode="interactive" >
-					<TextInput
-						autoCorrect={ false }
-						textAlignVertical="center"
-						numberOfLines={ 1 }
-						style={ styles.htmlViewTitle }
-						value={ this.props.title }
-						placeholder={ this.props.titlePlaceholder }
-						onChangeText={ this.props.setTitleAction }
-					/>
-					<TextInput
-						autoCorrect={ false }
-						textAlignVertical="top"
-						multiline
-						style={ { ...styles.htmlView, height: this.state.contentHeight + 16 } }
-						value={ this.props.value }
-						onChangeText={ this.props.onChangeHTMLText }
-						onBlur={ this.props.onBlurHTMLText }
-						placeholder={ this.props.htmlPlaceholder }
-						scrollEnabled={ false }
-						onContentSizeChange={ ( event ) => {
-							this.setState( { contentHeight: event.nativeEvent.contentSize.height } );
-						} }
-					/>
+					keyboardDismissMode="interactive"
+				>
+					{ this.props.content( false, style, this.onContentSizeChange) }
 				</ScrollView>
 			</KeyboardAvoidingView>
 		);

--- a/src/components/html-text-input-ui/html-text-input-ui.android.js
+++ b/src/components/html-text-input-ui/html-text-input-ui.android.js
@@ -24,7 +24,7 @@ type StateType = {
 	contentHeight: number,
 };
 
-class HTMLInputViewUI extends React.Component<PropsType, StateType> {
+class HTMLInputContainer extends React.Component<PropsType, StateType> {
 	static scrollEnabled: boolean;
 
 	constructor() {
@@ -54,6 +54,6 @@ class HTMLInputViewUI extends React.Component<PropsType, StateType> {
 	}
 }
 
-HTMLInputViewUI.scrollEnabled = false;
+HTMLInputContainer.scrollEnabled = false;
 
-export default HTMLInputViewUI;
+export default HTMLInputContainer;

--- a/src/components/html-text-input-ui/html-text-input-ui.android.js
+++ b/src/components/html-text-input-ui/html-text-input-ui.android.js
@@ -7,7 +7,7 @@
  * External dependencies
  */
 import * as React from 'react';
-import { ScrollView, View } from 'react-native';
+import { ScrollView } from 'react-native';
 
 /**
  * Internal dependencies

--- a/src/components/html-text-input-ui/html-text-input-ui.android.js
+++ b/src/components/html-text-input-ui/html-text-input-ui.android.js
@@ -21,31 +21,15 @@ type PropsType = {
 };
 
 type StateType = {
-	contentHeight: number,
 };
 
 class HTMLInputContainer extends React.Component<PropsType, StateType> {
 	static scrollEnabled: boolean;
 
-	constructor() {
-		super( ...arguments );
-
-		this.state = {
-			contentHeight: 0,
-		};
-	}
-
-	onContentSizeChange = ( event: NativeSyntheticEvent<TextInputContentSizeChangeEventData> ) => {
-		this.setState( { contentHeight: event.nativeEvent.contentSize.height } );
-	}
-
 	render() {
 		return (
 			<KeyboardAvoidingView style={ styles.keyboardAvoidingView } parentHeight={ this.props.parentHeight }>
-				<ScrollView
-					style={ { flex: 1 } }
-					keyboardDismissMode="interactive"
-				>
+				<ScrollView style={ styles.scrollView } >
 					{ this.props.children }
 				</ScrollView>
 			</KeyboardAvoidingView>

--- a/src/components/html-text-input-ui/html-text-input-ui.android.scss
+++ b/src/components/html-text-input-ui/html-text-input-ui.android.scss
@@ -8,7 +8,7 @@
 	padding-left: $padding;
 	padding-right: $padding;
 	padding-top: $padding;
-	padding-bottom: $padding;
+	padding-bottom: $padding + 16;
 }
 
 .htmlViewTitle {

--- a/src/components/html-text-input-ui/html-text-input-ui.android.scss
+++ b/src/components/html-text-input-ui/html-text-input-ui.android.scss
@@ -19,3 +19,7 @@
 	padding-top: $padding;
 	padding-bottom: $padding;
 }
+
+.scrollView {
+	flex: 1;
+}

--- a/src/components/html-text-input-ui/html-text-input-ui.ios.js
+++ b/src/components/html-text-input-ui/html-text-input-ui.ios.js
@@ -17,13 +17,14 @@ import KeyboardAvoidingView from '../keyboard-avoiding-view';
 
 type PropsType = {
 	parentHeight: number,
-	content: ( scrollEnabled: boolean, style: mixed, onContentSizeChange: () => void ) => React.Node,
+	children: React.Node,
 };
 
 type StateType = {
 };
 
-export default class HTMLInputViewUI extends React.Component<PropsType, StateType> {
+class HTMLInputViewUI extends React.Component<PropsType, StateType> {
+	static scrollEnabled: boolean;
 	panResponder: PanResponder;
 
 	constructor() {
@@ -50,8 +51,12 @@ export default class HTMLInputViewUI extends React.Component<PropsType, StateTyp
 				{ ...this.panResponder.panHandlers }
 				parentHeight={ this.props.parentHeight }
 			>
-				{ this.props.content( true, styles.htmlView, () => {} ) }
+				{ this.props.children }
 			</KeyboardAvoidingView>
 		);
 	}
 }
+
+HTMLInputViewUI.scrollEnabled = true;
+
+export default HTMLInputViewUI;

--- a/src/components/html-text-input-ui/html-text-input-ui.ios.js
+++ b/src/components/html-text-input-ui/html-text-input-ui.ios.js
@@ -34,7 +34,7 @@ export default class HTMLInputViewUI extends React.Component<PropsType, StateTyp
 
 			onPanResponderMove: ( e, gestureState ) => {
 				if ( gestureState.dy > 100 && gestureState.dy < 110 ) {
-					//Keyboard.dismiss() and this.textInput.blur() is not working here
+					//Keyboard.dismiss() and this.textInput.blur() are not working here
 					//They require to know the currentlyFocusedID under the hood but
 					//during this gesture there's no currentlyFocusedID
 					UIManager.blur( e.target );
@@ -46,12 +46,11 @@ export default class HTMLInputViewUI extends React.Component<PropsType, StateTyp
 	render() {
 		return (
 			<KeyboardAvoidingView
-				style={ styles.container }
+				style={ styles.keyboardAvoidingView }
 				{ ...this.panResponder.panHandlers }
 				parentHeight={ this.props.parentHeight }
 			>
 				{ this.props.content( true, styles.htmlView, () => {} ) }
-
 			</KeyboardAvoidingView>
 		);
 	}

--- a/src/components/html-text-input-ui/html-text-input-ui.ios.js
+++ b/src/components/html-text-input-ui/html-text-input-ui.ios.js
@@ -6,7 +6,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import * as React from 'react';
 import { TextInput, UIManager, PanResponder } from 'react-native';
 
 /**
@@ -16,14 +16,8 @@ import styles from './html-text-input-ui.scss';
 import KeyboardAvoidingView from '../keyboard-avoiding-view';
 
 type PropsType = {
-    setTitleAction: string => void,
-	value: string,
-	title: string,
     parentHeight: number,
-    onChangeHTMLText: string => mixed,
-    onBlurHTMLText: () => mixed,
-    titlePlaceholder: string,
-    htmlPlaceholder: string,
+	content: (scrollEnabled: boolean, style: mixed, onContentSizeChange: () => void) => React.Node,
 };
 
 type StateType = {

--- a/src/components/html-text-input-ui/html-text-input-ui.ios.js
+++ b/src/components/html-text-input-ui/html-text-input-ui.ios.js
@@ -23,7 +23,7 @@ type PropsType = {
 type StateType = {
 };
 
-class HTMLInputViewUI extends React.Component<PropsType, StateType> {
+class HTMLInputContainer extends React.Component<PropsType, StateType> {
 	static scrollEnabled: boolean;
 	panResponder: PanResponder;
 
@@ -57,6 +57,6 @@ class HTMLInputViewUI extends React.Component<PropsType, StateType> {
 	}
 }
 
-HTMLInputViewUI.scrollEnabled = true;
+HTMLInputContainer.scrollEnabled = true;
 
-export default HTMLInputViewUI;
+export default HTMLInputContainer;

--- a/src/components/html-text-input-ui/html-text-input-ui.ios.js
+++ b/src/components/html-text-input-ui/html-text-input-ui.ios.js
@@ -7,7 +7,7 @@
  * External dependencies
  */
 import * as React from 'react';
-import { TextInput, UIManager, PanResponder } from 'react-native';
+import { UIManager, PanResponder } from 'react-native';
 
 /**
  * Internal dependencies
@@ -16,8 +16,8 @@ import styles from './html-text-input-ui.scss';
 import KeyboardAvoidingView from '../keyboard-avoiding-view';
 
 type PropsType = {
-    parentHeight: number,
-	content: (scrollEnabled: boolean, style: mixed, onContentSizeChange: () => void) => React.Node,
+	parentHeight: number,
+	content: ( scrollEnabled: boolean, style: mixed, onContentSizeChange: () => void ) => React.Node,
 };
 
 type StateType = {
@@ -50,7 +50,7 @@ export default class HTMLInputViewUI extends React.Component<PropsType, StateTyp
 				{ ...this.panResponder.panHandlers }
 				parentHeight={ this.props.parentHeight }
 			>
-				{ this.props.content( true, styles.htmlView, ()=>{} ) }
+				{ this.props.content( true, styles.htmlView, () => {} ) }
 
 			</KeyboardAvoidingView>
 		);

--- a/src/components/html-text-input-ui/html-text-input-ui.ios.js
+++ b/src/components/html-text-input-ui/html-text-input-ui.ios.js
@@ -54,26 +54,10 @@ export default class HTMLInputViewUI extends React.Component<PropsType, StateTyp
 			<KeyboardAvoidingView
 				style={ styles.container }
 				{ ...this.panResponder.panHandlers }
-				parentHeight={ this.props.parentHeight }>
-				<TextInput
-					autoCorrect={ false }
-					textAlignVertical="center"
-					numberOfLines={ 1 }
-					style={ styles.htmlViewTitle }
-					value={ this.props.title }
-					placeholder={ this.props.titlePlaceholder }
-					onChangeText={ this.props.setTitleAction }
-				/>
-				<TextInput
-					autoCorrect={ false }
-					textAlignVertical="top"
-					multiline
-					style={ { ...styles.htmlView } }
-					value={ this.props.value }
-					onChangeText={ this.props.onChangeHTMLText }
-					onBlur={ this.props.onBlurHTMLText }
-					placeholder={ this.props.htmlPlaceholder }
-				/>
+				parentHeight={ this.props.parentHeight }
+			>
+				{ this.props.content( true, styles.htmlView, ()=>{} ) }
+
 			</KeyboardAvoidingView>
 		);
 	}

--- a/src/components/html-text-input-ui/html-text-input-ui.ios.scss
+++ b/src/components/html-text-input-ui/html-text-input-ui.ios.scss
@@ -9,7 +9,7 @@ $title-height: 32;
 	background-color: $backgroundColor;
 	padding-left: $padding;
 	padding-right: $padding;
-	padding-bottom: $title-height + $padding + 100;
+	padding-bottom: $title-height + $padding;
 }
 
 .htmlViewTitle {
@@ -20,5 +20,4 @@ $title-height: 32;
 	padding-top: $padding;
 	padding-bottom: $padding;
 	height: $title-height;
-	
 }

--- a/src/components/html-text-input-ui/html-text-input-ui.ios.scss
+++ b/src/components/html-text-input-ui/html-text-input-ui.ios.scss
@@ -9,7 +9,7 @@ $title-height: 32;
 	background-color: $backgroundColor;
 	padding-left: $padding;
 	padding-right: $padding;
-	padding-bottom: $title-height + $padding;
+	padding-bottom: $title-height + $padding + 100;
 }
 
 .htmlViewTitle {

--- a/src/components/html-text-input.js
+++ b/src/components/html-text-input.js
@@ -19,7 +19,7 @@ import { TextInput } from 'react-native';
 /**
  * Internal dependencies
  */
-import HTMLInputViewUI from './html-text-input-ui/html-text-input-ui';
+import HTMLInputContainer from './html-text-input-ui/html-text-input-ui';
 import styles from './html-text-input-ui/html-text-input-ui.scss';
 
 type PropsType = {
@@ -82,7 +82,7 @@ export class HTMLInputView extends React.Component<PropsType, StateType> {
 
 	render() {
 		return (
-			<HTMLInputViewUI parentHeight={ this.props.parentHeight }>
+			<HTMLInputContainer parentHeight={ this.props.parentHeight }>
 				<TextInput
 					autoCorrect={ false }
 					textAlignVertical="center"
@@ -101,9 +101,9 @@ export class HTMLInputView extends React.Component<PropsType, StateType> {
 					onChangeText={ this.edit }
 					onBlur={ this.stopEditing }
 					placeholder={ __( 'Start writing…' ) }
-					scrollEnabled={ HTMLInputViewUI.scrollEnabled }
+					scrollEnabled={ HTMLInputContainer.scrollEnabled }
 				/>
-			</HTMLInputViewUI>
+			</HTMLInputContainer>
 		);
 	}
 }

--- a/src/components/html-text-input.js
+++ b/src/components/html-text-input.js
@@ -14,11 +14,13 @@ import { withInstanceId, compose } from '@wordpress/compose';
  * External dependencies
  */
 import React from 'react';
+import { View, TextInput } from 'react-native';
 
 /**
  * Internal dependencies
  */
 import HTMLInputViewUI from './html-text-input-ui/html-text-input-ui';
+import styles from './html-text-input-ui/html-text-input-ui.scss';
 
 type PropsType = {
 	onChange: string => mixed,
@@ -81,14 +83,36 @@ export class HTMLInputView extends React.Component<PropsType, StateType> {
 	render() {
 		return (
 			<HTMLInputViewUI
-				setTitleAction={ this.props.setTitleAction }
-				value={ this.state.value }
-				title={ this.props.title }
 				parentHeight={ this.props.parentHeight }
-				onChangeHTMLText={ this.edit }
-				onBlurHTMLText={ this.stopEditing }
 				titlePlaceholder={ __( 'Add title' ) }
 				htmlPlaceholder={ __( 'Start writing…' ) }
+				content={ ( scrollEnabled, style, onContentSizeChange ) => {
+					return (
+						<View>
+							<TextInput
+								autoCorrect={ false }
+								textAlignVertical="center"
+								numberOfLines={ 1 }
+								style={ styles.htmlViewTitle }
+								value={ this.props.title }
+								placeholder={ __( 'Add title' ) }
+								onChangeText={ this.props.setTitleAction }
+							/>
+							<TextInput
+								autoCorrect={ false }
+								textAlignVertical="top"
+								multiline
+								style={ style }
+								value={ this.state.value }
+								onChangeText={ this.edit }
+								onBlur={ this.stopEditing }
+								placeholder={ __( 'Start writing…' ) }
+								scrollEnabled={ scrollEnabled }
+								onContentSizeChange={ onContentSizeChange }
+							/>
+						</View>
+					);
+				} }
 			/>
 		);
 	}

--- a/src/components/html-text-input.js
+++ b/src/components/html-text-input.js
@@ -84,9 +84,9 @@ export class HTMLInputView extends React.Component<PropsType, StateType> {
 		return (
 			<HTMLInputViewUI
 				parentHeight={ this.props.parentHeight }
-				content={ ( scrollEnabled, style, onContentSizeChange ) => {
+				content={ ( scrollEnabled, htmlStyle, onContentSizeChange ) => {
 					return (
-						<View>
+						<View style={ styles.container }>
 							<TextInput
 								autoCorrect={ false }
 								textAlignVertical="center"
@@ -100,7 +100,7 @@ export class HTMLInputView extends React.Component<PropsType, StateType> {
 								autoCorrect={ false }
 								textAlignVertical="top"
 								multiline
-								style={ style }
+								style={ htmlStyle }
 								value={ this.state.value }
 								onChangeText={ this.edit }
 								onBlur={ this.stopEditing }

--- a/src/components/html-text-input.js
+++ b/src/components/html-text-input.js
@@ -84,8 +84,6 @@ export class HTMLInputView extends React.Component<PropsType, StateType> {
 		return (
 			<HTMLInputViewUI
 				parentHeight={ this.props.parentHeight }
-				titlePlaceholder={ __( 'Add title' ) }
-				htmlPlaceholder={ __( 'Start writing…' ) }
 				content={ ( scrollEnabled, style, onContentSizeChange ) => {
 					return (
 						<View>

--- a/src/components/html-text-input.js
+++ b/src/components/html-text-input.js
@@ -14,7 +14,7 @@ import { withInstanceId, compose } from '@wordpress/compose';
  * External dependencies
  */
 import React from 'react';
-import { View, TextInput } from 'react-native';
+import { TextInput } from 'react-native';
 
 /**
  * Internal dependencies
@@ -82,36 +82,28 @@ export class HTMLInputView extends React.Component<PropsType, StateType> {
 
 	render() {
 		return (
-			<HTMLInputViewUI
-				parentHeight={ this.props.parentHeight }
-				content={ ( scrollEnabled, htmlStyle, onContentSizeChange ) => {
-					return (
-						<View style={ styles.container }>
-							<TextInput
-								autoCorrect={ false }
-								textAlignVertical="center"
-								numberOfLines={ 1 }
-								style={ styles.htmlViewTitle }
-								value={ this.props.title }
-								placeholder={ __( 'Add title' ) }
-								onChangeText={ this.props.setTitleAction }
-							/>
-							<TextInput
-								autoCorrect={ false }
-								textAlignVertical="top"
-								multiline
-								style={ htmlStyle }
-								value={ this.state.value }
-								onChangeText={ this.edit }
-								onBlur={ this.stopEditing }
-								placeholder={ __( 'Start writing…' ) }
-								scrollEnabled={ scrollEnabled }
-								onContentSizeChange={ onContentSizeChange }
-							/>
-						</View>
-					);
-				} }
-			/>
+			<HTMLInputViewUI parentHeight={ this.props.parentHeight }>
+				<TextInput
+					autoCorrect={ false }
+					textAlignVertical="center"
+					numberOfLines={ 1 }
+					style={ styles.htmlViewTitle }
+					value={ this.props.title }
+					placeholder={ __( 'Add title' ) }
+					onChangeText={ this.props.setTitleAction }
+				/>
+				<TextInput
+					autoCorrect={ false }
+					textAlignVertical="top"
+					multiline
+					style={ styles.htmlView }
+					value={ this.state.value }
+					onChangeText={ this.edit }
+					onBlur={ this.stopEditing }
+					placeholder={ __( 'Start writing…' ) }
+					scrollEnabled={ HTMLInputViewUI.scrollEnabled }
+				/>
+			</HTMLInputViewUI>
 		);
 	}
 }


### PR DESCRIPTION
This PR tries to implement HTMLInputView in a way that more code is shared between platforms, and branching just the necessary parts.

Since there were challenges sharing the HTML TextView that is the main component, and needs a slightly different configuration, the final result is not as strait forward as one would have liked.

Ideally we can check this out, and see if we like it enough to merge.
If this is more complex than it helps, it's all good to not merge and keep `HTMLInputView` as it is.
