### PR TITLE
Release/1.2.1 - Take two

### DIFF
--- a/android/app/src/main/java/com/gutenberg/MainApplication.java
+++ b/android/app/src/main/java/com/gutenberg/MainApplication.java
@@ -49,6 +49,9 @@ public class MainApplication extends Application implements ReactApplication {
                 public void requestMediaPickerFromDeviceCamera(MediaUploadCallback mediaUploadCallback) {}
 
                 @Override
+                public void requestMediaImport(String url, MediaSelectedCallback mediaSelectedCallback) {}
+
+                @Override
                 public void mediaUploadSync(MediaUploadCallback mediaUploadCallback) {}
 
                 @Override

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
@@ -46,6 +46,8 @@ public interface GutenbergBridgeJS2Parent {
 
     void requestMediaPickerFromDeviceCamera(MediaUploadCallback mediaUploadCallback);
 
+    void requestMediaImport(String url, MediaSelectedCallback mediaSelectedCallback);
+
     void mediaUploadSync(MediaUploadCallback mediaUploadCallback);
 
     void requestImageFailedRetryDialog(int mediaId);

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -109,6 +109,11 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
     }
 
     @ReactMethod
+    public void requestMediaImport(String url, final Callback onUploadMediaSelected) {
+        mGutenbergBridgeJS2Parent.requestMediaImport(url, getNewMediaSelectedCallback(onUploadMediaSelected));
+    }
+
+    @ReactMethod
     public void mediaUploadSync() {
         mGutenbergBridgeJS2Parent.mediaUploadSync(getNewUploadMediaCallback(null));
     }

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -152,7 +152,7 @@ public class WPAndroidGlueCode {
 
             @Override
             public void requestMediaImport(String url, MediaSelectedCallback mediaSelectedCallback) {
-                // no op - we still don't have a way to paste images, but the method needs to exist
+                // no op - we don't need to paste images on Android, but the method needs to exist
                 // to match the iOS counterpart
             }
 

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -151,6 +151,12 @@ public class WPAndroidGlueCode {
             }
 
             @Override
+            public void requestMediaImport(String url, MediaSelectedCallback mediaSelectedCallback) {
+                // no op - we still don't have a way to paste images, but the method needs to exist
+                // to match the iOS counterpart
+            }
+
+            @Override
             public void mediaUploadSync(MediaUploadCallback mediaUploadCallback) {
                 mPendingMediaUploadCallback = mediaUploadCallback;
                 mOnReattachQueryListener.onQueryCurrentProgressForUploadingMedia();


### PR DESCRIPTION
https://github.com/wordpress-mobile/gutenberg-mobile/pull/876 has been merged but @mzorz spotted an issue that we want to include a fix for.

The only change here is cherry-picking the fix for https://github.com/wordpress-mobile/gutenberg-mobile/pull/864 onto the release branch.

JS bundles are not updated since there is no JS change.