### PR TITLE
Use AztecAndroid's v1.3.27 tag

### DIFF
--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = 'gb-stray-selection-fix-try1'
+        aztecVersion = 'v1.3.27'
     }
 
     repositories {


### PR DESCRIPTION
We are already using the changes AztecAndroid v1.3.27 introduces (used here https://github.com/wordpress-mobile/gutenberg-mobile/pull/949) and this PR just updates the pointer to use a release tag.

This is a trivial, release process related PR so, will self-merge as soon as CI turns green.