### PR TITLE
Issue/697 change color of text and links

### DIFF
--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -23,6 +23,9 @@ module.exports = {
 		fontFamily: 'serif',
 		minHeight: 30,
 	},
+	'block-editor-rich-text-placeholder': {
+		color: '',
+	},
 	'block-editor-plain-text': {
 		fontFamily: 'serif',
 	},

--- a/react-native-aztec/ios/Cartfile
+++ b/react-native-aztec/ios/Cartfile
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "fff3d4712c6971cd2673fce273c8e9d9330a15ca"
+github "wordpress-mobile/AztecEditor-iOS" "bfcc9a52648bf92b992d0930ac54d10139923022"

--- a/react-native-aztec/ios/Cartfile.resolved
+++ b/react-native-aztec/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "fff3d4712c6971cd2673fce273c8e9d9330a15ca"
+github "wordpress-mobile/AztecEditor-iOS" "bfcc9a52648bf92b992d0930ac54d10139923022"

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -391,6 +391,15 @@ class RCTAztecView: Aztec.TextView {
         }
     }
 
+    @objc var linkTextColor: UIColor {
+        set {
+            linkTextAttributes = [.foregroundColor: newValue, .underlineStyle: NSNumber(value: NSUnderlineStyle.single.rawValue)]
+        }
+        get {
+            return linkTextAttributes[.foregroundColor] as? UIColor ?? UIColor.blue
+        }
+    }
+
     func setSelection(start: NSNumber, end: NSNumber) {
         if let startPosition = position(from: beginningOfDocument, offset: start.intValue),
             let endPosition = position(from: beginningOfDocument, offset: end.intValue) {

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecViewManager.m
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecViewManager.m
@@ -20,6 +20,7 @@ RCT_EXPORT_VIEW_PROPERTY(onActiveFormatAttributesChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(placeholder, NSString)
 RCT_EXPORT_VIEW_PROPERTY(placeholderTextColor, UIColor)
 RCT_REMAP_VIEW_PROPERTY(color, textColor, UIColor)
+RCT_EXPORT_VIEW_PROPERTY(linkTextColor, UIColor)
 
 RCT_EXPORT_VIEW_PROPERTY(fontFamily, NSString)
 RCT_EXPORT_VIEW_PROPERTY(fontSize, CGFloat)

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecViewManager.m
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecViewManager.m
@@ -19,6 +19,7 @@ RCT_EXPORT_VIEW_PROPERTY(onActiveFormatAttributesChange, RCTBubblingEventBlock)
 
 RCT_EXPORT_VIEW_PROPERTY(placeholder, NSString)
 RCT_EXPORT_VIEW_PROPERTY(placeholderTextColor, UIColor)
+RCT_REMAP_VIEW_PROPERTY(color, textColor, UIColor)
 
 RCT_EXPORT_VIEW_PROPERTY(fontFamily, NSString)
 RCT_EXPORT_VIEW_PROPERTY(fontSize, CGFloat)

--- a/react-native-aztec/src/AztecView.js
+++ b/react-native-aztec/src/AztecView.js
@@ -17,6 +17,7 @@ class AztecView extends React.Component {
     placeholder: PropTypes.string,
     placeholderTextColor: ColorPropType,
     color: ColorPropType,
+    linkTextColor: ColorPropType,
     maxImagesWidth: PropTypes.number,
     minImagesWidth: PropTypes.number,
     onChange: PropTypes.func,

--- a/src/_colors.scss
+++ b/src/_colors.scss
@@ -90,6 +90,7 @@ $blue-wordpress: #0087be;
 $blue-light: #78dcfa;
 $blue-medium: #00aadc;
 $blue-dark: #005082;
+$blue-500: #016087;
 
 // Grays
 $gray: #87a6bc;

--- a/src/_colors.scss
+++ b/src/_colors.scss
@@ -95,6 +95,7 @@ $blue-dark: #005082;
 $gray: #87a6bc;
 $gray-light: lighten( $gray, 33% ); //#f3f6f8
 $gray-dark: darken( $gray, 38% ); //#2e4453
+$gray-900: #1A1A1A;
 
 // $gray-text: ideal for standard, non placeholder text
 // $gray-text-min: minimum contrast needed for WCAG 2.0 AA on white background


### PR DESCRIPTION
Fixes #697 

Related GB PR: https://github.com/WordPress/gutenberg/pull/16016

![Simulator Screen Shot - iPhone Xʀ - 2019-06-06 at 14 40 39](https://user-images.githubusercontent.com/651601/59037402-19f5e600-8869-11e9-9705-878b200f9246.png)

This PR updates the RCTAztecView component to support the setting of base text color and the color for links.

To test:
 - Run the demo app
 - Check that the default body text on text blocks (paragraph/list/quotes) is using the new gray 900 color.
 - Check that links are being draw with the new blue-500 color

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
