### PR TITLE
Do not intercept delete when there is a range selection.

### DIFF
--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -292,7 +292,7 @@ class RCTAztecView: Aztec.TextView {
     }
     
     private func interceptBackspace() -> Bool {
-        guard isNewLineBeforeSelectionAndNotEndOfContent() || (selectedRange.location == 0 && selectedRange.length == 0),
+        guard (isNewLineBeforeSelectionAndNotEndOfContent() && selectedRange.length == 0) || (selectedRange.location == 0 && selectedRange.length == 0),
             let onBackspace = onBackspace else {
                 return false
         }


### PR DESCRIPTION
Fixes #

This PR fixes an issue where selecting a range of text on a block and pressing delete was not working properly.

To test:
 - Open the demo app
 - Select a range of text in any block
 - Press delete
 - Make sure the text is deleted.
 - Just to make sure all is correct, also text pressing delete with when no range selection is done.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
