### PR TITLE
Re-load the ReactVideoPackage that got removed by #821

### DIFF
--- a/android/app/src/main/java/com/gutenberg/MainApplication.java
+++ b/android/app/src/main/java/com/gutenberg/MainApplication.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.util.Log;
 
 import com.facebook.react.ReactApplication;
+import com.brentvatne.react.ReactVideoPackage;
 import com.facebook.react.devsupport.interfaces.DevOptionHandler;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.horcrux.svg.SvgPackage;
@@ -100,6 +101,7 @@ public class MainApplication extends Application implements ReactApplication {
             protected List<ReactPackage> getPackages() {
                 return Arrays.asList(
                         new MainReactPackage(),
+                        new ReactVideoPackage(),
                         new SvgPackage(),
                         new ReactAztecPackage(),
                         new RNRecyclerviewListPackage(),


### PR DESCRIPTION
Fixes #1015 

To test:
Run the demo app on Android. It should normally load without a red screen.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
