### PR TITLE
Move unselected block accessibility handling to block-holder

### DIFF
--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -28,7 +28,7 @@ import { compose } from '@wordpress/compose';
 import { addAction, removeAction, hasAction } from '@wordpress/hooks';
 import { getBlockType, getUnregisteredTypeHandlerName } from '@wordpress/blocks';
 import { BlockEdit } from '@wordpress/block-editor';
-import { __, _x } from '@wordpress/i18n';
+import { sprintf, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -200,21 +200,21 @@ export class BlockHolder extends React.Component<PropsType, StateType> {
 
 	accessibilityLabel() {
 		const { title, attributes, name } = this.props;
+		const { getAccessibilityContent = () => '' } = attributes;
 		if ( name === getUnregisteredTypeHandlerName() ) { // is the block unrecognized?
 			return title; //already localized
 		}
-		else {
-			return sprintf(
-				/* translators: accessibility text. 1: block name. 2: block content information. */
-				_x('%1$s block. %2$s', "Accessibility text for a block"), 
-				title, //already localized
-				attributes.accessibilityContent || '' 
-			);
-		}
+
+		return sprintf(
+			/* translators: accessibility text. 1: block name. 2: block content information. */
+			_x( '%1$s block. %2$s', 'Accessibility text for a block' ),
+			title, //already localized
+			getAccessibilityContent() || ''
+		);
 	}
 
 	render() {
-		const { isSelected, borderStyle, focusedBorderColor, attributes } = this.props;
+		const { isSelected, borderStyle, focusedBorderColor } = this.props;
 
 		const borderColor = isSelected ? focusedBorderColor : 'transparent';
 
@@ -224,6 +224,7 @@ export class BlockHolder extends React.Component<PropsType, StateType> {
 			<TouchableWithoutFeedback
 				accessible={ ! isSelected }
 				accessibilityLabel={ this.accessibilityLabel() }
+				accessibilityRole={ 'button' }
 				onPress={ this.onFocus } >
 
 				<View style={ [ styles.blockHolder, borderStyle, { borderColor } ] }>
@@ -259,7 +260,7 @@ export default compose( [
 		const isSelected = isBlockSelected( clientId );
 		const isFirstBlock = order === 0;
 		const isLastBlock = order === getBlocks().length - 1;
-		const title = getBlockType( name ).title;
+		const title = getBlockType( name ) !== undefined ? getBlockType( name ).title : '';
 
 		return {
 			attributes,


### PR DESCRIPTION
This PR moves accessibility handling of unselected blocks to block-holder, so:

- We don't have to handle blocks separately. Every block will have at least their name(including unknown blocks) read by screen reader without extra coding.
- If we wants to provide more information for a block we'll need to inject its own `getAccessibilityContent` function as its `attribute`.
- Some block content like Separator block have very little height, it is hard to select them otherwise.

gutenberg PR: https://github.com/WordPress/gutenberg/pull/15214

Note: This is still a kind of experiment, we can decide not to merge this based on your opinions and tests.

**To Test:**

It should be enough to test in only 1 platform.
Check below items with Voice Over on:

- [ ] Image block empty
- [ ] Image block with image - selected
- [ ] Image block with image - unselected
- [ ] Next page
- [ ] Paragraph block empty
- [ ] Paragraph block with text
- [ ] Post title empty
- [ ] Post title with text
- [ ] Unrecognized block
- [ ] Separator block (Should tell its name)
- [ ] Basic operations like Updating/Closing/Opening post