### PR TITLE
Focus the right RichText

### DIFF
--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -123,9 +123,6 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 			const insertionIndex = indexAfterSelected || this.props.blockCount;
 			this.props.insertBlock( newBlock, insertionIndex );
 		}
-
-		// now set the focus
-		this.props.selectBlock( newBlock.clientId );
 	}
 
 	onSafeAreaInsetsUpdate( result: Object ) {

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -44,7 +44,6 @@ type PropsType = {
 	blockCount: number,
 	clearSelectedBlock: () => void,
 	focusBlock: ( clientId: string ) => void,
-	selectBlock: ( clientId: string ) => void,
 	insertBlock: ( block: BlockType, position: number ) => void,
 	replaceBlock: ( string, BlockType ) => mixed,
 	getBlockName: string => string,
@@ -380,14 +379,12 @@ export default compose( [
 		const {
 			insertBlock,
 			replaceBlock,
-			selectBlock,
 			clearSelectedBlock,
 		} = dispatch( 'core/block-editor' );
 
 		return {
 			clearSelectedBlock,
 			insertBlock,
-			selectBlock,
 			replaceBlock,
 		};
 	} ),


### PR DESCRIPTION
Fixes #1042 

Gutenberg PR: https://github.com/WordPress/gutenberg/pull/15878

This PR adjusts the logic to be closer to the web's side of how/when a block gets selected when newly created.

It contains two changes:
1. When a block gets created from the Inserter, we now let the global selection logic to take over trying to focus the new block, based on the updated selection state (wrangled on the web side). cd47572 has that change.
2. Resolve the race condition where `RichText`s in blocks with multiple RichText components would compete in getting the focus. On the web, the equivalent to our BlockHolder actively tries to focus one of the inputboxes (see [here]( https://github.com/WordPress/gutenberg/blob/cb127c93baa22222d9c31eac8ea25efec8ac6cba/packages/block-editor/src/components/block-list/block.js#L230-L235)) but on the mobile side we don't have the DOM to do that. Instead, the solution introduced with the https://github.com/WordPress/gutenberg/pull/15878 is to pass a flag to any RichText we don't want to gain focus on mount. That includes for example the citation RichText in Quotes and the caption RichText in Images.

To test:
1. Run the demo app (ideally on both Android and iOS)
2. Add a Quote block and notice the caret correctly landing in the first input box of the Quote block
4. Add a list block and notice the caret landing in it
5. Split a paragraph block and notice the caret landing in the beginning of the new block

Known issues: On Android, https://github.com/wordpress-mobile/gutenberg-mobile/issues/1029 still holds, where the virtual keyboard doesn't automatically come up on block focus.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
