### PR TITLE
Implement the shadow node for proper laying out Aztec on Android

### DIFF
--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -19,8 +19,9 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
+import com.facebook.react.uimanager.BaseViewManager;
+import com.facebook.react.uimanager.LayoutShadowNode;
 import com.facebook.react.uimanager.PixelUtil;
-import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewDefaults;
@@ -31,6 +32,7 @@ import com.facebook.react.views.scroll.ScrollEvent;
 import com.facebook.react.views.scroll.ScrollEventType;
 import com.facebook.react.views.text.DefaultStyleValuesUtil;
 import com.facebook.react.views.text.ReactFontManager;
+import com.facebook.react.views.text.ReactTextUpdate;
 import com.facebook.react.views.textinput.ReactContentSizeChangedEvent;
 import com.facebook.react.views.textinput.ReactTextChangedEvent;
 import com.facebook.react.views.textinput.ReactTextInputEvent;
@@ -51,7 +53,7 @@ import java.util.Map;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
+public class ReactAztecManager extends BaseViewManager<ReactAztecText, LayoutShadowNode> {
 
     public static final String REACT_CLASS = "RCTAztecView";
 
@@ -95,6 +97,16 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
         aztecText.setFocusable(false);
         aztecText.setCalypsoMode(false);
         return aztecText;
+    }
+
+    @Override
+    public LayoutShadowNode createShadowNodeInstance() {
+        return new ReactAztecTextShadowNode();
+    }
+
+    @Override
+    public Class<? extends LayoutShadowNode> getShadowNodeClass() {
+        return ReactAztecTextShadowNode.class;
     }
 
     @Nullable
@@ -494,6 +506,19 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
         
         // Don't think we need to add setOnEditorActionListener here (intercept Enter for example), but
         // in case check ReactTextInputManager
+    }
+
+    @Override
+    public void updateExtraData(ReactAztecText view, Object extraData) {
+        if (extraData instanceof ReactTextUpdate) {
+            ReactTextUpdate update = (ReactTextUpdate) extraData;
+
+            view.setPadding(
+                    (int) update.getPaddingLeft(),
+                    (int) update.getPaddingTop(),
+                    (int) update.getPaddingRight(),
+                    (int) update.getPaddingBottom());
+        }
     }
 
     private class AztecTextWatcher implements TextWatcher {

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecTextShadowNode.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecTextShadowNode.java
@@ -1,0 +1,25 @@
+package org.wordpress.mobile.ReactNativeAztec;
+
+import android.support.annotation.Nullable;
+
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.views.textinput.ReactTextInputShadowNode;
+
+public class ReactAztecTextShadowNode extends ReactTextInputShadowNode {
+    private @Nullable
+    ReadableMap mTextMap = null;
+    private @Nullable Integer mColor = null;
+
+    @ReactProp(name = PROP_TEXT)
+    public void setText(@Nullable ReadableMap inputMap) {
+        mTextMap = inputMap;
+        markUpdated();
+    }
+
+    @ReactProp(name = "color", customType = "Color")
+    public void setColor(@Nullable Integer color) {
+        mColor = color;
+        markUpdated();
+    }
+}

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecTextShadowNode.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecTextShadowNode.java
@@ -7,8 +7,7 @@ import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.views.textinput.ReactTextInputShadowNode;
 
 public class ReactAztecTextShadowNode extends ReactTextInputShadowNode {
-    private @Nullable
-    ReadableMap mTextMap = null;
+    private @Nullable ReadableMap mTextMap = null;
     private @Nullable Integer mColor = null;
 
     @ReactProp(name = PROP_TEXT)


### PR DESCRIPTION
Addresses #1091

This PR implements the shadow node logic for the Aztec wrapper custom React Native view. This is needed for better View calculations.

This work begun as an attempt to remove the need to specify the `minHeight` style  on the Aztec wrapper. I think that the view should be able to update its height automatically within RN and the Android layout system, without us manually having to set it as a style prop. In that respect, the effort here is not finished; the `minHeight` style is still needed (try removing it and you'll see that the wrapper doesn't update its height properly, although its now initial height is much better than before). Although, my experiments so far with a basic demo app (in repo: https://github.com/hypest/RN060-aztec-experiments) seem to work and the Aztec wrapper there seems fine without specifying any `minHeight`.

Even in this state, the behavior in this PR is better than before and that's why I'm opening this PR.

Known issue: the height of the component seems smaller than the content text but only by a little. The `onContentSizeChange` logic repairs it but it's still visible. Besides, the glitch is minimized due to the work on #1076 and that's why this PR builds on top of that, albeit in a separate PR so #1076 doesn't get blocked/complex.

To test:
1. Run the demo app on Android
2. Put the caret in the middle or the end of the "Lorem ipsum" paragraph block
3. Split the block
4. Notice that the visual glitch of the existing block resizing is quite small

I have also 
Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
