### PR TITLE
[iOS] Deactivate Tab and Shift+Tab key shortcuts

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "wpandroid": "yarn android --root $TMPDIR/gbmobile-wpandroidfakernroot --variant wasabiDebug --appIdSuffix beta --appFolder WordPress --main-activity=ui.WPLaunchActivity",
     "preios": "yarn preios:xcode10 && yarn preios:carthage",
     "preios:carthage": "cd react-native-aztec && yarn install-aztec-ios",
+    "preios:carthage:update": "cd react-native-aztec && yarn update-aztec-ios",
     "preios:xcode10": "cd node_modules/react-native && ./scripts/ios-install-third-party.sh && cd third-party/glog-0.3.5 && [ -f libglog.pc ] || ../../scripts/ios-configure-glog.sh",
     "ios": "react-native run-ios",
     "test": "cross-env NODE_ENV=test jest --verbose --config jest.config.js",

--- a/react-native-aztec/ios/Cartfile
+++ b/react-native-aztec/ios/Cartfile
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" ~> 1.6.0-beta.1
+github "wordpress-mobile/AztecEditor-iOS" "26164fb0f24027ecacc7105201e6e8a4332c7906"

--- a/react-native-aztec/ios/Cartfile.resolved
+++ b/react-native-aztec/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.6.0-beta.1"
+github "wordpress-mobile/AztecEditor-iOS" "26164fb0f24027ecacc7105201e6e8a4332c7906"

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -265,6 +265,10 @@ class RCTAztecView: Aztec.TextView {
     // MARK: - Custom Edit Intercepts
     
     private func interceptEnter(_ text: String) -> Bool {
+        if text == "\t" {
+            return true
+        }
+
         guard text == "\n",
             let onEnter = onEnter else {
                 return false
@@ -285,7 +289,12 @@ class RCTAztecView: Aztec.TextView {
         onBackspace(caretData)
         return true
     }
-    
+
+    override var keyCommands: [UIKeyCommand]? {
+        // Remove defautls Tab and Shift+Tab commands, leaving just Shift+Enter command.
+        return [carriageReturnKeyCommand]
+    }
+
     // MARK: - Native-to-RN Value Packing Logic
     
     func packForRN(_ text: String, withName name: String) -> [AnyHashable: Any] {


### PR DESCRIPTION
Fixes a part of https://github.com/wordpress-mobile/gutenberg-mobile/issues/888

Related Aztec PR: https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1175

This PR removes the Tab and Shift+Tab key shortcuts.
On a second iteration of the ListBlock, we will want to reactivate them using gutenberg internal mechanism.

I also removed the `Tab` key functionality completely. It was adding tab characters to the content of blocks, and also breaking the ListBlock. This is different to how it works on Android and Web, so I don't see any harm on deactivating it until we handle it properly (cc @hypest )

IMHO, the functionality we want for the Tab key in this case is to move the focus to the next block, in the same way it works on web.

To test Tabs:
- Run the iOS example project on the simulator.
- Focus a RichText powered block.
- Press the Tab key (be sure to have the hardware keyboard connected to the simulator)
- Check that nothing happens.

To test Shift+Tabs:
- Replace the HTML content with this one: 
```html
<!-- wp:list -->
<ul><li>Hello<ul><li>world</li></ul></li></ul>
<!-- /wp:list -->
```

- Set the cursor in the indented list item.
- Press Shift+Tab in the hardware keyboard.
- Check that it doesn't modify the ListBlock.