### PR TITLE
[Android] Add Glue code to honor OS font size scale in wp-android editor

### DIFF
--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -545,5 +545,13 @@ public class WPAndroidGlueCode {
     private boolean isMediaUploadCallbackRegistered() {
         return mPendingMediaUploadCallback != null;
     }
+
+    /**
+     * Recreate the react application and context.
+     * See: https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java#L350
+     */
+    public void recreateReactContextInBackground() {
+        mReactInstanceManager.recreateReactContextInBackground();
+    }
 }
 


### PR DESCRIPTION
This PR just adds a small method to the Glue code that is going to be used to "re-draw" the GB mobile editor when the user changes font size in system settings.

To test this PR, and a full description of the problem(s), see the following `wp-android` PR - https://github.com/wordpress-mobile/WordPress-Android/pull/9509


