### PR TITLE
Remove deprecated controls plugin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,6 @@ const gutenbergSetup = () => {
 	const userId = 1;
 	const storageKey = 'WP_DATA_USER_' + userId;
 	wpData.use( wpData.plugins.persistence, { storageKey } );
-	wpData.use( wpData.plugins.controls );
 };
 
 const editorSetup = () => {


### PR DESCRIPTION
Fixes this warning:

![Simulator Screen Shot - iPhone Xs - 2019-04-03 at 20 11 44](https://user-images.githubusercontent.com/8739/55511558-2ab78f00-5661-11e9-9480-e161fbc2cb63.png)

According to the warning, "The controls plugins is now baked-in."

The change was done in https://github.com/WordPress/gutenberg/pull/14634 which was just brought in by merging Gutenberg `master` in #643.

To test:

- Open Gutenberg and verify there are no warnings displayed