### PR TITLE
FIX empty block creation on device running AOSP keyboard

### DIFF
--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -64,6 +64,7 @@ public class ReactAztecText extends AztecText {
     // This is required to keep placeholder text working, and start typing with styled text.
     // Ref: https://github.com/wordpress-mobile/gutenberg-mobile/issues/707
     private String mTagName = "";
+    private String mEmptyTagHTML = "";
 
     private static final HashMap<ITextFormat, String> typingFormatsMap = new HashMap<ITextFormat, String>() {
         {
@@ -101,8 +102,7 @@ public class ReactAztecText extends AztecText {
                         return onBackspace();
                     }
                     else {
-                        String emptyTag = "<" + getTagName() + "></" + getTagName() + ">";
-                        if (!content.equals(emptyTag)) {
+                        if (!content.equals(mEmptyTagHTML)) {
                             return onBackspace();
                         }
                     }
@@ -239,6 +239,7 @@ public class ReactAztecText extends AztecText {
 
     public void setTagName(@Nullable String tagName) {
         mTagName = tagName;
+        mEmptyTagHTML = "<" + mTagName + "></" + mTagName + ">";
     }
 
     public String getTagName() {

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -88,14 +88,14 @@ public class ReactAztecText extends AztecText {
         this.setAztecKeyListener(new ReactAztecText.OnAztecKeyListener() {
             @Override
             public boolean onEnterKey() {
-                if (shouldHandleOnEnter) {
+                if (shouldHandleOnEnter && !isTextChangedListenerDisabled()) {
                     return onEnter();
                 }
                 return false;
             }
             @Override
             public boolean onBackspaceKey() {
-                if (shouldHandleOnBackspace) {
+                if (shouldHandleOnBackspace && !isTextChangedListenerDisabled()) {
                     String content = toHtml(false);
                     if (TextUtils.isEmpty(content)) {
                         return onBackspace();


### PR DESCRIPTION
This PR fixes #856 by making sure to check if text listeners are enabled before doing any text/block manipulating action `onEnter` or `onBackSpace`. 

In this particular case the BackSpace.Key detection code in Aztec is called when the initial empty HTML content is set to the block via `setTextFromJS`. Text listeners are disabled in this case, and those are not running, but InputFilters are not disabled.... By the way, I guess a better fix would involve changes to Aztec, but probably is easier to fix them here, since this change could also fix other potential problems in the future.


Steps to repro:

- Start the demo app on STOCK emulator (Check AOSP keyboard)
- Insert a new empty para block
- Make sure it stays on the screen