### PR TITLE
Quotes: Fix handling of insertion and removal of empty lines.

### DIFF
--- a/react-native-aztec/ios/Cartfile
+++ b/react-native-aztec/ios/Cartfile
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.6.6"
+github "wordpress-mobile/AztecEditor-iOS" "fff3d4712c6971cd2673fce273c8e9d9330a15ca"

--- a/react-native-aztec/ios/Cartfile.resolved
+++ b/react-native-aztec/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.6.6"
+github "wordpress-mobile/AztecEditor-iOS" "fff3d4712c6971cd2673fce273c8e9d9330a15ca"

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -289,7 +289,7 @@ class RCTAztecView: Aztec.TextView {
     }
     
     private func interceptBackspace() -> Bool {
-        guard isNewLineBeforeSelection() || (selectedRange.location == 0 && selectedRange.length == 0),
+        guard isNewLineBeforeSelectionAndNotEndOfContent() || (selectedRange.location == 0 && selectedRange.length == 0),
             let onBackspace = onBackspace else {
                 return false
         }
@@ -299,12 +299,12 @@ class RCTAztecView: Aztec.TextView {
         return true
     }
 
-    private func isNewLineBeforeSelection() -> Bool {
+    private func isNewLineBeforeSelectionAndNotEndOfContent() -> Bool {
         guard let currentLocation = text.indexFromLocation(selectedRange.location) else {
             return false
         }
 
-        return text.isStartOfParagraph(at: currentLocation)
+        return text.isStartOfParagraph(at: currentLocation) && !(text.endIndex == currentLocation)
     }
     override var keyCommands: [UIKeyCommand]? {
         // Remove defautls Tab and Shift+Tab commands, leaving just Shift+Enter command.


### PR DESCRIPTION
Fixes #207

Relate GB PR: https://github.com/WordPress/gutenberg/pull/16013

This PR fixes the following issues around the insertion and removal of empty lines inside quotes:
 - It was impossible to insert multiple empty lines inside a quote block
- After the insertion of an empty line at the end of the quote block, trying to remove it caused a crash or the merge of the block with the block above.

The main changes are the following:
 -  Aztec is updated in order that empty block elements are not removed. So when entering a new line in quote that results in this HTML: `<p></p>` isn't remove by Aztec
 - Checks are done in GB JS code to check if the selection range returned by iOS is inside the text length in the format structure. This could happen in scenarios where extra characters were added by Aztec in order to display paragraph styles in the last line.

To test:
 - Open the demo app
 - Select a quote block
 - Add a new line to the end of content on the quote part
 - Add another line, make sure it shows up
 - Try to delete both lines 
 - Check that no crash or unnecessary merge happens.

**Know issues :** 
 - When adding a new line to the end of quote, an extra line is added, this is because Aztec iOS adds an extra line in order to keep the paragraph.
 - When adding a brand new quote the quote part will have immediately a new line and the placeholder text will not be show.

I know the issues above are not ideal, but I think they are better than having the crash on removal, or not having the possibility of adding multiple empty lines inside the quote.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
