### PR TITLE
Focus blocks on Android Device Tests

### DIFF
--- a/__device-tests__/gutenberg-editor-lists-end.test.js
+++ b/__device-tests__/gutenberg-editor-lists-end.test.js
@@ -9,7 +9,9 @@ import EditorPage from './pages/editor-page';
 import {
 	setupDriver,
 	isLocalEnvironment,
-	stopDriver } from './helpers/utils';
+	stopDriver,
+	isAndroid,
+} from './helpers/utils';
 import testData from './helpers/test-data';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 240000;
@@ -35,18 +37,27 @@ describe( 'Gutenberg Editor tests', () => {
 		editorPage = new EditorPage( driver );
 	} );
 
+	it( 'should be able to see visual editor', async () => {
+		await expect( editorPage.getBlockList() ).resolves.toBe( true );
+	} );
+
 	it( 'should be able to end a List block', async () => {
 		await editorPage.addNewListBlock();
 		const listBlockElement = await editorPage.getListBlockAtPosition( 1 );
+
+		// Click List block on Android to force EditText focus
+		if ( isAndroid() ) {
+			await listBlockElement.click();
+		}
 
 		// Send the first list item text
 		await editorPage.sendTextToListBlock( listBlockElement, testData.listItem1 );
 
 		// send an Enter
-		await editorPage.sendTextToParagraphBlock( listBlockElement, '\n' );
+		await editorPage.sendTextToListBlock( listBlockElement, '\n' );
 
 		// send an Enter
-		await editorPage.sendTextToParagraphBlock( listBlockElement, '\n' );
+		await editorPage.sendTextToListBlock( listBlockElement, '\n' );
 
 		await editorPage.verifyHtmlContent( testData.listEndedHtml );
 	} );

--- a/__device-tests__/gutenberg-editor-lists.test.js
+++ b/__device-tests__/gutenberg-editor-lists.test.js
@@ -9,7 +9,9 @@ import EditorPage from './pages/editor-page';
 import {
 	setupDriver,
 	isLocalEnvironment,
-	stopDriver } from './helpers/utils';
+	stopDriver,
+	isAndroid,
+} from './helpers/utils';
 import testData from './helpers/test-data';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 240000;
@@ -43,11 +45,16 @@ describe( 'Gutenberg Editor tests', () => {
 		await editorPage.addNewListBlock();
 		const listBlockElement = await editorPage.getListBlockAtPosition( 1 );
 
+		// Click List block on Android to force EditText focus
+		if ( isAndroid() ) {
+			await listBlockElement.click();
+		}
+
 		// Send the first list item text
 		await editorPage.sendTextToListBlock( listBlockElement, testData.listItem1 );
 
 		// send an Enter
-		await editorPage.sendTextToParagraphBlock( listBlockElement, '\n' );
+		await editorPage.sendTextToListBlock( listBlockElement, '\n' );
 
 		// Send the second list item text
 		await editorPage.sendTextToListBlock( listBlockElement, testData.listItem2 );

--- a/__device-tests__/gutenberg-editor.test.js
+++ b/__device-tests__/gutenberg-editor.test.js
@@ -11,7 +11,9 @@ import {
 	isLocalEnvironment,
 	clickMiddleOfElement,
 	clickBeginningOfElement,
-	stopDriver } from './helpers/utils';
+	stopDriver,
+	isAndroid,
+} from './helpers/utils';
 import testData from './helpers/test-data';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 240000;
@@ -44,6 +46,9 @@ describe( 'Gutenberg Editor tests', () => {
 	it( 'should be able to add a new Paragraph block', async () => {
 		await editorPage.addNewParagraphBlock();
 		const paragraphBlockElement = await editorPage.getParagraphBlockAtPosition( 1 );
+		if ( isAndroid() ) {
+			await paragraphBlockElement.click();
+		}
 		await editorPage.sendTextToParagraphBlock( paragraphBlockElement, testData.shortText );
 		await editorPage.removeParagraphBlockAtPosition( 1 );
 	} );
@@ -51,6 +56,9 @@ describe( 'Gutenberg Editor tests', () => {
 	it( 'should be able to split one paragraph block into two', async () => {
 		await editorPage.addNewParagraphBlock();
 		const paragraphBlockElement = await editorPage.getParagraphBlockAtPosition( 1 );
+		if ( isAndroid() ) {
+			await paragraphBlockElement.click();
+		}
 		await editorPage.sendTextToParagraphBlock( paragraphBlockElement, testData.shortText );
 		const textViewElement = await editorPage.getTextViewForParagraphBlock( paragraphBlockElement );
 		await clickMiddleOfElement( driver, textViewElement );
@@ -71,6 +79,9 @@ describe( 'Gutenberg Editor tests', () => {
 	it( 'should be able to merge 2 paragraph blocks into 1', async () => {
 		await editorPage.addNewParagraphBlock();
 		let paragraphBlockElement = await editorPage.getParagraphBlockAtPosition( 1 );
+		if ( isAndroid() ) {
+			await paragraphBlockElement.click();
+		}
 		await editorPage.sendTextToParagraphBlock( paragraphBlockElement, testData.shortText );
 		let textViewElement = await editorPage.getTextViewForParagraphBlock( paragraphBlockElement );
 		await clickMiddleOfElement( driver, textViewElement );
@@ -81,6 +92,9 @@ describe( 'Gutenberg Editor tests', () => {
 		const text0 = await editorPage.getTextForParagraphBlockAtPosition( 1 );
 		const text1 = await editorPage.getTextForParagraphBlockAtPosition( 2 );
 		paragraphBlockElement = await editorPage.getParagraphBlockAtPosition( 2 );
+		if ( isAndroid() ) {
+			await paragraphBlockElement.click();
+		}
 		textViewElement = await editorPage.getTextViewForParagraphBlock( paragraphBlockElement );
 		await clickBeginningOfElement( driver, textViewElement );
 		await editorPage.sendTextToParagraphBlock( paragraphBlockElement, '\u0008' );
@@ -94,6 +108,10 @@ describe( 'Gutenberg Editor tests', () => {
 
 	it( 'should be able to create a post with multiple paragraph blocks', async () => {
 		await editorPage.addNewParagraphBlock();
+		const paragraphBlockElement = await editorPage.getParagraphBlockAtPosition( 1 );
+		if ( isAndroid() ) {
+			await paragraphBlockElement.click();
+		}
 		await editorPage.sendTextToParagraphBlockAtPosition( 1, testData.longText );
 
 		for ( let i = 4; i > 0; i-- ) {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "test:inside-gb": "cross-env NODE_ENV=test jest --verbose --config jest_gb.config.js",
     "test:debug": "cross-env NODE_ENV=test node --inspect-brk jest --runInBand --verbose --config jest.config.js",
     "device-tests": "cross-env NODE_ENV=test jest --runInBand --reporters=default --reporters=jest-junit --detectOpenHandles --verbose --config jest_ui.config.js",
-    "device-tests:debug": "cross-env NODE_ENV=test node --inspect-brk node_modules/jest/bin/jest --runInBand --reporters=default --reporters=jest-junit --detectOpenHandles --verbose --config jest_ui.config.js",
+    "device-tests:debug": "cross-env NODE_ENV=test node $NODE_DEBUG_OPTION --inspect-brk node_modules/jest/bin/jest --runInBand --reporters=default --reporters=jest-junit --detectOpenHandles --verbose --config jest_ui.config.js",
     "test:e2e": "yarn test:e2e:android && yarn test:e2e:ios",
     "test:e2e:android": "TEST_RN_PLATFORM=android yarn device-tests",
     "test:e2e:android:debug": "TEST_RN_PLATFORM=android yarn device-tests:debug",


### PR DESCRIPTION
This PR adds code to focus on blocks before sending text to them on Android. In some cases, if this wasn't done the text would be sent to the wrong block. 

To test:
* Ensure all tests pass locally and in CI 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
