### PR TITLE
Follow web side's lead to add `indexToSelect` to onReplace

### DIFF
--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -283,8 +283,8 @@ export default compose( [
 			onChange: ( attributes: Object ) => {
 				updateBlockAttributes( clientId, attributes );
 			},
-			onReplace( blocks: Array<Object> ) {
-				replaceBlocks( [ clientId ], blocks );
+			onReplace( blocks: Array<Object>, indexToSelect: number ) {
+				replaceBlocks( [ clientId ], blocks, indexToSelect );
 			},
 		};
 	} ),


### PR DESCRIPTION
Fixes #1023 

This PR updates the `onReplace` dispatcher call to pass `indexToSelect` to it.

Relevant change on the web side:
https://github.com/wordpress/gutenberg/commit/eddd4fcd30f6a4ac8ce221888a8bcde397158476#diff-86ce6d1930888d88a252e7d2ee38334aR712 from the [RichText: stabilize onSplit](https://github.com/WordPress/gutenberg/pull/14765) PR.

To test:
1. Place the caret at the end of a middle item on the list of the demo content
2. Tap an "Enter" to create a new list item
3. Tap "Enter" again to split the list
4. A new paragraph block should be created in-between the split list and the caret placed in it

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
