### PR TITLE
CircleCI: Limit max Jest and Flow workers to avoid memory errors

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -94,6 +94,8 @@ module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|we
 ; mock/ignore style files
 module.name_mapper='.*\(.scss\)' -> 'empty/object'
 
+server.max_workers=4
+
 suppress_type=$FlowIssue
 suppress_type=$FlowFixMe
 suppress_type=$FlowFixMeProps

--- a/bin/ci-checks-js.sh
+++ b/bin/ci-checks-js.sh
@@ -14,8 +14,8 @@ if [[ -z "${CHECK_CORRECTNESS}" ]] && [[ -z "${CHECK_TESTS}" ]] ; then
 fi
 
 if [ "$CHECK_CORRECTNESS" = true ] ; then
-  yarn run flow || pFail
-  yarn run lint || pFail
+  yarn flow || pFail
+  yarn lint || pFail
 fi
 
 if [ "$GUTENBERG_AS_PARENT" = true ] ; then
@@ -27,9 +27,9 @@ fi
 if [ "$CHECK_TESTS" = true ] ; then
   # we'll run the tests twich (once for each platform) if the platform env var is not set
   if [[ -z "${TEST_RN_PLATFORM}" ]] ; then
-    TEST_RN_PLATFORM=android yarn run ${TEST_SCRIPT_NAME} --maxWorkers=4 || pFail
-    TEST_RN_PLATFORM=ios yarn run ${TEST_SCRIPT_NAME} --maxWorkers=4 || pFail
+    TEST_RN_PLATFORM=android yarn ${TEST_SCRIPT_NAME} --maxWorkers=4 || pFail
+    TEST_RN_PLATFORM=ios yarn ${TEST_SCRIPT_NAME} --maxWorkers=4 || pFail
   else
-    yarn run ${TEST_SCRIPT_NAME} --maxWorkers=4 || pFail
+    yarn ${TEST_SCRIPT_NAME} --maxWorkers=4 || pFail
   fi
 fi

--- a/bin/ci-checks-js.sh
+++ b/bin/ci-checks-js.sh
@@ -14,8 +14,8 @@ if [[ -z "${CHECK_CORRECTNESS}" ]] && [[ -z "${CHECK_TESTS}" ]] ; then
 fi
 
 if [ "$CHECK_CORRECTNESS" = true ] ; then
-  npm run flow || pFail
-  npm run lint || pFail
+  yarn run flow || pFail
+  yarn run lint || pFail
 fi
 
 if [ "$GUTENBERG_AS_PARENT" = true ] ; then
@@ -27,9 +27,9 @@ fi
 if [ "$CHECK_TESTS" = true ] ; then
   # we'll run the tests twich (once for each platform) if the platform env var is not set
   if [[ -z "${TEST_RN_PLATFORM}" ]] ; then
-    TEST_RN_PLATFORM=android npm run ${TEST_SCRIPT_NAME} || pFail
-    TEST_RN_PLATFORM=ios npm run ${TEST_SCRIPT_NAME} || pFail
+    TEST_RN_PLATFORM=android yarn run ${TEST_SCRIPT_NAME} --maxWorkers=4 || pFail
+    TEST_RN_PLATFORM=ios yarn run ${TEST_SCRIPT_NAME} --maxWorkers=4 || pFail
   else
-    npm run ${TEST_SCRIPT_NAME} || pFail
+    yarn run ${TEST_SCRIPT_NAME} --maxWorkers=4 || pFail
   fi
 fi


### PR DESCRIPTION
Recently there have been a significant number of both jest and flow failures on CircleCI. This limits parallelization of both so that memory problems are avoided.

I have run this many times already, and it seems to be working reliably (see [here](https://circleci.com/gh/wordpress-mobile/gutenberg-mobile/tree/circleci-memory-issues)).

Related to https://github.com/facebook/flow/issues/6242