### PR TITLE
Fix caret position after multi line paste

### DIFF
--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -88,6 +88,12 @@ export class BlockHolder extends React.Component<PropsType, StateType> {
 		this.props.onSelect( this.props.clientId );
 	};
 
+	selectBlock = ( block ) => {
+		if ( this.props.onSelect && block && block.clientId ) {
+			this.props.onSelect( block.clientId );
+		}
+	}
+
 	onRemoveBlockCheckUpload = ( mediaId: number ) => {
 		if ( hasAction( 'blocks.onRemoveBlockCheckUpload' ) ) {
 			// now remove the action as it's  a one-shot use and won't be needed anymore
@@ -181,6 +187,7 @@ export class BlockHolder extends React.Component<PropsType, StateType> {
 				setAttributes={ this.props.onChange }
 				onFocus={ this.onFocus }
 				onReplace={ this.props.onReplace }
+				selectBlock={ this.selectBlock }
 				insertBlocksAfter={ this.insertBlocksAfter }
 				mergeBlocks={ this.mergeBlocks }
 				onCaretVerticalPositionChange={ this.props.onCaretVerticalPositionChange }


### PR DESCRIPTION
## Description
This PR is a draft with the intent to open a discussion about how best to handle pasting multi-line content. The code changes are early steps to addressing this issue: https://github.com/wordpress-mobile/gutenberg-mobile/issues/828. This comment in particular contains details about the multi-line case: https://github.com/wordpress-mobile/gutenberg-mobile/issues/828#issuecomment-481127008.

Related gutenberg PR: https://github.com/WordPress/gutenberg/pull/14974

### Note
This PR should not be merged, as the changes in https://github.com/wordpress-mobile/gutenberg-mobile/pull/789 and https://github.com/WordPress/gutenberg/pull/14662 will conflict.

Currently, when multi-line content is pasted into a paragraph block, the content is split into multiple blocks, splitting the current block if necessary (if the caret position is somewhere in the middle of the original block's text). After the paste event ends, the first pasted block is focused, with the caret at the start of that block's text.

These changes expose a `selectBlock` method from the `BlockHolder` object, and make it available to the RichText component. This is sufficient for the RichText component receiving the paste event to select the last pasted block after inserting multiple blocks. However, this is not sufficient to ensure the caret is in the correct position on selected block.

In order to ensure the caret is in the correct position after paste, it may be possible to expose a method to the RichText component to manipulate the selection in a sibling block, or alternatively, pass selection information to a block at creation. Neither of these approaches feel particularly elegant. In both of these cases, I suspect a race condition will exist, as the underlying native instantiation of sibling blocks will only occur asynchronously, after the paste method has terminated. This could _theoretically_ be resolved via a callback, but I'd like to explore some ideas to see if a better approach can be found.

One concern with implementing the required behavior is that `onSplit` is used by both `onPaste` and `onEnter`. When `onEnter` is called, it creates a new "sibling" block containing the text following the caret. In this case, the expected caret position after the event is at the start of the new block. This is currently satisfied by setting the selection to 0 in native code when the view is instantiated (e.g. in Android, this occurs via the method `forceCaretAtStartOnTakeFocus`).

With the refactor and "porting" of `BlockHolder` and `BlockManager` to Gutenberg as `BlockListBlock` and `BlockList` respectively, I wonder if a solution can be implemented that could resolve this issue across mobile and web platforms.

## How has this been tested?
This has been tested using the steps here:
https://github.com/wordpress-mobile/gutenberg-mobile/issues/828#issuecomment-481546078

## Screenshots <!-- if applicable -->
<img src="https://user-images.githubusercontent.com/8507675/56077419-5b48b700-5e1f-11e9-965e-c35fac84e907.gif" width="360">

## Types of changes
This is a _partial_ bug fix, but currently only resolves a _part_ of the original issue. It serves as an incremental improvement. This is not intended to be merged.