### PR TITLE
Fix link "open in new tab" switch

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,2 +1,3 @@
 1.6.0
 ------
+* Fixed issue with link settings where “Open in New Tab” was always OFF on open.


### PR DESCRIPTION
This PR updates the gutenberg ref to test https://github.com/WordPress/gutenberg/pull/15812

It fixes the "Open in New Tab" option for links in gutenberg-mobile, where the switch started always off, even a link target was set.

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1018

![link-switch](https://user-images.githubusercontent.com/9772967/58329926-0f355d00-7e36-11e9-9dc3-d75a3a6cfd45.gif)

**To test:**
Please refer to https://github.com/WordPress/gutenberg/pull/15812 for testing steps.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.