### PR TITLE
Fixed typo in app path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,8 @@ jobs:
           cp ./ios/main.jsbundle ./ios/build/Gutenberg/Build/Products/Release-iphonesimulator/gutenberg.app/main.jsbundle
           cd ./ios/build/Gutenberg/Build/Products/Release-iphonesimulator/
           zip -r ./Gutenberg.app.zip ./gutenberg.app
-          mv ./Gutenberg.app.zip "$CIRCLE_WORKING_DIRECTORYGutenberg.app.zip"
+          ls -l ./Gutenberg.app.zip
+          mv ./Gutenberg.app.zip "${CIRCLE_WORKING_DIRECTORY}/Gutenberg.app.zip"
     - run:
         name: Upload .app to sauce labs
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,11 +133,11 @@ jobs:
     - run:
         name: Zip up .app file
         command: |
+          PWD=$(pwd)
           cp ./ios/main.jsbundle ./ios/build/Gutenberg/Build/Products/Release-iphonesimulator/gutenberg.app/main.jsbundle
           cd ./ios/build/Gutenberg/Build/Products/Release-iphonesimulator/
           zip -r ./Gutenberg.app.zip ./gutenberg.app
-          ls -l ./Gutenberg.app.zip
-          mv ./Gutenberg.app.zip "${CIRCLE_WORKING_DIRECTORY}/Gutenberg.app.zip"
+          mv ./Gutenberg.app.zip "${PWD}/Gutenberg.app.zip"
     - run:
         name: Upload .app to sauce labs
         command: |


### PR DESCRIPTION
There was a typo in the app path in CircleCI. It was missing a `/`. 