### PR TITLE
Update default versions used in CI

### DIFF
--- a/__device-tests__/helpers/caps.js
+++ b/__device-tests__/helpers/caps.js
@@ -6,7 +6,7 @@ exports.ios12 = {
 	os: 'iOS',
 	deviceOrientation: 'portrait',
 	automationName: 'XCUITest',
-	appiumVersion: '1.9.1', // SauceLabs requires appiumVersion to be specified.
+	appiumVersion: '1.13.0', // SauceLabs requires appiumVersion to be specified.
 	app: undefined, // will be set later, locally this is relative to root of project
 };
 
@@ -20,6 +20,6 @@ exports.android8 = {
 	appPackage: 'com.gutenberg',
 	appActivity: 'com.gutenberg.MainActivity',
 	deviceOrientation: 'portrait',
-	appiumVersion: '1.9.1',
+	appiumVersion: '1.13.0',
 	app: undefined,
 };

--- a/__device-tests__/helpers/caps.js
+++ b/__device-tests__/helpers/caps.js
@@ -1,7 +1,7 @@
 exports.ios12 = {
 	browserName: '',
 	platformName: 'iOS',
-	platformVersion: '12.0',
+	platformVersion: '12.2',
 	deviceName: 'iPhone Simulator',
 	os: 'iOS',
 	deviceOrientation: 'portrait',


### PR DESCRIPTION
Updates default platform version and appium version used in CI

To test:

Checking that the tests pass in CI is enough. 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
