### PR TITLE
Update Aztec version to 1.6.5

### DIFF
--- a/react-native-aztec/ios/Cartfile
+++ b/react-native-aztec/ios/Cartfile
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.6.4"
+github "wordpress-mobile/AztecEditor-iOS" "1.6.5"

--- a/react-native-aztec/ios/Cartfile.resolved
+++ b/react-native-aztec/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.6.4"
+github "wordpress-mobile/AztecEditor-iOS" "1.6.5"


### PR DESCRIPTION
Fixes #938 

This updates the current version of Aztec to 1.6.5. 
The main benefit of this version is to get copy/paste working across text blocks and copy/paste to external apps.

To test:

 - Start the demo app in iOS
 - Copy a bit of text from one block
 - Paste it on another block
 - Paste to another app in the system ( Notes app or Reminders)
 - See if the plain text is copied.
Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
