### PR TITLE
Fix move selected text on iOS

### DIFF
--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -123,7 +123,7 @@ class RCTAztecView: Aztec.TextView {
         delegate = self
         textContainerInset = .zero
         contentInset = .zero
-        textContainer.lineFragmentPadding = 0        
+        textContainer.lineFragmentPadding = 0
         addPlaceholder()
     }
 
@@ -533,8 +533,11 @@ extension RCTAztecView: UITextViewDelegate {
         textView.setNeedsLayout()
     }
 
-    func textViewDidBeginEditing(_ textView: UITextView) {
-        onFocus?([:])
+    override func becomeFirstResponder() -> Bool {
+        if !isFirstResponder && canBecomeFirstResponder {
+            onFocus?([:])
+        }
+        return super.becomeFirstResponder()
     }
 
     func textViewDidEndEditing(_ textView: UITextView) {

--- a/react-native-aztec/src/AztecView.js
+++ b/react-native-aztec/src/AztecView.js
@@ -134,8 +134,10 @@ class AztecView extends React.Component {
   }
 
   _onPress = (event) => {
-    this.focus(event); // Call to move the focus in RN way (TextInputState)
-    this._onFocus(event); // Check if there are listeners set on the focus event
+	if ( ! this.isFocused() ) {
+		this.focus(event); // Call to move the focus in RN way (TextInputState)
+		this._onFocus(event); // Check if there are listeners set on the focus event
+	}
   }
 
   _onAztecFocus = (event) => {


### PR DESCRIPTION
fixes #843 
Maybe this one too: https://github.com/wordpress-mobile/WordPress-iOS/issues/11583

This PR fixes an issue where the editor enters on a onFocus/onBlur infinite loop. This was easily reproduced by selecting text on a paragraph block, and moving it inside the same block.

I tracked the issue until this line:
https://github.com/wordpress-mobile/gutenberg-mobile/blob/6513ba88076009b883f8b708ec48dfcbe92793b5/react-native-aztec/src/AztecView.js#L149

But we need it in order to let Gutenberg know that the TextView was focused by iOS. Needed to solve this issue: https://github.com/wordpress-mobile/gutenberg-mobile/issues/702

With some investigation I noticed that `textViewDidBeginEditing` was sending one extra `onFocus` event that is not needed, and that triggered the loop. It was solved by sending the `onFocus` from `becomeFirstResponder`, with the proper checks.

![move-selected](https://user-images.githubusercontent.com/9772967/57063704-62e3d900-6cc4-11e9-8256-de6e2c65d1f3.gif)


To test:

- Run the example project on iOS
- Select a long paragraph block.
- Select some text long enough.
- Long press to move it and release it somewhere else in the block.
- Check that the editor behaves as expected.
- Check that the Hide Keyboard button stays functional after presenting the Links UI. (check for #702 )
- Smoke test on Android.