### PR TITLE
Added manifest merge to enable use of React Native's DevSettings screen

### DIFF
--- a/react-native-gutenberg-bridge/android/src/debug/AndroidManifest.xml
+++ b/react-native-gutenberg-bridge/android/src/debug/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools"
+          package="org.wordpress.mobile.ReactNativeGutenbergBridge">
+
+    <application>
+
+        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+    </application>
+
+</manifest>


### PR DESCRIPTION
This PR supersedes https://github.com/wordpress-mobile/WordPress-Android/pull/9510 as per @hypest suggestion to have any RN-related code contained in the bridge 👍 🙇 

This PR adds React Native's `DevSettingsActivity` to the `debug` manifest for accessing debugging settings while debugging WPAndroid+Gutenberg integration

To test (using WPAndroid):
1. build `ZalphaDebug` or for the case, any debug flavor
2. make sure to have Gutenberg enabled in App Settings (use Block Editor for new posts)
3. start a new draft to launch GB
4. tap on the overflow menu icon, then Debug Menu
5. in the RN's debug menu, select `Dev Settings`.
6. observe the app doesn't crash

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
