### PR TITLE
Store caret position in history and use this info on Undo/Redo

### DIFF
--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -193,7 +193,9 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
         if ( selection != null ) {
             int start = selection.getInt("start");
             int end = selection.getInt("end");
-            view.setSelection(start, end);
+            if (view.length() >= end && start >= 0) {
+                view.setSelection(start, end);
+            }
         }
     }
 


### PR DESCRIPTION
Opened this PR to discuss a couple of problems I found with RichText text based blocks and history.

Trying to fix #303 - _Cursor positioning on Rich Text-based blocks after undoing is pos+1_  - found out it is a problem with the caret position not kept retained in history. 
**We're only storing the content in history, then when the user taps on the undo/redo buttons the text is changed but the caret stays in the same position of before if possible**.  (it's often moved to the end of the block in case undo removes some text and `caret-position > newText.length`).

I then started working on adding the position of the caret, together with the content, in the history stack, and made it "kind of working", even if it feels a bit of an hack - for ref the GB side branch is available [here](https://github.com/WordPress/gutenberg/compare/rnmobile/303-undo-redo-caret-position-lost?expand=1).

While trying to fix #303 I've encountered lot of problems with the history, and decided to switch back to `develop` to check if I can replicate them there, since was having hard time on figuring out if it was my code the culprit of the bad behavior. 
Below is a list of problems I see with history on `develop`:

- History in not empty on a clean start of the editor!?  As soon as you tap in a block the `Back` button will be available, and if you tap on it "an action" is actually executed, the "redo" button slightly visible for a fraction of second, and the the "undo" is available again. See the GIF I attached below

- If you add a new empty block it's hard to get rid of hit by tapping on `Undo`. For the same reason of above, it seems two actions are executed in a sequence in a very small time.
If you want to get rid of the block you need to tap "undo" many times, very fast.

Investigated a bit, and it seems to me that the problem is due to the `onSelectionChange` called at init and every time the user adds new text -  `onSelectionChange` is called right after the `onChange` callback. So basically we're updating the JS side lot of times 🤔 
Not quite sure why we're calling `this.props.onChange( this.lastContent );` when the selection does change. cc @marecar3 

![history mess up](https://user-images.githubusercontent.com/518232/56295018-60ae4600-612c-11e9-9511-81afcfa8d292.gif)


I think it's better to fix the problems with the history before starting storing caret position in it. Otherwise we're messing things up a little more. 
Thoughts? 