### PR TITLE
Fix List block handling on Android

### DIFF
--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = 'list-block-fix-try5'
+        aztecVersion = '0a4a1b269fcb28972eabab81eae606df9469a228'
     }
 
     repositories {

--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = 'list-block-fix-try4'
+        aztecVersion = 'list-block-fix-try5'
     }
 
     repositories {

--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = '26f992c524'
+        aztecVersion = 'list-block-fix-try1'
     }
 
     repositories {

--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = '26f992c524aed9810da3e24aad01316b6dc722b0'
+        aztecVersion = '26f992c524'
     }
 
     repositories {

--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         gradlePluginVersion = '3.3.1'
-        kotlinVersion = '1.2.31'
+        kotlinVersion = '1.3.11'
         supportLibVersion = '28.0.0'
         tagSoupVersion = '1.2.1'
         glideVersion = '3.7.0'
@@ -23,6 +23,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:$gradlePluginVersion"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }
 

--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = '96762031f4daf568cbea8cfb2834c20cfce1048b'
+        aztecVersion = '26f992c524aed9810da3e24aad01316b6dc722b0'
     }
 
     repositories {

--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = 'v1.3.25'
+        aztecVersion = '4343fa4bff70e65bf791b75ed92946a4fc380885'
     }
 
     repositories {

--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = 'list-block-fix-try2'
+        aztecVersion = 'list-block-fix-try3'
     }
 
     repositories {
@@ -27,6 +27,7 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
 apply plugin: 'com.github.dcendents.android-maven'
 
 // import the `readReactNativeVersion()` function
@@ -62,6 +63,7 @@ android {
         main {
             dirs.each { dir ->
                 java.srcDirs "src/${dir}/java"
+                java.srcDirs += "src/${dir}/kotlin"
                 res.srcDirs "src/${dir}/res"
             }
         }

--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = '4845fe80b6a04cb738228a5595d0eff346bf5ea7'
+        aztecVersion = '428a6aa4693eea59ecef8e7a2c675a12d1ae4180'
     }
 
     repositories {

--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = '428a6aa4693eea59ecef8e7a2c675a12d1ae4180'
+        aztecVersion = '96762031f4daf568cbea8cfb2834c20cfce1048b'
     }
 
     repositories {

--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = 'list-block-fix-try1'
+        aztecVersion = 'list-block-fix-try2'
     }
 
     repositories {

--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = 'list-block-fix-try3'
+        aztecVersion = 'list-block-fix-try4'
     }
 
     repositories {

--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = '4343fa4bff70e65bf791b75ed92946a4fc380885'
+        aztecVersion = '4845fe80b6a04cb738228a5595d0eff346bf5ea7'
     }
 
     repositories {

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecBackSpaceEvent.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecBackSpaceEvent.java
@@ -15,12 +15,15 @@ class ReactAztecBackspaceEvent extends Event<ReactAztecBackspaceEvent> {
   private String mText;
   private int mSelectionStart;
   private int mSelectionEnd;
+  private boolean mFiredAfterTextChanged;
 
-  public ReactAztecBackspaceEvent(int viewId, String text, int selectionStart, int selectionEnd) {
+  public ReactAztecBackspaceEvent(int viewId, String text, int selectionStart, int selectionEnd,
+          boolean firedAfterTextChanged) {
     super(viewId);
     mText = text;
     mSelectionStart = selectionStart;
     mSelectionEnd = selectionEnd;
+    mFiredAfterTextChanged = firedAfterTextChanged;
   }
 
   @Override
@@ -44,6 +47,7 @@ class ReactAztecBackspaceEvent extends Event<ReactAztecBackspaceEvent> {
     eventData.putString("text", mText);
     eventData.putInt("selectionStart", mSelectionStart);
     eventData.putInt("selectionEnd", mSelectionEnd);
+    eventData.putBoolean("firedAfterTextChanged", mFiredAfterTextChanged);
     return eventData;
   }
 }

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecBackSpaceEvent.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecBackSpaceEvent.java
@@ -15,15 +15,12 @@ class ReactAztecBackspaceEvent extends Event<ReactAztecBackspaceEvent> {
   private String mText;
   private int mSelectionStart;
   private int mSelectionEnd;
-  private boolean mFiredAfterTextChanged;
 
-  public ReactAztecBackspaceEvent(int viewId, String text, int selectionStart, int selectionEnd,
-          boolean firedAfterTextChanged) {
+  public ReactAztecBackspaceEvent(int viewId, String text, int selectionStart, int selectionEnd) {
     super(viewId);
     mText = text;
     mSelectionStart = selectionStart;
     mSelectionEnd = selectionEnd;
-    mFiredAfterTextChanged = firedAfterTextChanged;
   }
 
   @Override
@@ -47,7 +44,6 @@ class ReactAztecBackspaceEvent extends Event<ReactAztecBackspaceEvent> {
     eventData.putString("text", mText);
     eventData.putInt("selectionStart", mSelectionStart);
     eventData.putInt("selectionEnd", mSelectionEnd);
-    eventData.putBoolean("firedAfterTextChanged", mFiredAfterTextChanged);
     return eventData;
   }
 }

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecEnterEvent.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecEnterEvent.java
@@ -15,13 +15,16 @@ class ReactAztecEnterEvent extends Event<ReactAztecEnterEvent> {
   private String mText;
   private int mSelectionStart;
   private int mSelectionEnd;
+  private boolean mFiredAfterTextChanged;
   private int mEventCount;
 
-  public ReactAztecEnterEvent(int viewId, String text, int selectionStart, int selectionEnd, int eventCount) {
+  public ReactAztecEnterEvent(int viewId, String text, int selectionStart, int selectionEnd,
+          boolean firedAfterTextChanged, int eventCount) {
     super(viewId);
     mText = text;
     mSelectionStart = selectionStart;
     mSelectionEnd = selectionEnd;
+    mFiredAfterTextChanged = firedAfterTextChanged;
     mEventCount = eventCount;
   }
 
@@ -46,6 +49,7 @@ class ReactAztecEnterEvent extends Event<ReactAztecEnterEvent> {
     eventData.putString("text", mText);
     eventData.putInt("selectionStart", mSelectionStart);
     eventData.putInt("selectionEnd", mSelectionEnd);
+    eventData.putBoolean("firedAfterTextChanged", mFiredAfterTextChanged);
     eventData.putInt("eventCount", mEventCount);
     return eventData;
   }

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -42,7 +42,7 @@ import org.wordpress.aztec.plugins.shortcodes.VideoShortcodePlugin;
 import org.wordpress.aztec.plugins.wpcomments.HiddenGutenbergPlugin;
 import org.wordpress.aztec.plugins.wpcomments.WordPressCommentsPlugin;
 import org.wordpress.aztec.plugins.wpcomments.toolbar.MoreToolbarButton;
-import org.wordpress.aztec.watchers.EnterPressedWatcher;
+import org.wordpress.aztec.watchers.EnterPressedUnderway;
 
 import java.util.Map;
 import java.util.ArrayList;
@@ -501,7 +501,7 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
 
             // if the "Enter" handling is underway, don't sent text change events. The ReactAztecEnterEvent will have
             // the text (minus the Enter char itself).
-            if (mEditText.getText().getSpans(0, 0, EnterPressedWatcher.EnterPressedUnderway.class).length == 0) {
+            if (mEditText.getText().getSpans(0, 0, EnterPressedUnderway.class).length == 0) {
                 int currentEventCount = mEditText.incrementAndGetEventCounter();
                 // The event that contains the event counter and updates it must be sent first.
                 // TODO: t7936714 merge these events

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -42,7 +42,6 @@ import org.wordpress.aztec.plugins.shortcodes.VideoShortcodePlugin;
 import org.wordpress.aztec.plugins.wpcomments.HiddenGutenbergPlugin;
 import org.wordpress.aztec.plugins.wpcomments.WordPressCommentsPlugin;
 import org.wordpress.aztec.plugins.wpcomments.toolbar.MoreToolbarButton;
-import org.wordpress.aztec.watchers.EnterPressedUnderway;
 
 import java.util.Map;
 import java.util.ArrayList;
@@ -413,6 +412,11 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
     @ReactProp(name = "onPaste", defaultBoolean = false)
     public void setOnPasteHandling(final ReactAztecText view, boolean onPasteHandling) {
         view.shouldHandleOnPaste = onPasteHandling;
+    }
+
+    @ReactProp(name = "deleteEnter", defaultBoolean = false)
+    public void setShouldDeleteEnter(final ReactAztecText view, boolean shouldDeleteEnter) {
+        view.shouldDeleteEnter = shouldDeleteEnter;
     }
 
     @Override

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -501,7 +501,7 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
 
             // if the "Enter" handling is underway, don't sent text change events. The ReactAztecEnterEvent will have
             // the text (minus the Enter char itself).
-            if (mEditText.getText().getSpans(0, 0, EnterPressedUnderway.class).length == 0) {
+            if (!mEditText.isEnterPressedUnderway()) {
                 int currentEventCount = mEditText.incrementAndGetEventCounter();
                 // The event that contains the event counter and updates it must be sent first.
                 // TODO: t7936714 merge these events

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -7,6 +7,7 @@ import android.graphics.Rect;
 import android.support.annotation.Nullable;
 import android.text.Editable;
 import android.text.InputType;
+import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.view.inputmethod.InputMethodManager;
@@ -88,16 +89,16 @@ public class ReactAztecText extends AztecText {
 
         this.setAztecKeyListener(new ReactAztecText.OnAztecKeyListener() {
             @Override
-            public boolean onEnterKey(boolean firedAfterTextChanged, int selStart, int selEnd) {
+            public boolean onEnterKey(Spanned text, boolean firedAfterTextChanged, int selStart, int selEnd) {
                 if (shouldHandleOnEnter && !isTextChangedListenerDisabled()) {
-                    return onEnter(firedAfterTextChanged, selStart, selEnd);
+                    return onEnter(text, firedAfterTextChanged, selStart, selEnd);
                 }
                 return false;
             }
             @Override
             public boolean onBackspaceKey(boolean firedAfterTextChanged) {
                 if (shouldHandleOnBackspace && !isTextChangedListenerDisabled()) {
-                    String content = toHtml(false);
+                    String content = toHtml(getText(), false);
                     if (TextUtils.isEmpty(content)) {
                         return onBackspace(firedAfterTextChanged);
                     }
@@ -296,7 +297,7 @@ public class ReactAztecText extends AztecText {
         if (!shouldHandleOnSelectionChange) {
             return;
         }
-        String content = toHtml(false);
+        String content = toHtml(getText(), false);
         ReactContext reactContext = (ReactContext) getContext();
         EventDispatcher eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
         eventDispatcher.dispatchEvent(
@@ -355,9 +356,9 @@ public class ReactAztecText extends AztecText {
         this.mIsSettingTextFromJS = mIsSettingTextFromJS;
     }
 
-    private boolean onEnter(boolean firedAfterTextChanged, int selStart, int selEnd) {
+    private boolean onEnter(Spanned text, boolean firedAfterTextChanged, int selStart, int selEnd) {
         disableTextChangedListener();
-        String content = toHtml(false);
+        String content = toHtml(text, false);
         int cursorPositionStart = firedAfterTextChanged ? selStart : getSelectionStart();
         int cursorPositionEnd = firedAfterTextChanged ? selEnd : getSelectionEnd();
 //        if (firedAfterTextChanged) {
@@ -383,7 +384,7 @@ public class ReactAztecText extends AztecText {
         }
 
         disableTextChangedListener();
-        String content = toHtml(false);
+        String content = toHtml(getText(), false);
         enableTextChangedListener();
         ReactContext reactContext = (ReactContext) getContext();
         EventDispatcher eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
@@ -426,7 +427,7 @@ public class ReactAztecText extends AztecText {
 
         // temporarily disable listener during call to toHtml()
         disableTextChangedListener();
-        String content = toHtml(false);
+        String content = toHtml(getText(), false);
         int cursorPositionStart = getSelectionStart();
         int cursorPositionEnd = getSelectionEnd();
         enableTextChangedListener();

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -361,10 +361,6 @@ public class ReactAztecText extends AztecText {
         String content = toHtml(text, false);
         int cursorPositionStart = firedAfterTextChanged ? selStart : getSelectionStart();
         int cursorPositionEnd = firedAfterTextChanged ? selEnd : getSelectionEnd();
-//        if (firedAfterTextChanged) {
-//            cursorPositionStart--;
-//            cursorPositionEnd--;
-//        }
         enableTextChangedListener();
         ReactContext reactContext = (ReactContext) getContext();
         EventDispatcher eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -334,7 +334,12 @@ public class ReactAztecText extends AztecText {
             // Keep the enter pressed watcher at the beginning of the watchers list.
             // We want to intercept Enter.key as soon as possible, and before other listeners start modifying the text.
             // Also note that this Watchers, when the AztecKeyListener is set, keep hold a copy of the content in the editor.
-            mListeners.add(new EnterPressedWatcher(this, () -> shouldDeleteEnter));
+            mListeners.add(new EnterPressedWatcher(this, new EnterDeleter() {
+                @Override
+                public boolean shouldDeleteEnter() {
+                    return shouldDeleteEnter;
+                }
+            }));
         }
 
         mListeners.add(watcher);

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -96,15 +96,15 @@ public class ReactAztecText extends AztecText {
                 return false;
             }
             @Override
-            public boolean onBackspaceKey(boolean firedAfterTextChanged) {
+            public boolean onBackspaceKey() {
                 if (shouldHandleOnBackspace && !isTextChangedListenerDisabled()) {
                     String content = toHtml(getText(), false);
                     if (TextUtils.isEmpty(content)) {
-                        return onBackspace(firedAfterTextChanged);
+                        return onBackspace();
                     }
                     else {
                         if (!content.equals(mEmptyTagHTML)) {
-                            return onBackspace(firedAfterTextChanged);
+                            return onBackspace();
                         }
                     }
                 }
@@ -371,7 +371,7 @@ public class ReactAztecText extends AztecText {
         return true;
     }
 
-    private boolean onBackspace(boolean firedAfterTextChanged) {
+    private boolean onBackspace() {
         int cursorPositionStart = getSelectionStart();
         int cursorPositionEnd = getSelectionEnd();
         // Make sure to report backspace at the beginning only, with no selection.
@@ -386,8 +386,7 @@ public class ReactAztecText extends AztecText {
         EventDispatcher eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
         // TODO: isRTL? Should be passed here?
         eventDispatcher.dispatchEvent(
-                new ReactAztecBackspaceEvent(getId(), content, cursorPositionStart, cursorPositionEnd,
-                        firedAfterTextChanged)
+                new ReactAztecBackspaceEvent(getId(), content, cursorPositionStart, cursorPositionEnd)
         );
         return true;
     }

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -88,22 +88,22 @@ public class ReactAztecText extends AztecText {
 
         this.setAztecKeyListener(new ReactAztecText.OnAztecKeyListener() {
             @Override
-            public boolean onEnterKey() {
+            public boolean onEnterKey(boolean firedAfterTextChanged) {
                 if (shouldHandleOnEnter && !isTextChangedListenerDisabled()) {
-                    return onEnter();
+                    return onEnter(firedAfterTextChanged);
                 }
                 return false;
             }
             @Override
-            public boolean onBackspaceKey() {
+            public boolean onBackspaceKey(boolean firedAfterTextChanged) {
                 if (shouldHandleOnBackspace && !isTextChangedListenerDisabled()) {
                     String content = toHtml(false);
                     if (TextUtils.isEmpty(content)) {
-                        return onBackspace();
+                        return onBackspace(firedAfterTextChanged);
                     }
                     else {
                         if (!content.equals(mEmptyTagHTML)) {
-                            return onBackspace();
+                            return onBackspace(firedAfterTextChanged);
                         }
                     }
                 }
@@ -355,7 +355,7 @@ public class ReactAztecText extends AztecText {
         this.mIsSettingTextFromJS = mIsSettingTextFromJS;
     }
 
-    private boolean onEnter() {
+    private boolean onEnter(boolean firedAfterTextChanged) {
         disableTextChangedListener();
         String content = toHtml(false);
         int cursorPositionStart = getSelectionStart();
@@ -364,12 +364,13 @@ public class ReactAztecText extends AztecText {
         ReactContext reactContext = (ReactContext) getContext();
         EventDispatcher eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
         eventDispatcher.dispatchEvent(
-                new ReactAztecEnterEvent(getId(), content, cursorPositionStart, cursorPositionEnd, incrementAndGetEventCounter())
+                new ReactAztecEnterEvent(getId(), content, cursorPositionStart, cursorPositionEnd,
+                        firedAfterTextChanged, incrementAndGetEventCounter())
         );
         return true;
     }
 
-    private boolean onBackspace() {
+    private boolean onBackspace(boolean firedAfterTextChanged) {
         int cursorPositionStart = getSelectionStart();
         int cursorPositionEnd = getSelectionEnd();
         // Make sure to report backspace at the beginning only, with no selection.
@@ -384,7 +385,8 @@ public class ReactAztecText extends AztecText {
         EventDispatcher eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
         // TODO: isRTL? Should be passed here?
         eventDispatcher.dispatchEvent(
-                new ReactAztecBackspaceEvent(getId(), content, cursorPositionStart, cursorPositionEnd)
+                new ReactAztecBackspaceEvent(getId(), content, cursorPositionStart, cursorPositionEnd,
+                        firedAfterTextChanged)
         );
         return true;
     }

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -7,6 +7,7 @@ import android.graphics.Rect;
 import android.support.annotation.Nullable;
 import android.text.Editable;
 import android.text.InputType;
+import android.text.Spannable;
 import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.TextWatcher;
@@ -91,7 +92,7 @@ public class ReactAztecText extends AztecText {
 
         this.setAztecKeyListener(new ReactAztecText.OnAztecKeyListener() {
             @Override
-            public boolean onEnterKey(Spanned text, boolean firedAfterTextChanged, int selStart, int selEnd) {
+            public boolean onEnterKey(Spannable text, boolean firedAfterTextChanged, int selStart, int selEnd) {
                 if (shouldHandleOnEnter && !isTextChangedListenerDisabled()) {
                     return onEnter(text, firedAfterTextChanged, selStart, selEnd);
                 }
@@ -368,7 +369,7 @@ public class ReactAztecText extends AztecText {
         this.mIsSettingTextFromJS = mIsSettingTextFromJS;
     }
 
-    private boolean onEnter(Spanned text, boolean firedAfterTextChanged, int selStart, int selEnd) {
+    private boolean onEnter(Spannable text, boolean firedAfterTextChanged, int selStart, int selEnd) {
         disableTextChangedListener();
         String content = toHtml(text, false);
         int cursorPositionStart = firedAfterTextChanged ? selStart : getSelectionStart();

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -61,6 +61,8 @@ public class ReactAztecText extends AztecText {
     boolean shouldHandleOnSelectionChange = false;
     boolean shouldHandleActiveFormatsChange = false;
 
+    boolean shouldDeleteEnter = false;
+
     // This optional variable holds the outer HTML tag that will be added to the text when the user start typing in it
     // This is required to keep placeholder text working, and start typing with styled text.
     // Ref: https://github.com/wordpress-mobile/gutenberg-mobile/issues/707
@@ -328,6 +330,11 @@ public class ReactAztecText extends AztecText {
         if (mListeners == null) {
             mListeners = new ArrayList<>();
             super.addTextChangedListener(getTextWatcherDelegator());
+
+            // Keep the enter pressed watcher at the beginning of the watchers list.
+            // We want to intercept Enter.key as soon as possible, and before other listeners start modifying the text.
+            // Also note that this Watchers, when the AztecKeyListener is set, keep hold a copy of the content in the editor.
+            mListeners.add(new EnterPressedWatcher(this, () -> shouldDeleteEnter));
         }
 
         mListeners.add(watcher);
@@ -456,6 +463,10 @@ public class ReactAztecText extends AztecText {
         ArrayList<ITextFormat> newStylesList = new ArrayList<>(selectedStylesSet);
         setSelectedStyles(newStylesList);
         updateToolbarButtons(newStylesList);
+    }
+
+    protected boolean isEnterPressedUnderway() {
+        return EnterPressedWatcher.Companion.isEnterPressedUnderway(getText());
     }
 
     /**

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -88,9 +88,9 @@ public class ReactAztecText extends AztecText {
 
         this.setAztecKeyListener(new ReactAztecText.OnAztecKeyListener() {
             @Override
-            public boolean onEnterKey(boolean firedAfterTextChanged) {
+            public boolean onEnterKey(boolean firedAfterTextChanged, int selStart, int selEnd) {
                 if (shouldHandleOnEnter && !isTextChangedListenerDisabled()) {
-                    return onEnter(firedAfterTextChanged);
+                    return onEnter(firedAfterTextChanged, selStart, selEnd);
                 }
                 return false;
             }
@@ -355,11 +355,15 @@ public class ReactAztecText extends AztecText {
         this.mIsSettingTextFromJS = mIsSettingTextFromJS;
     }
 
-    private boolean onEnter(boolean firedAfterTextChanged) {
+    private boolean onEnter(boolean firedAfterTextChanged, int selStart, int selEnd) {
         disableTextChangedListener();
         String content = toHtml(false);
-        int cursorPositionStart = getSelectionStart();
-        int cursorPositionEnd = getSelectionEnd();
+        int cursorPositionStart = firedAfterTextChanged ? selStart : getSelectionStart();
+        int cursorPositionEnd = firedAfterTextChanged ? selEnd : getSelectionEnd();
+//        if (firedAfterTextChanged) {
+//            cursorPositionStart--;
+//            cursorPositionEnd--;
+//        }
         enableTextChangedListener();
         ReactContext reactContext = (ReactContext) getContext();
         EventDispatcher eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();

--- a/react-native-aztec/android/src/main/kotlin/org/wordpress/mobile/ReactNativeAztec/EnterPressedWatcher.kt
+++ b/react-native-aztec/android/src/main/kotlin/org/wordpress/mobile/ReactNativeAztec/EnterPressedWatcher.kt
@@ -1,0 +1,71 @@
+package org.wordpress.mobile.ReactNativeAztec
+
+import android.text.Editable
+import android.text.SpannableStringBuilder
+import android.text.Spanned
+import android.text.TextWatcher
+import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.Constants
+import java.lang.ref.WeakReference
+
+// Class to be used as a span to temporarily denote that Enter was detected
+class EnterPressedUnderway
+
+interface EnterDeleter {
+    fun shouldDeleteEnter(): Boolean
+}
+
+class EnterPressedWatcher(aztecText: AztecText, var enterDeleter: EnterDeleter) : TextWatcher {
+
+    private val aztecTextRef: WeakReference<AztecText?> = WeakReference(aztecText)
+    private lateinit var textBefore : SpannableStringBuilder
+    private var start: Int = -1
+    private var selStart: Int = 0
+    private var selEnd: Int = 0
+    var done = false
+
+    override fun beforeTextChanged(text: CharSequence, start: Int, count: Int, after: Int) {
+        val aztecText = aztecTextRef.get()
+        if (aztecText?.getAztecKeyListener() != null && !aztecText.isTextChangedListenerDisabled()) {
+            // we need to make a copy to preserve the contents as they were before the change
+            textBefore = SpannableStringBuilder(text)
+            this.start = start
+            this.selStart = aztecText.selectionStart
+            this.selEnd = aztecText.selectionEnd
+        }
+    }
+
+    override fun onTextChanged(text: CharSequence, start: Int, before: Int, count: Int) {
+        val aztecText = aztecTextRef.get()
+        val aztecKeyListener = aztecText?.getAztecKeyListener()
+        if (aztecText != null && !aztecText.isTextChangedListenerDisabled() && aztecKeyListener != null) {
+            val newTextCopy = SpannableStringBuilder(text)
+            // if new text length is longer than original text by 1
+            if (textBefore?.length == newTextCopy.length - 1) {
+                // now check that the inserted character is actually a NEWLINE
+                if (newTextCopy[this.start] == Constants.NEWLINE) {
+                    done = false
+                    aztecText.editableText.setSpan(EnterPressedUnderway(), 0, 0, Spanned.SPAN_USER)
+                    aztecKeyListener.onEnterKey(newTextCopy.replace(this.start, this.start+1, ""), true, selStart, selEnd)
+                }
+            }
+        }
+    }
+
+    override fun afterTextChanged(text: Editable) {
+        aztecTextRef.get()?.editableText?.getSpans(0, 0, EnterPressedUnderway::class.java)?.forEach {
+            if (!done) {
+                done = true
+                if (enterDeleter.shouldDeleteEnter())
+                    text.replace(start, start + 1, "")
+                }
+            aztecTextRef.get()?.editableText?.removeSpan(it)
+        }
+    }
+
+    companion object {
+        fun isEnterPressedUnderway(spanned: Spanned?): Boolean {
+            return spanned?.getSpans(0, 0, EnterPressedUnderway::class.java)?.isNotEmpty() ?: false
+        }
+    }
+}

--- a/react-native-aztec/src/AztecView.js
+++ b/react-native-aztec/src/AztecView.js
@@ -12,6 +12,7 @@ class AztecView extends React.Component {
     activeFormats: PropTypes.array,
     isSelected: PropTypes.bool,
     disableGutenbergMode: PropTypes.bool,
+    deleteEnter: PropTypes.bool,
     text: PropTypes.object,
     placeholder: PropTypes.string,
     placeholderTextColor: ColorPropType,
@@ -158,6 +159,7 @@ class AztecView extends React.Component {
           onHTMLContentWithCursor = { this._onHTMLContentWithCursor }
           onSelectionChange = { this._onSelectionChange }
           onEnter = { this.props.onEnter && this._onEnter }
+          deleteEnter = { this.props.deleteEnter }
           // IMPORTANT: the onFocus events are thrown away as these are handled by onPress() in the upper level.
           // It's necessary to do this otherwise onFocus may be set by `{...otherProps}` and thus the onPress + onFocus
           // combination generate an infinite loop as described in https://github.com/wordpress-mobile/gutenberg-mobile/issues/302


### PR DESCRIPTION
Fixes #898 , #899 

### Companion PRs
Gutenberg: https://github.com/WordPress/gutenberg/pull/15168
Aztec-Android: https://github.com/wordpress-mobile/AztecEditor-Android/pull/812

This PR updates the way the "Enter" key is processed along with the general way changes from Aztec (Android) are updating the RN state without forcing them back to Aztec again.

This PR is WIP.

### Background

An Aztec-Android, the virtual keyboard has different behavior than external/hardware keyboards and the program flows through different code paths depending on whether it's the virtual keyboard or not. The key press from hardware keyboards is detected/intercepted before it changes the editor's text, the opposite happens on the virtual one. On the hardware keyboard, the event can be intercepted (and swallowed) upon detection, while on the virtual one the event _will_ cause text change in Aztec. Then, virtual keyboards have a generally weird way to update the text, especially when auto-suggestions are enabled: a single key press may produce multiple "text-changed" events, each one with an intermediate state of the text change.

### Changes
1. `comesFromAztec`: A flag that signals whether a change initiated in Aztec, versus initiated by the RN app.
2. `firedAfterTextChanged`: A signal from Aztec to show _when_ was the "Enter" key fired from the system. "Before text change" means it was fired from the hardware key listener, while "after" means it was from the virtual keyboard. If "before", Aztec will not process the "Enter" event so, no list processing will happen at that level. The format-lib will handle the list processing and so, RN needs to force the processed text into Aztec. On the contrary, If the event happened "after" the text change, the RN side just needs to update its internal model, without forcing anything to Aztec since Aztec will also process the event.
3. Won't send `ReactTextChangedEvent` and `ReactTextInputEvent` when the "Enter" key detection process is in progress in Aztec. We'll rely on the `ReactAztecEnterEvent` that will be sent and will have all the info we need, regarding text and caret. Introduced the `EnterPressedUnderway` span class to mark text as still being processed for the "Enter" key detection.
4. Introduced the `EnterPressedWatcher` TextWatcher (moved it here from the Aztec project) so we can specify that we need the watcher to remove the `Enter` key when in an empty paragraph block. We don't specify that for the list block case because Aztec's list handling will remove the `Enter` on the list end anyway.

### Test case A

1. Have a list with a word as a list item
2. Split the word by hitting "Enter" inside the word. Try both the "Enter" key on the virtual keyboard and an external key (e.g. via Vysor)
3. The word should be split in two separate list items
4. Tap backspace to merge the two list items. The word should merge.
5. Try splitting and merging again a few times. It should always work normally.

### Test case B

1. Have a list with a few list items
2. Tap "Enter" at the end of the last item to create a new item
3. Tap "Enter" again. The list should be ended and a new paragraph block should be created

### Test case C

1. Have a list with 3 list items, the middle of which be empty
2. Tap "Enter" in the middle item
3. The list should be split and a new paragraph block should appear between the 2 newly split lists

### Test case D

1. Have a list with 3 list items, the middle of which be empty
2. Place the caret at the beginning of the 3rd item and hit "Backspace"
3. The middle item should get removed and the 3rd item becomes 2nd. On iOS in particular, the 3rd item loses its bullet.
4. Hit "Backspace" again
5. The list should have only one item with all the text now merged

### Test case E

1. Write fast inside a paragraph block. It should work as normal.