### PR TITLE
Fix crash occurring when we try to display block picker

### DIFF
--- a/src/block-management/block-picker.js
+++ b/src/block-management/block-picker.js
@@ -12,7 +12,7 @@ import { FlatList, Text, TouchableHighlight, View } from 'react-native';
 /**
  * WordPress dependencies
  */
-import { SVG } from '@wordpress/components';
+import { SVG, Dashicon } from '@wordpress/components';
 import { BottomSheet } from '@wordpress/block-editor';
 import { Component } from '@wordpress/element';
 import { getBlockTypes, getUnregisteredTypeHandlerName } from '@wordpress/blocks';
@@ -76,12 +76,18 @@ export default class BlockPicker extends Component<PropsType> {
 		);
 	}
 
-	iconWithUpdatedFillColor( color: string, icon: SVG ) {
-		return (
-			<SVG viewBox={ icon.src.props.viewBox } xmlns={ icon.src.props.xmlns } style={ { fill: color } }>
-				{ icon.src.props.children }
-			</SVG>
-		);
+	iconWithUpdatedFillColor( color: string, icon: Object ) {
+		if ( 'string' === typeof icon.src ) {
+			return (
+				<Dashicon icon={ icon.src } fill={ color } size={ styles.modalIcon.width } />
+			);
+		} else if ( icon.src && ( icon.src.type === 'svg' || icon.src.type === SVG ) ) {
+			return (
+				<SVG viewBox={ icon.src.props.viewBox } xmlns={ icon.src.props.xmlns } style={ { fill: color } }>
+					{ icon.src.props.children }
+				</SVG>
+			);
+		}
 	}
 
 	calculateNumberOfColumns() {


### PR DESCRIPTION
This crash occurs when we we try to show block picker. It is not yet on the develop branch but it will come in when we update the gutenberg ref to the latest master. This looks like a side effect of: https://github.com/WordPress/gutenberg/pull/15462/files

<img width="343" alt="Screen Shot 2019-05-17 at 20 03 20" src="https://user-images.githubusercontent.com/5032900/57947997-2aa9e080-78e9-11e9-9545-309b1d6fd003.png">


To test:

- Tap on (+) and display the block picker
- Verify it doesn't crash
- Verify Heading block has a new icon

![Simulator Screen Shot - iPhone X - 2019-05-17 at 21 15 52](https://user-images.githubusercontent.com/5032900/57947968-0948f480-78e9-11e9-94de-b75621008f55.png)

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
