### PR TITLE
Accessibility Mark I - Toolbar Buttons

### DIFF
--- a/src/block-management/block-toolbar.js
+++ b/src/block-management/block-toolbar.js
@@ -82,7 +82,7 @@ export class BlockToolbar extends Component<PropsType> {
 				{ showKeyboardHideButton &&
 				( <Toolbar passedStyle={ styles.keyboardHideContainer }>
 					<ToolbarButton
-						title={ __( 'Hide keyboard' )}
+						title={ __( 'Hide keyboard' ) }
 						icon="keyboard-hide"
 						onClick={ this.onKeyboardHide }
 					/>

--- a/src/block-management/block-toolbar.js
+++ b/src/block-management/block-toolbar.js
@@ -48,7 +48,7 @@ export class BlockToolbar extends Component<PropsType> {
 		} = this.props;
 
 		return (
-			<View style={ styles.container }>
+			<View style={ styles.container } >
 				<ScrollView
 					horizontal={ true }
 					showsHorizontalScrollIndicator={ false }
@@ -58,18 +58,19 @@ export class BlockToolbar extends Component<PropsType> {
 				>
 					<Toolbar>
 						<ToolbarButton
-							label={ __( 'Add block' ) }
+							title={ __( 'Add block' ) }
 							icon={ ( <Dashicon icon="plus-alt" style={ styles.addBlockButton } color={ styles.addBlockButton.color } /> ) }
 							onClick={ onInsertClick }
+							extraProps={ { hint: __( 'Double tap to add a block' ) } }
 						/>
 						<ToolbarButton
-							label={ __( 'Undo' ) }
+							title={ __( 'Undo' ) }
 							icon="undo"
 							isDisabled={ ! hasUndo }
 							onClick={ undo }
 						/>
 						<ToolbarButton
-							label={ __( 'Redo' ) }
+							title={ __( 'Redo' ) }
 							icon="redo"
 							isDisabled={ ! hasRedo }
 							onClick={ redo }
@@ -81,6 +82,7 @@ export class BlockToolbar extends Component<PropsType> {
 				{ showKeyboardHideButton &&
 				( <Toolbar passedStyle={ styles.keyboardHideContainer }>
 					<ToolbarButton
+						title={ __( 'Hide keyboard' )}
 						icon="keyboard-hide"
 						onClick={ this.onKeyboardHide }
 					/>


### PR DESCRIPTION
Part of #476 

This is a simple PR that implements the changes made on https://github.com/WordPress/gutenberg/pull/14697 to improve accessibility on the toolbar buttons.

### To test (iOS):
- Activate VoiceOver: https://github.com/wordpress-mobile/WordPress-iOS/wiki/Using-VoiceOver
- Select the "Add Block" button.
- Check that VoiceOver reads the label, that it reads the element type (button), and it reads the hint (after a couple of seconds).
- Select the "Unod/Redo" buttons.
- Check that it reads the label, the element type (button) and the state (dimmed)
  - For some reason it says dimmed instead of disabled, but it's a iOS system thing.
- Select a Paragraph or Heading block.
- Check that the format buttons are read correctly (label and type).
- Activate one of the format buttons (**b**, _i_, ~ABC~, H2, H3, or H4).
- Check that the button state is read correctly (selected)
- Select the Hide Keyboard button.
- Check that it reads properly (label and type).

### To test (Android):
- Activate TalkBack: https://www.wikihow.com/Enable-TalkBack-on-Your-Android
  - In my case, the system had a handy tutorial on how to use it.
  - If your version doesn't have it, it's actually very similar to [VoiceOver.](https://www.wikihow.com/Enable-TalkBack-on-Your-Android)
- Select the "Add Block" button.
- Check that VoiceOver reads the label, that it reads the element type (button), and it reads the hint (after a couple of seconds).
- Select the "Unod/Redo" buttons.
- Check that it reads the label, the element type (button) and the state (dimmed)

And that's it. On Android, blocks are still unusable by TalkBack :( 