### PR TITLE
Update Aztec reference.

### DIFF
--- a/react-native-aztec/ios/Cartfile
+++ b/react-native-aztec/ios/Cartfile
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "06f3b1493ceddc657782849f9c7911f9b3ce2101"
+github "wordpress-mobile/AztecEditor-iOS" "1.6.6"

--- a/react-native-aztec/ios/Cartfile
+++ b/react-native-aztec/ios/Cartfile
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.6.5"
+github "wordpress-mobile/AztecEditor-iOS" "06f3b1493ceddc657782849f9c7911f9b3ce2101"

--- a/react-native-aztec/ios/Cartfile.resolved
+++ b/react-native-aztec/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "06f3b1493ceddc657782849f9c7911f9b3ce2101"
+github "wordpress-mobile/AztecEditor-iOS" "1.6.6"

--- a/react-native-aztec/ios/Cartfile.resolved
+++ b/react-native-aztec/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.6.5"
+github "wordpress-mobile/AztecEditor-iOS" "06f3b1493ceddc657782849f9c7911f9b3ce2101"


### PR DESCRIPTION
Fixes #1044 

This PR simply updates the Aztec reference in order to have support for copy/cut paste of HTML in the editor

To test:
 - Start the demo app
 - Copy paste text from one block that has formatting active: for example bold italic
 - Paste it to another block
 - See if formatting went across
 - Copy a list element
 - Paste it in a new block
 - Copy a heading
 - Paste it to a new block.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
