### PR TITLE
Use react-native-cli with the Android debugging fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,5 +146,8 @@
     "tinycolor2": "^1.4.1",
     "turbo-combine-reducers": "^1.0.2",
     "underscore": "^1.9.1"
+  },
+  "resolutions": {
+    "@react-native-community/cli": "^1.5.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,10 +1028,10 @@
     "@types/istanbul-lib-coverage" "^1.1.0"
     "@types/yargs" "^12.0.9"
 
-"@react-native-community/cli@^1.2.1":
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-1.4.5.tgz#6cf35d73e14f65e13e77fbb572f2d5b9d2cbadb5"
-  integrity sha512-WH5E7rEUpftXJ4aAS/U/3euMx1S7FI0+CwT2VN3sFDtErtCVgqmyBXnBNp9Zk3XK5ANbf49cVR25rkOBjf5TVw==
+"@react-native-community/cli@^1.2.1", "@react-native-community/cli@^1.5.2":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-1.6.0.tgz#889fbb1eff961945df28bb7e896dcee8516b010f"
+  integrity sha512-OV3N5O/wzjb8OTZDiFerX0gf9/KzLJOvDttU38BqIvn8+OLkH6SIgGrKked9vrKKvH5bFG6jmCmKCW5gP+tOwQ==
   dependencies:
     chalk "^1.1.1"
     commander "^2.19.0"


### PR DESCRIPTION
The [recent upgrade to React Native 0.59](https://github.com/wordpress-mobile/gutenberg-mobile/pull/741) had a regression that made us lose the ability to properly debug the JS source code under Android.

This PR introduces a workaround by using the fixes version of the `react-native-cli` package, before it becomes available directly via a future React Native release.

Relevant tickets: https://github.com/facebook/react-native/issues/23955, https://github.com/facebook/metro/issues/380

To test:

0. Add a `debugger;` statement somewhere in the JS code. Good examples can be the `block-holder.js` module and the `render()` function in `gutenberg/.../components/rich-text/index.native.js`.
1. Run the demo app on Android
2. Enable the Remote JS debugging mode via the debug menu, and notice Chrome opening up to debug
3. Notice the debugger stopping at the `debugger` statements and properly showing the source file