### PR TITLE
Xcode 10.2 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
           command: yarn device-tests
   ios-device-checks:
     macos:
-      xcode: "10.0"
+      xcode: "10.2.0"
     steps:
     - checkout
     - checkout-gutenberg

--- a/react-native-aztec/ios/Cartfile
+++ b/react-native-aztec/ios/Cartfile
@@ -1,2 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" ~> 1.5.2
-
+github "wordpress-mobile/AztecEditor-iOS" ~> 1.6.0-beta.1

--- a/react-native-aztec/ios/Cartfile.resolved
+++ b/react-native-aztec/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.5.2"
+github "wordpress-mobile/AztecEditor-iOS" "1.6.0-beta.1"


### PR DESCRIPTION
This breaks compatibility with Xcode versions < 10.2 so merging should be done carefully. The only change is an update to Aztec-iOS (see https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1172).