### PR TITLE
UI for invalid block content

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,2 +1,3 @@
 1.6.0
 ------
+* Added UI to display a warning when a block has invalid content.

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -27,7 +27,7 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { addAction, hasAction, removeAction } from '@wordpress/hooks';
 import { getBlockType } from '@wordpress/blocks';
-import { BlockEdit } from '@wordpress/block-editor';
+import { BlockEdit, BlockInvalidWarning } from '@wordpress/block-editor';
 import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -197,7 +197,7 @@ export class BlockHolder extends React.Component<PropsType, StateType> {
 						style={ [ ! isSelected && styles.blockContainer, isSelected && styles.blockContainerFocused ] }>
 							{ isValid && this.getBlockForType() }
 							{ ! isValid &&
-								<Text>ERROR</Text>
+								<BlockInvalidWarning />
 							}
 					</View>
 					{ this.renderToolbar() }

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -175,11 +175,13 @@ export class BlockHolder extends React.Component<PropsType, StateType> {
 	}
 
 	render() {
-		const { isSelected, borderStyle, focusedBorderColor, isValid } = this.props;
+		const { isSelected, borderStyle, focusedBorderColor, isValid, name } = this.props;
 
 		const borderColor = isSelected ? focusedBorderColor : 'transparent';
 
 		const accessibilityLabel = this.getAccessibilityLabelForBlock();
+		const blockType = getBlockType( name );
+		const title = getBlockType( name ).title;
 
 		return (
 			// accessible prop needs to be false to access children
@@ -197,7 +199,7 @@ export class BlockHolder extends React.Component<PropsType, StateType> {
 						style={ [ ! isSelected && styles.blockContainer, isSelected && styles.blockContainerFocused ] }>
 							{ isValid && this.getBlockForType() }
 							{ ! isValid &&
-								<BlockInvalidWarning />
+								<BlockInvalidWarning title={ blockType.title } icon={ blockType.icon } />
 							}
 					</View>
 					{ this.renderToolbar() }

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -194,11 +194,12 @@ export class BlockHolder extends React.Component<PropsType, StateType> {
 					<View
 						accessibile={ true }
 						accessibilityLabel={ accessibilityLabel }
-						style={ [ ! isSelected && styles.blockContainer, isSelected && styles.blockContainerFocused ] }>
-							{ isValid && this.getBlockForType() }
-							{ ! isValid &&
-								<BlockInvalidWarning blockTitle={ blockType.title } icon={ blockType.icon } />
-							}
+						style={ [ ! isSelected && styles.blockContainer, isSelected && styles.blockContainerFocused ] }
+					>
+						{ isValid && this.getBlockForType() }
+						{ ! isValid &&
+							<BlockInvalidWarning blockTitle={ blockType.title } icon={ blockType.icon } />
+						}
 					</View>
 					{ this.renderToolbar() }
 				</View>
@@ -211,7 +212,6 @@ export class BlockHolder extends React.Component<PropsType, StateType> {
 export default compose( [
 	withSelect( ( select, { clientId, rootClientId } ) => {
 		const {
-			// getBlockAttributes,
 			getBlockName,
 			getBlockIndex,
 			getBlocks,
@@ -220,8 +220,6 @@ export default compose( [
 			isBlockSelected,
 			__unstableGetBlockWithoutInnerBlocks,
 		} = select( 'core/block-editor' );
-		// const name = getBlockName( clientId );
-		// const attributes = getBlockAttributes( clientId );
 		const order = getBlockIndex( clientId, rootClientId );
 		const isSelected = isBlockSelected( clientId );
 		const isFirstBlock = order === 0;

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -175,7 +175,7 @@ export class BlockHolder extends React.Component<PropsType, StateType> {
 	}
 
 	render() {
-		const { isSelected, borderStyle, focusedBorderColor } = this.props;
+		const { isSelected, borderStyle, focusedBorderColor, isValid } = this.props;
 
 		const borderColor = isSelected ? focusedBorderColor : 'transparent';
 
@@ -186,15 +186,19 @@ export class BlockHolder extends React.Component<PropsType, StateType> {
 			// https://facebook.github.io/react-native/docs/accessibility#accessible-ios-android
 			<TouchableWithoutFeedback
 				accessible={ false }
-				onPress={ this.onFocus } >
-
+				onPress={ this.onFocus }
+			>
+					
 				<View style={ [ styles.blockHolder, borderStyle, { borderColor } ] }>
 					{ this.props.showTitle && this.renderBlockTitle() }
 					<View
 						accessibile={ true }
 						accessibilityLabel={ accessibilityLabel }
 						style={ [ ! isSelected && styles.blockContainer, isSelected && styles.blockContainerFocused ] }>
-						{ this.getBlockForType() }
+							{ isValid && this.getBlockForType() }
+							{ ! isValid &&
+								<Text>ERROR</Text>
+							}
 					</View>
 					{ this.renderToolbar() }
 				</View>
@@ -207,20 +211,23 @@ export class BlockHolder extends React.Component<PropsType, StateType> {
 export default compose( [
 	withSelect( ( select, { clientId, rootClientId } ) => {
 		const {
-			getBlockAttributes,
+			// getBlockAttributes,
 			getBlockName,
 			getBlockIndex,
 			getBlocks,
 			getPreviousBlockClientId,
 			getNextBlockClientId,
 			isBlockSelected,
+			__unstableGetBlockWithoutInnerBlocks,
 		} = select( 'core/block-editor' );
-		const name = getBlockName( clientId );
-		const attributes = getBlockAttributes( clientId );
+		// const name = getBlockName( clientId );
+		// const attributes = getBlockAttributes( clientId );
 		const order = getBlockIndex( clientId, rootClientId );
 		const isSelected = isBlockSelected( clientId );
 		const isFirstBlock = order === 0;
 		const isLastBlock = order === getBlocks().length - 1;
+		const block = __unstableGetBlockWithoutInnerBlocks( clientId );
+		const { name, attributes, isValid } = block || {};
 
 		return {
 			attributes,
@@ -232,6 +239,7 @@ export default compose( [
 			isLastBlock,
 			isSelected,
 			name,
+			isValid,
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId, rootClientId }, { select } ) => {

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -188,7 +188,7 @@ export class BlockHolder extends React.Component<PropsType, StateType> {
 				accessible={ false }
 				onPress={ this.onFocus }
 			>
-					
+
 				<View style={ [ styles.blockHolder, borderStyle, { borderColor } ] }>
 					{ this.props.showTitle && this.renderBlockTitle() }
 					<View

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -178,10 +178,8 @@ export class BlockHolder extends React.Component<PropsType, StateType> {
 		const { isSelected, borderStyle, focusedBorderColor, isValid, name } = this.props;
 
 		const borderColor = isSelected ? focusedBorderColor : 'transparent';
-
 		const accessibilityLabel = this.getAccessibilityLabelForBlock();
 		const blockType = getBlockType( name );
-		const title = getBlockType( name ).title;
 
 		return (
 			// accessible prop needs to be false to access children
@@ -199,7 +197,7 @@ export class BlockHolder extends React.Component<PropsType, StateType> {
 						style={ [ ! isSelected && styles.blockContainer, isSelected && styles.blockContainerFocused ] }>
 							{ isValid && this.getBlockForType() }
 							{ ! isValid &&
-								<BlockInvalidWarning title={ blockType.title } icon={ blockType.icon } />
+								<BlockInvalidWarning blockTitle={ blockType.title } icon={ blockType.icon } />
 							}
 					</View>
 					{ this.renderToolbar() }


### PR DESCRIPTION
Fixes #969 

This PR implements `BlockInvalidWarning` on `BlockHolder` to show a warning UI when the block content is invalid.

`gutenberg` side PR: https://github.com/WordPress/gutenberg/pull/15789

![IMG_1853](https://user-images.githubusercontent.com/9772967/58235425-16c70a00-7d41-11e9-88d8-08de70b61d7d.png)

To test:
- Run the example app.
- Display on gutenberg the HTML content from [here](https://gist.github.com/etoledom/a47cfe010a0f5c9f410d5c226b1560b3)
- You will see a red screen (since there is invalid content).
- Dismiss the red screen.
- Check that the invalid content UI is showing for all blocks. 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
