### PR TITLE
Remove drag-drop text interaction from Aztec-iOS wrapper

### DIFF
--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -132,6 +132,9 @@ class RCTAztecView: Aztec.TextView {
         textContainerInset = .zero
         contentInset = .zero
         addPlaceholder()
+        if #available(iOS 11.0, *) {
+            textDragInteraction?.isEnabled = false
+        }
     }
 
     func addPlaceholder() {


### PR DESCRIPTION
Fixes #1064 

This PR removes the system drag and drop text functionality from Aztec-iOS Wrapper.

The focus loop issue could be fixed by not sending selection change events to JS when Aztec is not firstResponder, but there is also another issue: After dropping text to a new block, it looses all its formatting.

With @SergioEstevao we decided that is best to remove this functionality until we manage to fix this other issue too.

![drag-drop](https://user-images.githubusercontent.com/9772967/59064276-3a926000-88aa-11e9-8650-48a2797e6973.gif)


To test:
- Select a couple of lines of text on a paragraph block.
- Long press over the selection.
- Check that nothing happens.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.