### PR TITLE
Remove duplicated imagepipeline-okhttp3 dependency

### DIFF
--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -121,7 +121,6 @@ dependencies {
         implementation project(':react-native-recyclerview-list')
 
         implementation 'com.facebook.react:react-native:+'
-
     } else {
         implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-svg', readHashedVersion('../../package.json', 'react-native-svg', 'dependencies')))
         implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-recyclerview-list', 'f845b3c2c4411b8e97db23724bf1a535530c5435'))

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -121,7 +121,7 @@ dependencies {
         implementation project(':react-native-recyclerview-list')
 
         implementation 'com.facebook.react:react-native:+'
-        implementation "com.facebook.fresco:imagepipeline-okhttp3:1.10.0"
+
     } else {
         implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-svg', readHashedVersion('../../package.json', 'react-native-svg', 'dependencies')))
         implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-recyclerview-list', 'f845b3c2c4411b8e97db23724bf1a535530c5435'))


### PR DESCRIPTION
Fixes : https://github.com/wordpress-mobile/gutenberg-mobile/issues/904

At the time when I was working on this PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/788/files, for some reason, I trusted Android Studio IDE when it was complaining about missing classes from imagepipeline-okhttp3 dependency, so I have included dependency.

After some time I have found out that I was wrong and that I mistakenly put dependency which was already part of RN core: https://github.com/facebook/react-native/blob/758eb9fa7bba1d1a14fd8c8870e2a00ad3a31809/ReactAndroid/build.gradle#L316

Test : 

Compile RN `react-native-gutenberg-bridge` with command : `./gradlew clean assembleDebug`

 