### PR TITLE
Add text alignment prop for centering image captions

### DIFF
--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -3,14 +3,18 @@ package org.wordpress.mobile.ReactNativeAztec;
 
 import android.graphics.Color;
 import android.graphics.Typeface;
+import android.os.Build;
 import android.support.annotation.Nullable;
 import android.text.Editable;
+import android.text.Layout;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.util.TypedValue;
+import android.view.Gravity;
 import android.view.View;
 
 import com.facebook.infer.annotation.Assertions;
+import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
@@ -291,6 +295,40 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
         return fontWeightString.length() == 3 && fontWeightString.endsWith("00")
                 && fontWeightString.charAt(0) <= '9' && fontWeightString.charAt(0) >= '1' ?
                 100 * (fontWeightString.charAt(0) - '0') : -1;
+    }
+
+    /**
+     * This method is based on {@link ReactTextInputManager#setTextAlign}. The only change made to that method is to
+     * use {@link android.widget.TextView#setGravity} instead of a custom method that preserves vertical gravity
+     * like the setGravityHorizontal method from {@link com.facebook.react.views.textinput.ReactEditText}. The
+     * reason for this change was to simplify the code. Since we never set vertical gravity, we do not need to add
+     * the complexity of preserving vertical gravity—we can just use {@link android.widget.TextView#setGravity}
+     * directly.
+     */
+    @ReactProp(name = ViewProps.TEXT_ALIGN)
+    public void setTextAlign(ReactAztecText view, @Nullable String textAlign) {
+        if ("justify".equals(textAlign)) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                view.setJustificationMode(Layout.JUSTIFICATION_MODE_INTER_WORD);
+            }
+            view.setGravity(Gravity.START);
+        } else {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                view.setJustificationMode(Layout.JUSTIFICATION_MODE_NONE);
+            }
+
+            if (textAlign == null || "auto".equals(textAlign)) {
+                view.setGravity(Gravity.NO_GRAVITY);
+            } else if ("left".equals(textAlign)) {
+                view.setGravity(Gravity.START);
+            } else if ("right".equals(textAlign)) {
+                view.setGravity(Gravity.END);
+            } else if ("center".equals(textAlign)) {
+                view.setGravity(Gravity.CENTER_HORIZONTAL);
+            } else {
+                throw new JSApplicationIllegalArgumentException("Invalid textAlign: " + textAlign);
+            }
+        }
     }
 
     /* End of the code taken from ReactTextInputManager */

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -34,6 +34,14 @@ class RCTAztecView: Aztec.TextView {
         }
     }
 
+    override var textAlignment: NSTextAlignment {
+        didSet {
+            super.textAlignment = textAlignment
+            defaultParagraphStyle.alignment = textAlignment
+            placeholderLabel.textAlignment = textAlignment
+        }
+    }
+
     var blockModel = BlockModel(tag: "") {
         didSet {
             forceTypingAttributesIfNeeded()
@@ -123,15 +131,17 @@ class RCTAztecView: Aztec.TextView {
         delegate = self
         textContainerInset = .zero
         contentInset = .zero
-        textContainer.lineFragmentPadding = 0        
+        textContainer.lineFragmentPadding = 0
         addPlaceholder()
     }
 
     func addPlaceholder() {
         addSubview(placeholderLabel)
+        let topConstant = contentInset.top + textContainerInset.top
         NSLayoutConstraint.activate([
             placeholderHorizontalConstraint,
-            placeholderLabel.topAnchor.constraint(equalTo: topAnchor, constant: contentInset.top + textContainerInset.top)
+            placeholderLabel.topAnchor.constraint(equalTo: topAnchor, constant: topConstant),
+            placeholderLabel.widthAnchor.constraint(equalTo: widthAnchor),
         ])
     }
 

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -131,10 +131,6 @@ class RCTAztecView: Aztec.TextView {
         delegate = self
         textContainerInset = .zero
         contentInset = .zero
-<<<<<<< HEAD
-        textContainer.lineFragmentPadding = 0
-=======
->>>>>>> feature/caption
         addPlaceholder()
     }
 

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecViewManager.m
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecViewManager.m
@@ -27,8 +27,6 @@ RCT_EXPORT_VIEW_PROPERTY(fontWeight, NSString)
 RCT_EXPORT_VIEW_PROPERTY(disableEditingMenu, BOOL)
 RCT_REMAP_VIEW_PROPERTY(textAlign, textAlignment, NSTextAlignment)
 
-//RCT_REMAP_VIEW_PROPERTY(textAlign, textAlignment, NSTextAlignment)
-
 RCT_EXTERN_METHOD(applyFormat:(nonnull NSNumber *)node format:(NSString *)format)
 RCT_EXTERN_METHOD(setLink:(nonnull NSNumber *)node url:(nonnull NSString *)url title:(nullable NSString *)title)
 RCT_EXTERN_METHOD(removeLink:(nonnull NSNumber *)node)

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecViewManager.m
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecViewManager.m
@@ -25,6 +25,9 @@ RCT_EXPORT_VIEW_PROPERTY(fontSize, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(fontWeight, NSString)
 
 RCT_EXPORT_VIEW_PROPERTY(disableEditingMenu, BOOL)
+RCT_REMAP_VIEW_PROPERTY(textAlign, textAlignment, NSTextAlignment)
+
+//RCT_REMAP_VIEW_PROPERTY(textAlign, textAlignment, NSTextAlignment)
 
 RCT_EXTERN_METHOD(applyFormat:(nonnull NSNumber *)node format:(NSString *)format)
 RCT_EXTERN_METHOD(setLink:(nonnull NSNumber *)node url:(nonnull NSString *)url title:(nullable NSString *)title)


### PR DESCRIPTION
## Description
This PR adds a `textAlign` property to the `ReactAztecManager` so the text in image captions can be centered. See the [companion gutenberg PR](https://github.com/WordPress/gutenberg/pull/15257) for usage on the React Native side.

This addresses the loss of center alignment for image captions that was introduced when [the image caption was switched to use a `RichText` component](https://github.com/WordPress/gutenberg/pull/14883).

![center_caption_resized](https://user-images.githubusercontent.com/4656348/56936848-9ad1fd00-6ac7-11e9-85ee-2ee969a95c1d.png)

⚠️ Implementation of the `textAlign` prop still needs to be completed on iOS.

## Test Cases
1. An image caption's text should have center alignment when the image caption is not selected.
2. An image caption's text should have center alignment when the image caption is selected.
3. An image caption's text should have center alignment when the image caption is being edited.
4. When an image with an empty caption is selected, the placeholder text "Write caption..." should appear centered.
5. Image caption lines that are wider than the available space should wrap to a new line.
6. Pressing the enter key while editing an image caption should add a new line to the image caption.
7. It should be possible to add bold, italic, link, and strikethrough styling attributes to an image caption.

## Issue Adding New Lines to Styled Text
One issue that exists on Android is that tapping enter to add a new line to a caption _that has styles applied_ will frequently not move the cursor to the newly created line. I think that this is a broader issue with `RichText` components that span multiple lines (I'm looking at you list blocks), which will be resolved by @hypest's [PR Fixing List Block Handling](https://github.com/wordpress-mobile/gutenberg-mobile/pull/928) (see [my comment](https://github.com/wordpress-mobile/gutenberg-mobile/pull/928#issuecomment-487577796) on that PR discussing this issue). For that reason, I do not think this issue should block this PR.