### PR TITLE
[iOS]: Make Hide-Keyboard button work again after dismissing Links UI.

### DIFF
--- a/react-native-aztec/src/AztecView.js
+++ b/react-native-aztec/src/AztecView.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import ReactNative, {requireNativeComponent, ViewPropTypes, UIManager, ColorPropType, TouchableWithoutFeedback} from 'react-native';
+import ReactNative, {requireNativeComponent, ViewPropTypes, UIManager, ColorPropType, TouchableWithoutFeedback, Platform} from 'react-native';
 import TextInputState from 'react-native/lib/TextInputState';
 
 const AztecManager = UIManager.getViewManagerConfig('RCTAztecView');
@@ -138,19 +138,27 @@ class AztecView extends React.Component {
     this._onFocus(event); // Check if there are listeners set on the focus event
   }
 
+  _onAztecFocus = (event) => {
+    // IMPORTANT: the onFocus events from Aztec are thrown away on Android as these are handled by onPress() in the upper level.
+    // It's necessary to do this otherwise onFocus may be set by `{...otherProps}` and thus the onPress + onFocus
+    // combination generate an infinite loop as described in https://github.com/wordpress-mobile/gutenberg-mobile/issues/302
+    // For iOS, this is necessary to let the system know when Aztec was focused programatically.
+    if ( Platform.OS == 'ios' ) {
+      this._onPress(event);
+    }
+  }
+
   render() {
-    const { onActiveFormatsChange, ...otherProps } = this.props    
+    const { onActiveFormatsChange, onFocus, ...otherProps } = this.props
     return (
       <TouchableWithoutFeedback onPress={ this._onPress }>
-        <RCTAztecView {...otherProps}
+        <RCTAztecView
+          {...otherProps}
           onContentSizeChange = { this._onContentSizeChange }
           onHTMLContentWithCursor = { this._onHTMLContentWithCursor }
           onSelectionChange = { this._onSelectionChange }
           onEnter = { this._onEnter }
-          // IMPORTANT: the onFocus events are thrown away as these are handled by onPress() in the upper level.
-          // It's necessary to do this otherwise onFocus may be set by `{...otherProps}` and thus the onPress + onFocus
-          // combination generate an infinite loop as described in https://github.com/wordpress-mobile/gutenberg-mobile/issues/302
-          onFocus = { () => {} } 
+          onFocus = { this._onAztecFocus } 
           onBlur = { this._onBlur }
           onBackspace = { this._onBackspace }
         />

--- a/src/block-management/block-toolbar.js
+++ b/src/block-management/block-toolbar.js
@@ -36,8 +36,8 @@ type PropsType = {
 export class BlockToolbar extends Component<PropsType> {
 	onKeyboardHide = () => {
 		this.props.clearSelectedBlock();
-		if ( Platform.OS == 'android' ) {
-			// Avoiding extra blur calls on iOS but still needed for android. 
+		if ( Platform.OS === 'android' ) {
+			// Avoiding extra blur calls on iOS but still needed for android.
 			Keyboard.dismiss();
 		}
 	};

--- a/src/block-management/block-toolbar.js
+++ b/src/block-management/block-toolbar.js
@@ -7,7 +7,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { View, ScrollView, Keyboard } from 'react-native';
+import { View, ScrollView, Keyboard, Platform } from 'react-native';
 
 /**
  * WordPress dependencies
@@ -30,11 +30,16 @@ type PropsType = {
 	hasUndo: boolean,
 	redo: void => void,
 	undo: void => void,
+	clearSelectedBlock: void => void,
 };
 
 export class BlockToolbar extends Component<PropsType> {
 	onKeyboardHide = () => {
-		Keyboard.dismiss();
+		this.props.clearSelectedBlock();
+		if ( Platform.OS == 'android' ) {
+			// Avoiding extra blur calls on iOS but still needed for android. 
+			Keyboard.dismiss();
+		}
 	};
 
 	render() {
@@ -98,5 +103,6 @@ export default compose( [
 	withDispatch( ( dispatch ) => ( {
 		redo: dispatch( 'core/editor' ).redo,
 		undo: dispatch( 'core/editor' ).undo,
+		clearSelectedBlock: dispatch( 'core/editor' ).clearSelectedBlock,
 	} ) ),
 ] )( BlockToolbar );


### PR DESCRIPTION
fixes #702 

This PR fixes an issue that made the Hide-Keyboard toolbar button not work after the Links UI bottom-sheet was dismissed.
Additionally, now on both platform, dismissing the keyboard with this button will clear the block selection.

![hide-keyboard](https://user-images.githubusercontent.com/9772967/54985041-5fb44980-4fb0-11e9-9607-5750ee2413b6.gif)

To test (iOS):
- Select a paragraph block.
- Present the Links UI (pressing the links button on the toolbar).
- Dismiss the Links UI bottom-sheet.
- Press the hide-keyboard button on the toolbar.
- Check that the button works and the keyboard is dismissed.
- Check that the block is now deselected.

To test (Android):
**Note:** On Android, the keyboard is already hidden after dismissing the Links UI.

- Select a paragraph block.
- Press the hide-keyboard button on the toolbar.
- Check that the keyboard is dismissed.
- Check that the block is now deselected.