### PR TITLE
log jobURL at end of successful job

### DIFF
--- a/__device-tests__/helpers/utils.js
+++ b/__device-tests__/helpers/utils.js
@@ -8,6 +8,7 @@
  */
 import childProcess from 'child_process';
 import wd from 'wd';
+import crypto from 'crypto';
 
 /**
  * Internal dependencies
@@ -108,6 +109,18 @@ const setupDriver = async () => {
 };
 
 const stopDriver = async ( driver: wd.PromiseChainWebdriver ) => {
+	if ( ! isLocalEnvironment() ) {
+		const jobID = driver.sessionID;
+		const username = process.env.SAUCE_USERNAME;
+		const accessKey = process.env.SAUCE_ACCESS_KEY;
+
+		const hash = crypto.createHmac( 'md5', jobID )
+			.update( `${ username }:${ accessKey }` )
+			.digest( 'hex' );
+		const jobURL = `https://saucelabs.com/jobs/${ jobID }?auth=${ hash }.`;
+		// eslint-disable-next-line no-console
+		console.log( `You can view the video of this test run at ${ jobURL }` );
+	}
 	if ( driver === undefined ) {
 		return;
 	}

--- a/__device-tests__/helpers/utils.js
+++ b/__device-tests__/helpers/utils.js
@@ -111,11 +111,9 @@ const setupDriver = async () => {
 const stopDriver = async ( driver: wd.PromiseChainWebdriver ) => {
 	if ( ! isLocalEnvironment() ) {
 		const jobID = driver.sessionID;
-		const username = process.env.SAUCE_USERNAME;
-		const accessKey = process.env.SAUCE_ACCESS_KEY;
 
 		const hash = crypto.createHmac( 'md5', jobID )
-			.update( `${ username }:${ accessKey }` )
+			.update( serverConfigs.sauce.auth )
 			.digest( 'hex' );
 		const jobURL = `https://saucelabs.com/jobs/${ jobID }?auth=${ hash }.`;
 		// eslint-disable-next-line no-console


### PR DESCRIPTION
This PR updates the tests to provide a URL to access the video recording at the end of test execution in CI(or locally if running on SauceLabs). SauceLabs docs for building the URL can be found [here](https://wiki.saucelabs.com/display/DOCS/Building+Links+to+Test+Results) In CI at the end of the test run, the following should be printed 

`You can view the video of this test run at ${ jobURL }`