### PR TITLE
Update Aztec-iOS to 1.6.3 in the demo app

### DIFF
--- a/react-native-aztec/ios/Cartfile
+++ b/react-native-aztec/ios/Cartfile
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.6.1"
+github "wordpress-mobile/AztecEditor-iOS" "1.6.3"

--- a/react-native-aztec/ios/Cartfile.resolved
+++ b/react-native-aztec/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.6.1"
+github "wordpress-mobile/AztecEditor-iOS" "1.6.3"


### PR DESCRIPTION
This brings the demo app dependency on Aztec to the latest release

List of changes: https://github.com/wordpress-mobile/AztecEditor-iOS/compare/1.6.1...1.6.3

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.