### PR TITLE
Avoid sending onEnter when AztecView is not focused.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.7.0
+------
+* Fixed keyboard flickering issue after pressing Enter repeatedly on the Post Title.
+
 1.6.0
 ------
 * Fixed issue with link settings where “Open in New Tab” was always OFF on open.

--- a/react-native-aztec/src/AztecView.js
+++ b/react-native-aztec/src/AztecView.js
@@ -56,6 +56,10 @@ class AztecView extends React.Component {
   }
 
   _onEnter = (event) => {
+    if (!this.isFocused()) {
+      return;
+    }
+
     if (!this.props.onEnter) {
       return;
     }


### PR DESCRIPTION
fixes #1063 
fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/11583

The issue happens when the blur event takes longer to get to the native side than the second Enter. When this happens, a second onEnter -> onSplit chain of events is fired while the first one is still occurring. This seems to be confusing for the gutenberg store.

This doesn't happen on Android because of this:

https://github.com/wordpress-mobile/gutenberg-mobile/blob/ec43c9f1f4709fccdb9d5c74bd6681ae4e621b76/react-native-aztec/src/AztecView.js#L153-L155

On Android the focus-blur loop is broken there, but on iOS this is needed to solve this issue https://github.com/wordpress-mobile/gutenberg-mobile/pull/784

To test:
- Run the example project from develop on the oldest/slowest device available
- Try to reproduce the original bug:
  - Focus on the title
  - Press Enter two or more times fast
  - See the focus loop happening
- Checkout this branch.
- Try to reproduce the issue.
- Hopefully it won't happen anymore.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.