### PR TITLE
CircleCI: Use API 28 for Android build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,20 +80,13 @@ jobs:
           command: bin/ci-checks-js.sh
   android-device-checks:
     docker:
-    - image: circleci/android:api-27-node8-alpha
+    - image: circleci/android:api-28-node8-alpha
     steps:
       - checkout
       - run:
           name: Checkout Gutenberg
           command: git submodule update --init --recursive
       - yarn-install
-      - run:
-          name: Accept Licenses
-          command: |
-            yes | sdkmanager --licenses > /dev/null
-            sleep 10
-            sdkmanager --update
-          background: true
       - run:
           name: Set Environment Variables
           command: |


### PR DESCRIPTION
Updating the CircleCI image to use API 28 seems to remove the need to accept licenses 😄 