### PR TITLE
List end test

### DIFF
--- a/__device-tests__/gutenberg-editor-lists-end.test.js
+++ b/__device-tests__/gutenberg-editor-lists-end.test.js
@@ -1,0 +1,60 @@
+/**
+ * @format
+ * */
+
+/**
+ * Internal dependencies
+ */
+import EditorPage from './pages/editor-page';
+import {
+	setupDriver,
+	isLocalEnvironment,
+	stopDriver } from './helpers/utils';
+import testData from './helpers/test-data';
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 240000;
+
+describe( 'Gutenberg Editor tests', () => {
+	let driver;
+	let editorPage;
+	let allPassed = true;
+
+	// Use reporter for setting status for saucelabs Job
+	if ( ! isLocalEnvironment() ) {
+		const reporter = {
+			specDone: async ( result ) => {
+				allPassed = allPassed && result.status !== 'failed';
+			},
+		};
+
+		jasmine.getEnv().addReporter( reporter );
+	}
+
+	beforeAll( async () => {
+		driver = await setupDriver();
+		editorPage = new EditorPage( driver );
+	} );
+
+	it( 'should be able to end a List block', async () => {
+		await editorPage.addNewListBlock();
+		const listBlockElement = await editorPage.getListBlockAtPosition( 1 );
+
+		// Send the first list item text
+		await editorPage.sendTextToListBlock( listBlockElement, testData.listItem1 );
+
+		// send an Enter
+		await editorPage.sendTextToParagraphBlock( listBlockElement, '\n' );
+
+		// send an Enter
+		await editorPage.sendTextToParagraphBlock( listBlockElement, '\n' );
+
+		await editorPage.verifyHtmlContent( testData.listEndedHtml );
+	} );
+
+	afterAll( async () => {
+		if ( ! isLocalEnvironment() ) {
+			driver.sauceJobStatus( allPassed );
+		}
+		await stopDriver( driver );
+	} );
+} );

--- a/__device-tests__/gutenberg-editor-lists.test.js
+++ b/__device-tests__/gutenberg-editor-lists.test.js
@@ -3,11 +3,6 @@
  * */
 
 /**
- * External dependencies
- */
-import { Platform } from 'react-native';
-
-/**
  * Internal dependencies
  */
 import EditorPage from './pages/editor-page';
@@ -57,12 +52,8 @@ describe( 'Gutenberg Editor tests', () => {
 		// Send the second list item text
 		await editorPage.sendTextToListBlock( listBlockElement, testData.listItem2 );
 
-		if ( Platform.OS === 'android' ) {
-			// switch to html and verify html
-			await editorPage.verifyHtmlContent( testData.listHtml );
-		} else {
-			// TODO: implement html verification on iOS too
-		}
+		// switch to html and verify html
+		await editorPage.verifyHtmlContent( testData.listHtml );
 	} );
 
 	afterAll( async () => {

--- a/__device-tests__/helpers/test-data.js
+++ b/__device-tests__/helpers/test-data.js
@@ -10,3 +10,10 @@ exports.listItem2 = `Honey`;
 exports.listHtml = `<!-- wp:list -->
 <ul><li>Milk</li><li>Honey</li></ul>
 <!-- /wp:list -->`;
+exports.listEndedHtml = `<!-- wp:list -->
+<ul><li>Milk</li></ul>
+<!-- /wp:list -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->`;

--- a/__device-tests__/pages/editor-page.js
+++ b/__device-tests__/pages/editor-page.js
@@ -6,6 +6,7 @@
  * External dependencies
  */
 import wd from 'wd';
+import { Platform } from 'react-native';
 
 /**
  * WordPress dependencies
@@ -269,6 +270,14 @@ export default class EditorPage {
 	}
 
 	async verifyHtmlContent( html: string ) {
+		if ( Platform.OS === 'android' ) {
+			await this.verifyHtmlContentAndroid( html );
+		} else {
+			// TODO: implement html verification on iOS too
+		}
+	}
+
+	async verifyHtmlContentAndroid( html: string ) {
 		await toggleHtmlMode( this.driver );
 
 		const htmlContentView = await this.getTextViewForHtmlViewContent();


### PR DESCRIPTION
This PR adds an Appium test for testing the list block ending when inputting an "Enter" at an empty list item where the expectation is that that block should "end" and a new empty paragraph should be created underneath it.

### Things to note

1. The test only really tests the Android side of things as on the iOS we're still missing an implementation of the html check step. See https://github.com/wordpress-mobile/gutenberg-mobile/blob/876ebe714219f4f0ba3ab23e82e535747db041e6/__device-tests__/pages/editor-page.js#L272-L278
2. The new test is added in a _new_ testsuite module (a file separate to the other list test module) because we currently don't have a good way to clean up the state and blocks before starting the next test case. With a separate testsuite, the whole editor is cleaned up by tearing it down and re-starting it. cc @JavonDavis since you've extensively worked on the Appium tests and you might have some ideas and insights on this.

To test:

* Let the CI makes its pass and observe the SauceLabs output to verify that the list ending test runs fine. Edit: the CI run has finished for Android and here's a quick link to the video if the test: https://app.saucelabs.com/tests/340a973602ff40a28c39bd6462e9b778?auth=230dbdb64a11ce68fe91a0d14877cd11

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
