### PR TITLE
[Issue/605][Android]Apply OS font size scale change in editor

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
-        android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+        android:configChanges="keyboard|keyboardHidden|orientation|screenSize|fontScale"
         android:windowSoftInputMode="adjustResize">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -219,6 +219,7 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
         view.setTextSize(
                 TypedValue.COMPLEX_UNIT_PX,
                 (int) Math.ceil(PixelUtil.toPixelFromSP(fontSize)));
+        view.refreshText();
     }
 
     @ReactProp(name = ViewProps.FONT_FAMILY)

--- a/react-native-aztec/src/AztecView.js
+++ b/react-native-aztec/src/AztecView.js
@@ -168,13 +168,11 @@ class AztecView extends React.Component {
 
   render() {
     const { onActiveFormatsChange, onFocus, fontSize, ...otherProps } = this.props
-    const scaledFontSize = getScaledFontSize(fontSize, this.state.fontScale);
-
     return (
       <TouchableWithoutFeedback onPress={ this._onPress }>
         <RCTAztecView
           {...otherProps}
-          fontSize={ scaledFontSize }
+          fontSize={ getScaledFontSize(fontSize, this.state.fontScale) }
           onContentSizeChange = { this._onContentSizeChange }
           onHTMLContentWithCursor = { this._onHTMLContentWithCursor }
           onSelectionChange = { this._onSelectionChange }

--- a/react-native-aztec/src/AztecView.js
+++ b/react-native-aztec/src/AztecView.js
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import ReactNative, {requireNativeComponent, ViewPropTypes, UIManager, ColorPropType, TouchableWithoutFeedback, Platform} from 'react-native';
+import ReactNative, {requireNativeComponent, ViewPropTypes, UIManager, ColorPropType, TouchableWithoutFeedback, Platform, Dimensions} from 'react-native';
 import TextInputState from 'react-native/lib/TextInputState';
+import { getScaledFontSize } from './utils';
 
 const AztecManager = UIManager.getViewManagerConfig('RCTAztecView');
 
@@ -30,6 +31,23 @@ class AztecView extends React.Component {
     onCaretVerticalPositionChange: PropTypes.func,
     blockType: PropTypes.object,
     ...ViewPropTypes, // include the default view properties
+  }
+
+  constructor() {
+    super();
+    this.state = { fontScale: Dimensions.get('window').fontScale };
+  }
+
+  _onDimensionsChange = dimensions => {
+    this.setState({ fontScale: dimensions.window.fontScale });
+  }
+
+  componentWillMount() {
+    Dimensions.addEventListener('change', this._onDimensionsChange);
+  }
+
+  componentWillUnmount() {
+    Dimensions.removeEventListener('change', this._onDimensionsChange);
   }
 
   dispatch(command, params) {
@@ -149,11 +167,14 @@ class AztecView extends React.Component {
   }
 
   render() {
-    const { onActiveFormatsChange, onFocus, ...otherProps } = this.props
+    const { onActiveFormatsChange, onFocus, fontSize, ...otherProps } = this.props
+    const scaledFontSize = getScaledFontSize(fontSize, this.state.fontScale);
+
     return (
       <TouchableWithoutFeedback onPress={ this._onPress }>
         <RCTAztecView
           {...otherProps}
+          fontSize={ scaledFontSize }
           onContentSizeChange = { this._onContentSizeChange }
           onHTMLContentWithCursor = { this._onHTMLContentWithCursor }
           onSelectionChange = { this._onSelectionChange }

--- a/react-native-aztec/src/utils.js
+++ b/react-native-aztec/src/utils.js
@@ -1,7 +1,10 @@
 import { Platform } from 'react-native';
 
+// Basically React Native has a mechanism to scale font size automatically.
+// But GM is rendered on top of fragment of which retain flag is true.
+// Hence we deal with fontScale change manually on our side.
 export function getScaledFontSize( fontSize, fontScale ) {
-	if ( Platform.OS == 'ios' ) {
+	if ( Platform.OS === 'ios' ) {
 		return fontSize ? fontSize : undefined; // to not to affect to iOS
 	}
 	const baseFontSize = 18;

--- a/react-native-aztec/src/utils.js
+++ b/react-native-aztec/src/utils.js
@@ -1,0 +1,9 @@
+import { Platform } from 'react-native';
+
+export function getScaledFontSize( fontSize, fontScale ) {
+	if ( Platform.OS == 'ios' ) {
+		return fontSize ? fontSize : undefined; // to not to affect to iOS
+	}
+	const baseFontSize = 18;
+	return ( fontSize ? fontSize : baseFontSize ) * fontScale;
+}


### PR DESCRIPTION
## Issue

- Fixes android part of https://github.com/wordpress-mobile/gutenberg-mobile/issues/605

## Overview

This PR fixes GM editor to apply system level font scale change immediately.

Honestly this change is a bit tricky as React Native has a [mechanism](https://facebook.github.io/react-native/docs/text#allowfontscaling) that allows `<Text>` component to scale font size according to system setting. **But the point is we're using GM component on top of fragment of which [retain flag is true](https://github.com/wordpress-mobile/WordPress-Android/blob/ff8a0692400f02286331f09a4f3705f8b2c54014/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java#L193)**, we can't rely on RN font scaling system.

After several investigations, I've noticed we can detect fontScale change on RN side by observing `Dimensions` change and added a function to calculate new font size to deal with the issue.

### Note

This PR doesn't affect to iOS side since the situation I explained above is a different on each platform.

### Links

- https://facebook.github.io/react-native/docs/text#allowfontscaling
- https://facebook.github.io/react-native/docs/dimensions

### Screenshots

| Before | After |
| ----------- | ----------- |
|<img src="https://user-images.githubusercontent.com/471318/55295497-b4d8db00-5448-11e9-8862-64c053f38022.gif" width="250" />|<img src="https://user-images.githubusercontent.com/471318/55295510-cde18c00-5448-11e9-8f69-59f9bb59c5a2.gif" width="250" />|

### Test

- Run example app on Android
- Turn on `Use Block Editor` from app setting
- Open editor screen and type something
- Go to OS setting(Accessibility→Font Size) and change font size
- Back to editor screen and confirm content font size has been changed