### PR TITLE
Intercept image request to add access token when site is private

### DIFF
--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -121,6 +121,7 @@ dependencies {
         implementation project(':react-native-recyclerview-list')
 
         implementation 'com.facebook.react:react-native:+'
+        implementation "com.facebook.fresco:imagepipeline-okhttp3:1.10.0"
     } else {
         implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-svg', readHashedVersion('../../package.json', 'react-native-svg', 'dependencies')))
         implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-recyclerview-list', 'f845b3c2c4411b8e97db23724bf1a535530c5435'))

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/OkHttpHeaderInterceptor.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/OkHttpHeaderInterceptor.java
@@ -1,0 +1,35 @@
+package org.wordpress.mobile.WPAndroidGlue;
+
+import android.util.Log;
+
+import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnAuthHeaderRequestedListener;
+
+import java.io.IOException;
+
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class OkHttpHeaderInterceptor implements Interceptor {
+
+    private static final String AUTHORIZATION_HEADER_KEY = "Authorization";
+
+    private OnAuthHeaderRequestedListener mOnAuthHeaderRequestedListener;
+
+    void setOnAuthHeaderRequestedListener(OnAuthHeaderRequestedListener onAuthHeaderRequestedListener) {
+        mOnAuthHeaderRequestedListener = onAuthHeaderRequestedListener;
+    }
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Request.Builder builder = chain.request().newBuilder();
+
+        String authHeader = mOnAuthHeaderRequestedListener.onAuthHeaderRequested(chain.request().url().toString());
+        if (authHeader.length() > 0) {
+            builder.addHeader(AUTHORIZATION_HEADER_KEY, authHeader);
+        }
+
+        return chain.proceed(builder.build());
+    }
+
+}

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/OkHttpHeaderInterceptor.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/OkHttpHeaderInterceptor.java
@@ -1,6 +1,6 @@
 package org.wordpress.mobile.WPAndroidGlue;
 
-import android.util.Log;
+import android.text.TextUtils;
 
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnAuthHeaderRequestedListener;
 
@@ -25,7 +25,7 @@ public class OkHttpHeaderInterceptor implements Interceptor {
         Request.Builder builder = chain.request().newBuilder();
 
         String authHeader = mOnAuthHeaderRequestedListener.onAuthHeaderRequested(chain.request().url().toString());
-        if (authHeader.length() > 0) {
+        if (!TextUtils.isEmpty(authHeader)) {
             builder.addHeader(AUTHORIZATION_HEADER_KEY, authHeader);
         }
 

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -183,11 +183,9 @@ public class WPAndroidGlueCode {
             }
         });
 
-        ImagePipelineConfig imagePipelineConfig = getImagePipelineConfig(sOkHttpClient);
-        MainReactPackage mainReactPackage = new MainReactPackage(getMainPackageConfig(imagePipelineConfig));
 
         return Arrays.asList(
-                mainReactPackage,
+                new MainReactPackage(getMainPackageConfig(getImagePipelineConfig(sOkHttpClient))),
                 new SvgPackage(),
                 new ReactAztecPackage(),
                 new RNRecyclerviewListPackage(),

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -13,6 +13,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout.LayoutParams;
 
+import com.facebook.imagepipeline.backends.okhttp3.OkHttpImagePipelineConfigFactory;
+import com.facebook.imagepipeline.core.ImagePipelineConfig;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactInstanceManagerBuilder;
 import com.facebook.react.ReactPackage;
@@ -20,6 +22,7 @@ import com.facebook.react.ReactRootView;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.common.LifecycleState;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
+import com.facebook.react.shell.MainPackageConfig;
 import com.facebook.react.shell.MainReactPackage;
 import com.facebook.soloader.SoLoader;
 import com.github.godness84.RNRecyclerViewList.RNRecyclerviewListPackage;
@@ -40,6 +43,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import okhttp3.OkHttpClient;
+
 
 public class WPAndroidGlueCode {
     private ReactRootView mReactRootView;
@@ -70,6 +75,9 @@ public class WPAndroidGlueCode {
     private static final String PROP_NAME_INITIAL_HTML_MODE_ENABLED = "initialHtmlModeEnabled";
     private static final String PROP_NAME_LOCALE = "locale";
     private static final String PROP_NAME_TRANSLATIONS = "translations";
+
+    private static OkHttpHeaderInterceptor sAddCookiesInterceptor = new OkHttpHeaderInterceptor();
+    private static OkHttpClient sOkHttpClient = new OkHttpClient.Builder().addInterceptor(sAddCookiesInterceptor).build();
 
     public void onCreate(Context context) {
         SoLoader.init(context, /* native exopackage */ false);
@@ -102,6 +110,10 @@ public class WPAndroidGlueCode {
 
     public interface OnEditorMountListener {
         void onEditorDidMount(boolean hasUnsupportedBlocks);
+    }
+
+    public interface OnAuthHeaderRequestedListener {
+        String onAuthHeaderRequested(String url);
     }
 
     protected List<ReactPackage> getPackages() {
@@ -170,12 +182,25 @@ public class WPAndroidGlueCode {
                 }
             }
         });
+
+        ImagePipelineConfig imagePipelineConfig = getImagePipelineConfig(sOkHttpClient);
+        MainReactPackage mainReactPackage = new MainReactPackage(getMainPackageConfig(imagePipelineConfig));
+
         return Arrays.asList(
-                new MainReactPackage(),
+                mainReactPackage,
                 new SvgPackage(),
                 new ReactAztecPackage(),
                 new RNRecyclerviewListPackage(),
                 mRnReactNativeGutenbergBridgePackage);
+    }
+
+    private MainPackageConfig getMainPackageConfig(ImagePipelineConfig imagePipelineConfig) {
+        return new MainPackageConfig.Builder().setFrescoConfig(imagePipelineConfig).build();
+    }
+
+    private ImagePipelineConfig getImagePipelineConfig(OkHttpClient client) {
+        return  OkHttpImagePipelineConfigFactory
+                .newBuilder(mReactRootView.getContext(), client).build();
     }
 
     public void onCreateView(Context initContext, boolean htmlModeEnabled,
@@ -217,13 +242,16 @@ public class WPAndroidGlueCode {
 
     public void attachToContainer(ViewGroup viewGroup, OnMediaLibraryButtonListener onMediaLibraryButtonListener,
                                   OnReattachQueryListener onReattachQueryListener,
-                                  OnEditorMountListener onEditorMountListener) {
+                                  OnEditorMountListener onEditorMountListener,
+                                  OnAuthHeaderRequestedListener onAuthHeaderRequestedListener) {
         MutableContextWrapper contextWrapper = (MutableContextWrapper) mReactRootView.getContext();
         contextWrapper.setBaseContext(viewGroup.getContext());
 
         mOnMediaLibraryButtonListener = onMediaLibraryButtonListener;
         mOnReattachQueryListener = onReattachQueryListener;
         mOnEditorMountListener = onEditorMountListener;
+
+        sAddCookiesInterceptor.setOnAuthHeaderRequestedListener(onAuthHeaderRequestedListener);
 
         if (mReactRootView.getParent() != null) {
             ((ViewGroup) mReactRootView.getParent()).removeView(mReactRootView);
@@ -279,6 +307,7 @@ public class WPAndroidGlueCode {
         if (mReactRootView != null) {
             mReactRootView.unmountReactApplication();
             mReactRootView = null;
+            sAddCookiesInterceptor.setOnAuthHeaderRequestedListener(null);
         }
         if (mReactInstanceManager != null) {
             // onDestroy may be called on a ReactFragment after another ReactFragment has been


### PR DESCRIPTION
This is the PR based on issue : https://github.com/wordpress-mobile/gutenberg-mobile/issues/376

It allows WPAndroid users who have a private site to access images when creating new blog Post.

Test Steps : 

Follow instructions on WPAndroid related PR : https://github.com/wordpress-mobile/WordPress-Android/pull/9483