### PR TITLE
Mitigate the problem of moving the current block down sets the caret to the wrong block 

### DIFF
--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -13,6 +13,7 @@ import {
 	TouchableWithoutFeedback,
 	NativeSyntheticEvent,
 	NativeTouchEvent,
+	Keyboard,
 } from 'react-native';
 import TextInputState from 'react-native/lib/TextInputState';
 import {
@@ -96,6 +97,7 @@ export class BlockHolder extends React.Component<PropsType, StateType> {
 	}
 
 	onInlineToolbarButtonPressed = ( button: number ) => {
+		Keyboard.dismiss();
 		switch ( button ) {
 			case InlineToolbarActions.UP:
 				this.props.moveBlockUp();


### PR DESCRIPTION
This PR does help on mitigating the problem reported in #311, where under some circumstances the caret is moved to another block when the current `TextInput` powered block in moved down by the user. The problem was originally reported for Android, but it seems could happen on iOS too, even though with less frequency. 

In this PR we're just hiding the Keyboard on block Up/Down/Delete operations.

**A GIF of the original problem**

![focus-wrong](https://user-images.githubusercontent.com/518232/49815723-b5037c80-fd6c-11e8-9524-4bd5796b6226.gif)


During my tentative to fix the problem I've also found other scenarios where the same issue comes up on writing. 
IE:
- Tap on a para block (that's not the first one on the list)
- Tap on the Page break block
- Boom 🤯 the caret is moved to the first TextInput block in the list
For more details see the comment and video linked here https://github.com/wordpress-mobile/gutenberg-mobile/issues/311#issuecomment-478140593


**To test**
- Start the demo app
- Select a RichText block that is not the first in thelist, IE. `Hello World` block
- Tap the down arrow on the toolbar
- The block is correctly moved down and the keyboard dismissed




