### PR TITLE
Remove flow from the files that will go to Gutenberg

### DIFF
--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -1,6 +1,6 @@
 /**
 * @format
-* @flow
+*
 */
 
 /**
@@ -11,8 +11,6 @@ import {
 	View,
 	Text,
 	TouchableWithoutFeedback,
-	NativeSyntheticEvent,
-	NativeTouchEvent,
 	Keyboard,
 } from 'react-native';
 import TextInputState from 'react-native/lib/TextInputState';
@@ -32,41 +30,11 @@ import { BlockEdit } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
-import type { BlockType } from '../store/types';
 import styles from './block-holder.scss';
 import InlineToolbar, { InlineToolbarActions } from './inline-toolbar';
 
-type PropsType = BlockType & {
-	clientId: string,
-	rootClientId: string,
-	isSelected: boolean,
-	isFirstBlock: boolean,
-	isLastBlock: boolean,
-	showTitle: boolean,
-	borderStyle: Object,
-	testID: string,
-	focusedBorderColor: string,
-	getBlockIndex: ( clientId: string, rootClientId: string ) => number,
-	getPreviousBlockClientId: ( clientId: string ) => string,
-	getNextBlockClientId: ( clientId: string ) => string,
-	getBlockName: ( clientId: string ) => string,
-	onChange: ( attributes: mixed ) => void,
-	onInsertBlocks: ( blocks: Array<Object>, index: number ) => void,
-	onCaretVerticalPositionChange: ( targetId: number, caretY: number, previousCaretY: ?number ) => void,
-	onReplace: ( blocks: Array<Object> ) => void,
-	onSelect: ( clientId: string ) => void,
-	mergeBlocks: ( clientId: string, clientId: string ) => void,
-	moveBlockUp: () => void,
-	moveBlockDown: () => void,
-	removeBlock: () => void,
-};
-
-type StateType = {
-	isFullyBordered: boolean;
-}
-
-export class BlockHolder extends React.Component<PropsType, StateType> {
-	constructor( props: PropsType ) {
+export class BlockHolder extends React.Component {
+	constructor( props ) {
 		super( props );
 
 		this.state = {
@@ -74,7 +42,7 @@ export class BlockHolder extends React.Component<PropsType, StateType> {
 		};
 	}
 
-	onFocus = ( event: NativeSyntheticEvent<NativeTouchEvent> ) => {
+	onFocus = ( event ) => {
 		if ( event ) {
 			// == Hack for the Alpha ==
 			// When moving the focus from a TextInput field to another kind of field the call that hides the keyboard is not invoked
@@ -88,7 +56,7 @@ export class BlockHolder extends React.Component<PropsType, StateType> {
 		this.props.onSelect( this.props.clientId );
 	};
 
-	onRemoveBlockCheckUpload = ( mediaId: number ) => {
+	onRemoveBlockCheckUpload = ( mediaId ) => {
 		if ( hasAction( 'blocks.onRemoveBlockCheckUpload' ) ) {
 			// now remove the action as it's  a one-shot use and won't be needed anymore
 			removeAction( 'blocks.onRemoveBlockCheckUpload', 'gutenberg-mobile/blocks' );
@@ -96,7 +64,7 @@ export class BlockHolder extends React.Component<PropsType, StateType> {
 		}
 	}
 
-	onInlineToolbarButtonPressed = ( button: number ) => {
+	onInlineToolbarButtonPressed = ( button ) => {
 		Keyboard.dismiss();
 		switch ( button ) {
 			case InlineToolbarActions.UP:
@@ -114,7 +82,7 @@ export class BlockHolder extends React.Component<PropsType, StateType> {
 		}
 	};
 
-	insertBlocksAfter = ( blocks: Array<Object> ) => {
+	insertBlocksAfter = ( blocks ) => {
 		const order = this.props.getBlockIndex( this.props.clientId, this.props.rootClientId );
 		this.props.onInsertBlocks( blocks, order + 1 );
 
@@ -124,7 +92,7 @@ export class BlockHolder extends React.Component<PropsType, StateType> {
 		}
 	};
 
-	mergeBlocks = ( forward: boolean = false ) => {
+	mergeBlocks = ( forward = false ) => {
 		const {
 			clientId,
 			getPreviousBlockClientId,
@@ -280,17 +248,17 @@ export default compose( [
 			removeBlock() {
 				removeBlock( clientId );
 			},
-			onInsertBlocks( blocks: Array<Object>, index: number ) {
+			onInsertBlocks( blocks, index ) {
 				insertBlocks( blocks, index, rootClientId );
 			},
-			onSelect: ( selectedClientId: string ) => {
+			onSelect: ( selectedClientId ) => {
 				clearSelectedBlock();
 				selectBlock( selectedClientId );
 			},
-			onChange: ( attributes: Object ) => {
+			onChange: ( attributes ) => {
 				updateBlockAttributes( clientId, attributes );
 			},
-			onReplace( blocks: Array<Object> ) {
+			onReplace( blocks ) {
 				replaceBlocks( [ clientId ], blocks );
 			},
 		};

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -1,6 +1,5 @@
 /**
  * @format
- * @flow
  */
 
 /**
@@ -8,7 +7,7 @@
  */
 import React from 'react';
 import { identity } from 'lodash';
-import { Text, View, Keyboard, LayoutChangeEvent, SafeAreaView, Platform } from 'react-native';
+import { Text, View, Keyboard, SafeAreaView, Platform } from 'react-native';
 
 /**
  * WordPress dependencies
@@ -25,7 +24,6 @@ import { sendNativeEditorDidLayout, subscribeSetFocusOnTitle, subscribeMediaAppe
  * Internal dependencies
  */
 import BlockHolder from './block-holder';
-import type { BlockType } from '../store/types';
 import styles from './block-manager.scss';
 import blockHolderStyles from './block-holder.scss';
 import inlineToolbarStyles from './inline-toolbar/style.scss';
@@ -38,52 +36,22 @@ import { KeyboardAwareFlatList, handleCaretVerticalPositionChange } from '../com
 import SafeArea from 'react-native-safe-area';
 import ReadableContentView from '../components/readable-content-view';
 
-type PropsType = {
-	rootClientId: ?string,
-	blockClientIds: Array<string>,
-	blockCount: number,
-	focusBlock: ( clientId: string ) => void,
-	insertBlock: ( block: BlockType, position: number ) => void,
-	replaceBlock: ( string, BlockType ) => mixed,
-	getBlockName: string => string,
-	selectedBlock: ?BlockType,
-	selectedBlockClientId: string,
-	setTitleAction: string => void,
-	selectedBlockOrder: number,
-	isBlockSelected: string => boolean,
-	showHtml: boolean,
-	title: string,
-};
+export class BlockManager extends React.Component {
 
-type StateType = {
-	blockTypePickerVisible: boolean,
-	isKeyboardVisible: boolean,
-	rootViewHeight: number,
-	safeAreaBottomInset: number,
-	isFullyBordered: boolean,
-};
-
-export class BlockManager extends React.Component<PropsType, StateType> {
-	scrollViewRef: Object;
-	postTitleRef: ?Object;
-	subscriptionParentSetFocusOnTitle: ?Object;
-	subscriptionParentMediaAppend: ?Object;
-	_isMounted: boolean;
-
-	constructor( props: PropsType ) {
+	constructor( props ) {
 		super( props );
 
-		( this: any ).renderItem = this.renderItem.bind( this );
-		( this: any ).shouldFlatListPreventAutomaticScroll = this.shouldFlatListPreventAutomaticScroll.bind( this );
-		( this: any ).renderDefaultBlockAppender = this.renderDefaultBlockAppender.bind( this );
-		( this: any ).renderHeader = this.renderHeader.bind( this );
-		( this: any ).onSafeAreaInsetsUpdate = this.onSafeAreaInsetsUpdate.bind( this );
-		( this: any ).onBlockTypeSelected = this.onBlockTypeSelected.bind( this );
-		( this: any ).onRootViewLayout = this.onRootViewLayout.bind( this );
-		( this: any ).keyboardDidShow = this.keyboardDidShow.bind( this );
-		( this: any ).keyboardDidHide = this.keyboardDidHide.bind( this );
-		( this: any ).onCaretVerticalPositionChange = this.onCaretVerticalPositionChange.bind( this );
-		( this: any ).scrollViewInnerRef = this.scrollViewInnerRef.bind( this );
+		this.renderItem = this.renderItem.bind( this );
+		this.shouldFlatListPreventAutomaticScroll = this.shouldFlatListPreventAutomaticScroll.bind( this );
+		this.renderDefaultBlockAppender = this.renderDefaultBlockAppender.bind( this );
+		this.renderHeader = this.renderHeader.bind( this );
+		this.onSafeAreaInsetsUpdate = this.onSafeAreaInsetsUpdate.bind( this );
+		this.onBlockTypeSelected = this.onBlockTypeSelected.bind( this );
+		this.onRootViewLayout = this.onRootViewLayout.bind( this );
+		this.keyboardDidShow = this.keyboardDidShow.bind( this );
+		this.keyboardDidHide = this.keyboardDidHide.bind( this );
+		this.onCaretVerticalPositionChange = this.onCaretVerticalPositionChange.bind( this );
+		this.scrollViewInnerRef = this.scrollViewInnerRef.bind( this );
 
 		this.state = {
 			blockTypePickerVisible: false,
@@ -97,11 +65,11 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 
 	// TODO: in the near future this will likely be changed to onShowBlockTypePicker and bound to this.props
 	// once we move the action to the toolbar
-	showBlockTypePicker( show: boolean ) {
+	showBlockTypePicker( show ) {
 		this.setState( { blockTypePickerVisible: show } );
 	}
 
-	onBlockTypeSelected( itemValue: string ) {
+	onBlockTypeSelected( itemValue ) {
 		this.setState( { blockTypePickerVisible: false } );
 
 		// create an empty block of the selected type
@@ -110,7 +78,7 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 		this.finishBlockAppendingOrReplacing( newBlock );
 	}
 
-	finishBlockAppendingOrReplacing( newBlock: Object ) {
+	finishBlockAppendingOrReplacing( newBlock ) {
 		// now determine whether we need to replace the currently selected block (if it's empty)
 		// or just add a new block as usual
 		if ( this.isReplaceable( this.props.selectedBlock ) ) {
@@ -126,19 +94,19 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 		this.props.focusBlock( newBlock.clientId );
 	}
 
-	onSafeAreaInsetsUpdate( result: Object ) {
+	onSafeAreaInsetsUpdate( result ) {
 		const { safeAreaInsets } = result;
 		if ( this._isMounted && this.state.safeAreaBottomInset !== safeAreaInsets.bottom ) {
 			this.setState( { ...this.state, safeAreaBottomInset: safeAreaInsets.bottom } );
 		}
 	}
 
-	onRootViewLayout( event: LayoutChangeEvent ) {
+	onRootViewLayout( event ) {
 		this.setHeightState( event );
 		this.setBorderStyleState();
 	}
 
-	setHeightState( event: LayoutChangeEvent ) {
+	setHeightState( event ) {
 		const { height } = event.nativeEvent.layout;
 		this.setState( { rootViewHeight: height }, () => {
 			sendNativeEditorDidLayout();
@@ -201,11 +169,11 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 		this.setState( { isKeyboardVisible: false } );
 	}
 
-	onCaretVerticalPositionChange( targetId: number, caretY: number, previousCaretY: ?number ) {
+	onCaretVerticalPositionChange( targetId, caretY, previousCaretY ) {
 		handleCaretVerticalPositionChange( this.scrollViewRef, targetId, caretY, previousCaretY );
 	}
 
-	scrollViewInnerRef( ref: Object ) {
+	scrollViewInnerRef( ref ) {
 		this.scrollViewRef = ref;
 	}
 
@@ -306,14 +274,14 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 		);
 	}
 
-	isReplaceable( block: ?BlockType ) {
+	isReplaceable( block ) {
 		if ( ! block ) {
 			return false;
 		}
 		return isUnmodifiedDefaultBlock( block );
 	}
 
-	renderItem( value: { item: string, index: number } ) {
+	renderItem( value ) {
 		const clientId = value.item;
 		const testID = `block-${ value.index }-${ this.props.getBlockName( clientId ) }`;
 

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -37,7 +37,6 @@ import SafeArea from 'react-native-safe-area';
 import ReadableContentView from '../components/readable-content-view';
 
 export class BlockManager extends React.Component {
-
 	constructor( props ) {
 		super( props );
 

--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -1,6 +1,5 @@
 /**
  * @format
- * @flow
  */
 
 /**
@@ -22,15 +21,7 @@ import { getBlockTypes, getUnregisteredTypeHandlerName } from '@wordpress/blocks
  */
 import styles from './block-picker.scss';
 
-type PropsType = {
-	style?: StyleSheet,
-	isReplacement: boolean,
-	onValueSelected: ( itemValue: string ) => void,
-	onDismiss: () => void,
-	addExtraBottomPadding: boolean,
-};
-
-export default class BlockPicker extends Component<PropsType> {
+export default class BlockPicker extends Component {
 	availableBlockTypes = getBlockTypes().filter( ( { name } ) => name !== getUnregisteredTypeHandlerName() );
 
 	render() {
@@ -76,7 +67,7 @@ export default class BlockPicker extends Component<PropsType> {
 		);
 	}
 
-	iconWithUpdatedFillColor( color: string, icon: SVG ) {
+	iconWithUpdatedFillColor( color, icon ) {
 		return (
 			<SVG viewBox={ icon.src.props.viewBox } xmlns={ icon.src.props.xmlns } style={ { fill: color } }>
 				{ icon.src.props.children }

--- a/src/block-management/block-toolbar.js
+++ b/src/block-management/block-toolbar.js
@@ -1,6 +1,5 @@
 /**
  * @format
- * @flow
  */
 
 /**
@@ -23,17 +22,7 @@ import { __ } from '@wordpress/i18n';
  */
 import styles from './block-toolbar.scss';
 
-type PropsType = {
-	onInsertClick: void => void,
-	showKeyboardHideButton: boolean,
-	hasRedo: boolean,
-	hasUndo: boolean,
-	redo: void => void,
-	undo: void => void,
-	clearSelectedBlock: void => void,
-};
-
-export class BlockToolbar extends Component<PropsType> {
+export class BlockToolbar extends Component {
 	onKeyboardHide = () => {
 		this.props.clearSelectedBlock();
 		if ( Platform.OS === 'android' ) {

--- a/src/block-management/inline-toolbar/actions.js
+++ b/src/block-management/inline-toolbar/actions.js
@@ -1,6 +1,6 @@
 /**
  * @format
- * @flow
+ *
  */
 
 const InlineToolbarActions = {

--- a/src/block-management/inline-toolbar/button.js
+++ b/src/block-management/inline-toolbar/button.js
@@ -1,4 +1,4 @@
-/** @flow
+/**
  * @format */
 
 /**
@@ -17,13 +17,7 @@ import { Dashicon } from '@wordpress/components';
  */
 import styles from './style.scss';
 
-type PropsType = {
-	disabled: boolean,
-	icon: string,
-	onPress: () => void,
-};
-
-export default class InlineToolbarButton extends React.Component<PropsType> {
+export default class InlineToolbarButton extends React.Component {
 	static defaultProps = {
 		disabled: false,
 	};

--- a/src/block-management/inline-toolbar/index.js
+++ b/src/block-management/inline-toolbar/index.js
@@ -1,4 +1,4 @@
-/** @flow
+/**
  * @format */
 
 /**
@@ -22,21 +22,14 @@ import InlineToolbarActions from './actions';
 
 export { InlineToolbarActions };
 
-type PropsType = {
-	clientId: string,
-	canMoveUp: boolean,
-	canMoveDown: boolean,
-	onButtonPressed: ( button: number ) => void,
-};
-
-export default class InlineToolbar extends React.Component<PropsType> {
+export default class InlineToolbar extends React.Component {
 	constructor() {
 		super( ...arguments );
 		// Flow gets picky about reassigning methods on classes
 		// https://github.com/facebook/flow/issues/1517#issuecomment-194538151
-		( this: any ).onUpPressed = this.onUpPressed.bind( this );
-		( this: any ).onDownPressed = this.onDownPressed.bind( this );
-		( this: any ).onDeletePressed = this.onDeletePressed.bind( this );
+		this.onUpPressed = this.onUpPressed.bind( this );
+		this.onDownPressed = this.onDownPressed.bind( this );
+		this.onDeletePressed = this.onDeletePressed.bind( this );
 	}
 
 	onUpPressed() {

--- a/src/components/html-text-input-ui/html-text-input-ui.android.js
+++ b/src/components/html-text-input-ui/html-text-input-ui.android.js
@@ -1,6 +1,5 @@
 /**
  * @format
- * @flow
  */
 
 /**
@@ -15,17 +14,7 @@ import { ScrollView } from 'react-native';
 import styles from './html-text-input-ui.scss';
 import KeyboardAvoidingView from '../keyboard-avoiding-view';
 
-type PropsType = {
-	parentHeight: number,
-	children: React.Node,
-};
-
-type StateType = {
-};
-
-class HTMLInputContainer extends React.Component<PropsType, StateType> {
-	static scrollEnabled: boolean;
-
+class HTMLInputContainer extends React.Component {
 	render() {
 		return (
 			<KeyboardAvoidingView style={ styles.keyboardAvoidingView } parentHeight={ this.props.parentHeight }>

--- a/src/components/html-text-input-ui/html-text-input-ui.ios.js
+++ b/src/components/html-text-input-ui/html-text-input-ui.ios.js
@@ -1,6 +1,5 @@
 /**
  * @format
- * @flow
  */
 
 /**
@@ -15,18 +14,7 @@ import { UIManager, PanResponder } from 'react-native';
 import styles from './html-text-input-ui.scss';
 import KeyboardAvoidingView from '../keyboard-avoiding-view';
 
-type PropsType = {
-	parentHeight: number,
-	children: React.Node,
-};
-
-type StateType = {
-};
-
-class HTMLInputContainer extends React.Component<PropsType, StateType> {
-	static scrollEnabled: boolean;
-	panResponder: PanResponder;
-
+class HTMLInputContainer extends React.Component {
 	constructor() {
 		super( ...arguments );
 

--- a/src/components/html-text-input.js
+++ b/src/components/html-text-input.js
@@ -1,6 +1,5 @@
 /**
  * @format
- * @flow
  */
 /**
  * WordPress dependencies
@@ -22,24 +21,7 @@ import { TextInput } from 'react-native';
 import HTMLInputContainer from './html-text-input-ui/html-text-input-ui';
 import styles from './html-text-input-ui/html-text-input-ui.scss';
 
-type PropsType = {
-	onChange: string => mixed,
-	onPersist: string => mixed,
-	setTitleAction: string => void,
-	value: string,
-	title: string,
-	parentHeight: number,
-};
-
-type StateType = {
-	isDirty: boolean,
-	value: string,
-};
-
-export class HTMLInputView extends React.Component<PropsType, StateType> {
-	edit: string => mixed;
-	stopEditing: () => mixed;
-
+export class HTMLInputView extends React.Component {
 	constructor() {
 		super( ...arguments );
 
@@ -52,7 +34,7 @@ export class HTMLInputView extends React.Component<PropsType, StateType> {
 		};
 	}
 
-	static getDerivedStateFromProps( props: PropsType, state: StateType ) {
+	static getDerivedStateFromProps( props, state ) {
 		if ( state.isDirty ) {
 			return null;
 		}
@@ -68,7 +50,7 @@ export class HTMLInputView extends React.Component<PropsType, StateType> {
 		this.stopEditing();
 	}
 
-	edit( html: string ) {
+	edit( html ) {
 		this.props.onChange( html );
 		this.setState( { value: html, isDirty: true } );
 	}

--- a/src/components/keyboard-avoiding-view.android.js
+++ b/src/components/keyboard-avoiding-view.android.js
@@ -1,20 +1,14 @@
 /**
 * @format
-* @flow
 */
 
 /**
  * External dependencies
  */
 import React from 'react';
-import { View, KeyboardAvoidingView as AndroidKeyboardAvoidingView } from 'react-native';
+import { KeyboardAvoidingView as AndroidKeyboardAvoidingView } from 'react-native';
 
-type PropsType = {
-	...View.propTypes,
-	parentHeight: number;
-}
-
-const KeyboardAvoidingView = ( propsType: PropsType ) => {
+const KeyboardAvoidingView = ( propsType ) => {
 	const { ...props } = propsType;
 
 	return (

--- a/src/components/keyboard-avoiding-view.ios.js
+++ b/src/components/keyboard-avoiding-view.ios.js
@@ -1,20 +1,14 @@
 /**
 * @format
-* @flow
 */
 
 /**
  * External dependencies
  */
 import React from 'react';
-import { View, KeyboardAvoidingView as IOSKeyboardAvoidingView, Dimensions } from 'react-native';
+import { KeyboardAvoidingView as IOSKeyboardAvoidingView, Dimensions } from 'react-native';
 
-type PropsType = {
-	...View.propTypes,
-	parentHeight: number;
-}
-
-const KeyboardAvoidingView = ( propsType: PropsType ) => {
+const KeyboardAvoidingView = ( propsType ) => {
 	const { parentHeight, ...props } = propsType;
 	const { height: fullHeight } = Dimensions.get( 'window' );
 	const keyboardVerticalOffset = fullHeight - parentHeight;

--- a/src/components/keyboard-aware-flat-list.android.js
+++ b/src/components/keyboard-aware-flat-list.android.js
@@ -1,6 +1,5 @@
 /**
 * @format
-* @flow
 */
 
 /**
@@ -13,15 +12,7 @@ import { FlatList } from 'react-native';
  */
 import KeyboardAvoidingView from '../components/keyboard-avoiding-view';
 
-type PropsType = {
-	...FlatList.propTypes,
-	shouldPreventAutomaticScroll: void => boolean,
-	blockToolbarHeight: number,
-	innerToolbarHeight: number,
-	innerRef?: Function,
-}
-
-export const KeyboardAwareFlatList = ( props: PropsType ) => {
+export const KeyboardAwareFlatList = ( props ) => {
 	return (
 		<KeyboardAvoidingView style={ { flex: 1 } }>
 			<FlatList { ...props } />

--- a/src/components/keyboard-aware-flat-list.ios.js
+++ b/src/components/keyboard-aware-flat-list.ios.js
@@ -1,6 +1,5 @@
 /**
 * @format
-* @flow
 */
 
 /**
@@ -15,16 +14,7 @@ import { FlatList } from 'react-native';
  */
 import styles from '../block-management/block-holder.scss';
 
-type PropsType = {
-	...FlatList.propTypes,
-	shouldPreventAutomaticScroll: void => boolean,
-	blockToolbarHeight: number,
-	innerToolbarHeight: number,
-	safeAreaBottomInset: number,
-	innerRef?: Function,
-}
-
-export const KeyboardAwareFlatList = ( props: PropsType ) => {
+export const KeyboardAwareFlatList = ( props ) => {
 	const {
 		blockToolbarHeight,
 		innerToolbarHeight,
@@ -46,27 +36,27 @@ export const KeyboardAwareFlatList = ( props: PropsType ) => {
 			inputAccessoryViewHeight={ blockToolbarHeight }
 			extraHeight={ 0 }
 			innerRef={ ( ref ) => {
-				( this: any ).scrollViewRef = ref;
+				this.scrollViewRef = ref;
 				innerRef( ref );
 			} }
 			onKeyboardWillHide={ () => {
-				( this: any ).keyboardWillShowIndicator = false;
+				this.keyboardWillShowIndicator = false;
 			} }
 			onKeyboardDidHide={ () => {
 				setTimeout( () => {
-					if ( ! ( this: any ).keyboardWillShowIndicator &&
-						( this: any ).latestContentOffsetY !== undefined &&
+					if ( ! this.keyboardWillShowIndicator &&
+						this.latestContentOffsetY !== undefined &&
 						! shouldPreventAutomaticScroll() ) {
 						// Reset the content position if keyboard is still closed
-						( this: any ).scrollViewRef.props.scrollToPosition( 0, ( this: any ).latestContentOffsetY, true );
+						this.scrollViewRef.props.scrollToPosition( 0, this.latestContentOffsetY, true );
 					}
 				}, 50 );
 			} }
 			onKeyboardWillShow={ () => {
-				( this: any ).keyboardWillShowIndicator = true;
+				this.keyboardWillShowIndicator = true;
 			} }
-			onScroll={ ( event: Object ) => {
-				( this: any ).latestContentOffsetY = event.nativeEvent.contentOffset.y;
+			onScroll={ ( event ) => {
+				this.latestContentOffsetY = event.nativeEvent.contentOffset.y;
 			} } >
 			<FlatList { ...listProps } />
 		</KeyboardAwareScrollView>
@@ -74,10 +64,10 @@ export const KeyboardAwareFlatList = ( props: PropsType ) => {
 };
 
 export const handleCaretVerticalPositionChange = (
-	scrollView: Object,
-	targetId: number,
-	caretY: number,
-	previousCaretY: ?number ) => {
+	scrollView,
+	targetId,
+	caretY,
+	previousCaretY ) => {
 	if ( previousCaretY ) { //if this is not the first tap
 		scrollView.props.refreshScrollForField( targetId );
 	}

--- a/src/components/readable-content-view.js
+++ b/src/components/readable-content-view.js
@@ -1,6 +1,5 @@
 /**
  * @format
- * @flow
  */
 
 /**
@@ -14,11 +13,7 @@ import { View, Dimensions } from 'react-native';
  */
 import styles from './readable-content-view.scss';
 
-type PropsType = {
-	children?: React.Node,
-};
-
-const ReadableContentView = ( props: PropsType ) => {
+const ReadableContentView = ( props ) => {
 	return (
 		<View style={ styles.container } >
 			<View style={ styles.centeredContent } >
@@ -28,7 +23,7 @@ const ReadableContentView = ( props: PropsType ) => {
 	);
 };
 
-const isContentMaxWidth = (): boolean => {
+const isContentMaxWidth = () => {
 	const { width } = Dimensions.get( 'window' );
 	return width > styles.centeredContent.maxWidth;
 };


### PR DESCRIPTION
As a first step for #958, we're removing flow annotations from all the files that we will migrate to the Gutenberg repo and then port to the BlockList API.

See #789 for a preview of the changes

## To test

There are no code changes other than flow. App should run normally and tests should pass.