### PR TITLE
Improve Screen Reader support for Inner Toolbar

### DIFF
--- a/src/block-management/inline-toolbar/index.js
+++ b/src/block-management/inline-toolbar/index.js
@@ -56,17 +56,19 @@ export default class InlineToolbar extends React.Component<PropsType> {
 			<View style={ styles.toolbar } >
 				<ToolbarButton
 					accessibilityLabel={ __( 'Move up' ) }
-					label={ __( 'Move up' ) }
+					title={ __( 'Move up' ) }
 					isDisabled={ ! this.props.canMoveUp }
 					onClick={ this.onUpPressed }
 					icon="arrow-up-alt"
+					extraProps={ { hint: __( 'Double tap to move up the block' ) } }
 				/>
 
 				<ToolbarButton
-					label={ __( 'Move down' ) }
+					title={ __( 'Move down' ) }
 					isDisabled={ ! this.props.canMoveDown }
 					onClick={ this.onDownPressed }
 					icon="arrow-down-alt"
+					extraProps={ { hint: __( 'Double tap to move down the block' ) } }
 				/>
 
 				<View style={ styles.spacer } />
@@ -74,9 +76,10 @@ export default class InlineToolbar extends React.Component<PropsType> {
 				<InspectorControls.Slot />
 
 				<ToolbarButton
-					label={ __( 'Remove' ) }
+					title={ __( 'Remove' ) }
 					onClick={ this.onDeletePressed }
 					icon="trash"
+					extraProps={ { hint: __( 'Double tap to remove the block' ) } }
 				/>
 			</View>
 		);

--- a/src/block-management/inline-toolbar/index.js
+++ b/src/block-management/inline-toolbar/index.js
@@ -60,7 +60,7 @@ export default class InlineToolbar extends React.Component<PropsType> {
 					isDisabled={ ! this.props.canMoveUp }
 					onClick={ this.onUpPressed }
 					icon="arrow-up-alt"
-					extraProps={ { hint: __( 'Double tap to move up the block' ) } }
+					extraProps={ { hint: __( 'Double tap to move the block up' ) } }
 				/>
 
 				<ToolbarButton
@@ -68,7 +68,7 @@ export default class InlineToolbar extends React.Component<PropsType> {
 					isDisabled={ ! this.props.canMoveDown }
 					onClick={ this.onDownPressed }
 					icon="arrow-down-alt"
-					extraProps={ { hint: __( 'Double tap to move down the block' ) } }
+					extraProps={ { hint: __( 'Double tap to move the block down' ) } }
 				/>
 
 				<View style={ styles.spacer } />


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/911

**To test (iOS):**

Activate VoiceOver: https://github.com/wordpress-mobile/WordPress-iOS/wiki/Using-VoiceOver

**To test (Android):**

Activate TalkBack: https://www.wikihow.com/Enable-TalkBack-on-Your-Android
In my case, the system had a handy tutorial on how to use it.
If your version doesn't have it, it's actually very similar to VoiceOver.

**Test Steps**

- [ ] Check in both platforms that you hear titles and hints for Move up, Move down, Trash buttons
- [ ] Check in both platforms that you hear disabled(a.k.a. dimmed in iOS) status on Move up, Move down buttons
