### PR TITLE
Upgrade react-native to version 0.59.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "node-libs-react-native": "^1.0.2",
     "node-sass": "^4.8.3",
     "react": "16.8.3",
-    "react-native": "0.59.0",
+    "react-native": "0.59.3",
     "react-native-hr": "git+https://github.com/Riglerr/react-native-hr.git#2d01a5cf77212d100e8b99e0310cce5234f977b3",
     "react-native-keyboard-aware-scroll-view": "git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#gb-v0.8.7",
     "react-native-modal": "^6.5.0",

--- a/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
+++ b/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "React",
-  "version": "0.59.0",
+  "version": "0.59.3",
   "summary": "A framework for building native apps using React",
   "description": "React Native apps are built using the React JS\nframework, and render directly to native UIKit\nelements using a fully asynchronous architecture.\nThere is no browser and no HTML. We have picked what\nwe think is the best set of features from these and\nother technologies to build what we hope to become\nthe best product development framework available,\nwith an emphasis on iteration speed, developer\ndelight, continuity of technology, and absolutely\nbeautiful and fast products with no compromises in\nquality or capability.",
   "homepage": "http://facebook.github.io/react-native/",
@@ -8,7 +8,7 @@
   "authors": "Facebook",
   "source": {
     "git": "https://github.com/facebook/react-native.git",
-    "tag": "v0.59.0"
+    "tag": "v0.59.3"
   },
   "default_subspecs": "Core",
   "requires_arc": true,
@@ -30,7 +30,7 @@
       "name": "Core",
       "dependencies": {
         "yoga": [
-          "0.59.0.React"
+          "0.59.3.React"
         ]
       },
       "source_files": "React/**/*.{c,h,m,mm,S,cpp}",

--- a/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
+++ b/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "yoga",
-  "version": "0.59.0.React",
+  "version": "0.59.3.React",
   "license": {
     "type": "MIT"
   },
@@ -11,7 +11,7 @@
   "authors": "Facebook",
   "source": {
     "git": "https://github.com/facebook/react-native.git",
-    "tag": "v0.59.0"
+    "tag": "v0.59.3"
   },
   "module_name": "yoga",
   "requires_arc": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7829,10 +7829,10 @@ react-native-sass-transformer@^1.1.1:
   version "9.3.3"
   resolved "git+https://github.com/wordpress-mobile/react-native-svg.git#55244dc79ab876550599c82dca763c3eba0153c5"
 
-react-native@0.59.0:
-  version "0.59.0"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.59.0.tgz#7d0ad297da3fd2e18f387f0ef5581270aaabac42"
-  integrity sha512-7DTOCFfmo9e2P0gXAaCH8DDUqW154Y6UFyKE74X08k1QW9FU5O9dQ+GQ7ryJYS0sxMLNQGDhMSADhnn72QQT4g==
+react-native@0.59.3:
+  version "0.59.3"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.59.3.tgz#b984bbe457f63d5515046d32ea5721fd22843548"
+  integrity sha512-dv3AA2rH0L0IccxRkIs4YsriaECy9ttTXrwrgwETXqmE45uVrBFRGePUFnqjcikYkkm6sS0FRxcva088un76JA==
   dependencies:
     "@babel/runtime" "^7.0.0"
     "@react-native-community/cli" "^1.2.1"


### PR DESCRIPTION
This PR upgrades react native to the latest version: `0.59.3`.
This last `react-native` patch fixes an issue with running our app in iOS simulator with Xcode 10.2

See this issue https://github.com/facebook/react-native/issues/24139

### Testing Instructions
- [ ] Run the demo app with XCode and make sure there is no regression
- [ ] Run gutenberg-mobile inside WPiOS
- [x] Run the demo app on Android and make sure there is no regression
- [x] Run gutenberg-mobile inside WPAndroid and check for regression

Note: sourcemap is still broken on Android