### PR TITLE
Use the Aztec-Android version with the #845 fix

### DIFF
--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = 'v1.3.24'
+        aztecVersion = '3a6ab4ffde163ec2f2ebd3732a20013ebd8723a4'
     }
 
     repositories {

--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = '3a6ab4ffde163ec2f2ebd3732a20013ebd8723a4'
+        aztecVersion = '1400adb886ca9372211f06b62dd24fbbbd252f42'
     }
 
     repositories {


### PR DESCRIPTION
Fixes #845 

This PR updates to a fixed Aztec Android version. No changes on the gutenberg-mobile side.

Aztec-Android PR: https://github.com/wordpress-mobile/AztecEditor-Android/pull/807
WPAndroid PR: https://github.com/wordpress-mobile/WordPress-Android/pull/9614

To test:

1. In the demo app, do a long list, long enough to have a few empty list items here and there
2. Try to add a new item at the end of the list
3. The new list item should be normally created at the end and the caret should be placed on it