### PR TITLE
FIX NPE in WPAndroidGlue while setting Auth header

### DIFF
--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/OkHttpHeaderInterceptor.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/OkHttpHeaderInterceptor.java
@@ -6,12 +6,12 @@ import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnAuthHeaderRequeste
 
 import java.io.IOException;
 
+import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
 
 public class OkHttpHeaderInterceptor implements Interceptor {
-
     private static final String AUTHORIZATION_HEADER_KEY = "Authorization";
 
     private OnAuthHeaderRequestedListener mOnAuthHeaderRequestedListener;
@@ -23,13 +23,16 @@ public class OkHttpHeaderInterceptor implements Interceptor {
     @Override
     public Response intercept(Chain chain) throws IOException {
         Request.Builder builder = chain.request().newBuilder();
+        final HttpUrl httpUrl = chain.request().url();
+        // This should not be necessary here, but https://github.com/wordpress-mobile/WordPress-Android/issues/9833
+        // does seem to show that a null value is returned
+        String urlString = httpUrl != null && httpUrl.toString() != null ? httpUrl.toString() : "";
 
-        String authHeader = mOnAuthHeaderRequestedListener.onAuthHeaderRequested(chain.request().url().toString());
+        String authHeader = mOnAuthHeaderRequestedListener.onAuthHeaderRequested(urlString);
         if (!TextUtils.isEmpty(authHeader)) {
             builder.addHeader(AUTHORIZATION_HEADER_KEY, authHeader);
         }
 
         return chain.proceed(builder.build());
     }
-
 }

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/OkHttpHeaderInterceptor.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/OkHttpHeaderInterceptor.java
@@ -11,7 +11,6 @@ import okhttp3.Request;
 import okhttp3.Response;
 
 public class OkHttpHeaderInterceptor implements Interceptor {
-
     private static final String AUTHORIZATION_HEADER_KEY = "Authorization";
 
     private OnAuthHeaderRequestedListener mOnAuthHeaderRequestedListener;
@@ -24,12 +23,12 @@ public class OkHttpHeaderInterceptor implements Interceptor {
     public Response intercept(Chain chain) throws IOException {
         Request.Builder builder = chain.request().newBuilder();
 
-        String authHeader = mOnAuthHeaderRequestedListener.onAuthHeaderRequested(chain.request().url().toString());
+        String authHeader = mOnAuthHeaderRequestedListener != null
+                ? mOnAuthHeaderRequestedListener.onAuthHeaderRequested(chain.request().url().toString()) : null;
         if (!TextUtils.isEmpty(authHeader)) {
             builder.addHeader(AUTHORIZATION_HEADER_KEY, authHeader);
         }
 
         return chain.proceed(builder.build());
     }
-
 }

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/OkHttpHeaderInterceptor.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/OkHttpHeaderInterceptor.java
@@ -6,12 +6,12 @@ import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnAuthHeaderRequeste
 
 import java.io.IOException;
 
-import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
 
 public class OkHttpHeaderInterceptor implements Interceptor {
+
     private static final String AUTHORIZATION_HEADER_KEY = "Authorization";
 
     private OnAuthHeaderRequestedListener mOnAuthHeaderRequestedListener;
@@ -23,16 +23,13 @@ public class OkHttpHeaderInterceptor implements Interceptor {
     @Override
     public Response intercept(Chain chain) throws IOException {
         Request.Builder builder = chain.request().newBuilder();
-        final HttpUrl httpUrl = chain.request().url();
-        // This should not be necessary here, but https://github.com/wordpress-mobile/WordPress-Android/issues/9833
-        // does seem to show that a null value is returned
-        String urlString = httpUrl != null && httpUrl.toString() != null ? httpUrl.toString() : "";
 
-        String authHeader = mOnAuthHeaderRequestedListener.onAuthHeaderRequested(urlString);
+        String authHeader = mOnAuthHeaderRequestedListener.onAuthHeaderRequested(chain.request().url().toString());
         if (!TextUtils.isEmpty(authHeader)) {
             builder.addHeader(AUTHORIZATION_HEADER_KEY, authHeader);
         }
 
         return chain.proceed(builder.build());
     }
+
 }


### PR DESCRIPTION
This PR fixes https://github.com/wordpress-mobile/WordPress-Android/issues/9833 by making sure the Auth header requested listener is not null before using it. As described in this comment [here](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1056#issuecomment-498183372) the auth header requested listener is unset on exit of the editor, but the network queue is still filled with "old" pictures request. When the queue process those pictures the listener previously unset is invoked leading to the crash.

To test:

- Load a post with lot of pictures
- Exit the editor asap
- Wait until all the request end and no crash


Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
