### PR TITLE
Issue/1045 paste of attributed strings

### DIFF
--- a/react-native-aztec/ios/Cartfile
+++ b/react-native-aztec/ios/Cartfile
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "d1146bb3eaa7bd8162183f07ef99f992ffb5d808"
+github "wordpress-mobile/AztecEditor-iOS" "1.7.0"

--- a/react-native-aztec/ios/Cartfile
+++ b/react-native-aztec/ios/Cartfile
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "fff3d4712c6971cd2673fce273c8e9d9330a15ca"
+github "wordpress-mobile/AztecEditor-iOS" "d1146bb3eaa7bd8162183f07ef99f992ffb5d808"

--- a/react-native-aztec/ios/Cartfile.resolved
+++ b/react-native-aztec/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "d1146bb3eaa7bd8162183f07ef99f992ffb5d808"
+github "wordpress-mobile/AztecEditor-iOS" "1.7.0"

--- a/react-native-aztec/ios/Cartfile.resolved
+++ b/react-native-aztec/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "fff3d4712c6971cd2673fce273c8e9d9330a15ca"
+github "wordpress-mobile/AztecEditor-iOS" "d1146bb3eaa7bd8162183f07ef99f992ffb5d808"

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -189,6 +189,13 @@ class RCTAztecView: Aztec.TextView {
 
     private func readHTML(from pasteboard: UIPasteboard) -> String? {
 
+        if let data = pasteboard.data(forPasteboardType: kUTTypeHTML as String), let html = String(data: data, encoding: .utf8) {
+            // Make sure we are not getting a full HTML DOC. We only want inner content
+            if !html.hasPrefix("<!DOCTYPE html") {
+                return html
+            }
+        }
+
         if let flatRTFDString = read(from: pasteboard, uti: kUTTypeFlatRTFD as String, documentType: DocumentType.rtfd) {
             return  flatRTFDString
         }
@@ -201,15 +208,11 @@ class RCTAztecView: Aztec.TextView {
             return  rtfdString
         }
 
-        if let data = pasteboard.data(forPasteboardType: kUTTypeHTML as String) {
-            return String(data: data, encoding: .utf8)
-        }
-
         return nil
     }
     
     private func readText(from pasteboard: UIPasteboard) -> String? {
-        return pasteboard.string        
+        return pasteboard.string
     }
 
     func saveToDisk(image: UIImage) -> URL? {

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -178,7 +178,7 @@ class RCTAztecView: Aztec.TextView {
     }
     
     // MARK: - Paste handling
-    private func read(from pasteboard: UIPasteboard, uti: String, documentType: DocumentType) -> String? {
+    private func read(from pasteboard: UIPasteboard, uti: CFString, documentType: DocumentType) -> String? {
         guard let data = pasteboard.data(forPasteboardType: uti as String),
             let attributedString = try? NSAttributedString(data: data, options: [.documentType: documentType], documentAttributes: nil),
             let storage = self.textStorage as? TextStorage else {
@@ -196,15 +196,15 @@ class RCTAztecView: Aztec.TextView {
             }
         }
 
-        if let flatRTFDString = read(from: pasteboard, uti: kUTTypeFlatRTFD as String, documentType: DocumentType.rtfd) {
+        if let flatRTFDString = read(from: pasteboard, uti: kUTTypeFlatRTFD, documentType: DocumentType.rtfd) {
             return  flatRTFDString
         }
 
-        if let rtfString = read(from: pasteboard, uti: kUTTypeRTF as String, documentType: DocumentType.rtf) {
+        if let rtfString = read(from: pasteboard, uti: kUTTypeRTF, documentType: DocumentType.rtf) {
             return  rtfString
         }
 
-        if let rtfdString = read(from: pasteboard, uti: kUTTypeRTFD as String, documentType: DocumentType.rtfd) {
+        if let rtfdString = read(from: pasteboard, uti: kUTTypeRTFD, documentType: DocumentType.rtfd) {
             return  rtfdString
         }
 

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -183,6 +183,15 @@ class RCTAztecView: Aztec.TextView {
         
         return String(data: data, encoding: .utf8)
     }
+
+    private func htmlFromAttributedString(from pasteboard: UIPasteboard) -> String? {
+        guard let data = pasteboard.data(forPasteboardType: kUTTypeRTF as String),
+            let attributedString = try? NSAttributedString(data: data, options: [.documentType: DocumentType.rtf], documentAttributes: nil),
+            let storage = self.textStorage as? TextStorage else {
+            return nil
+        }
+        return  storage.getHTML(from: attributedString)
+    }
     
     private func text(from pasteboard: UIPasteboard) -> String? {
         guard let data = pasteboard.data(forPasteboardType: kUTTypePlainText as String) else {
@@ -227,7 +236,10 @@ class RCTAztecView: Aztec.TextView {
         
         let pasteboard = UIPasteboard.general
         let text = self.text(from: pasteboard) ?? ""
-        let html = self.html(from: pasteboard) ?? ""
+        var html = self.html(from: pasteboard) ?? ""
+        if html.isEmpty {
+            html = htmlFromAttributedString(from: pasteboard) ?? ""
+        }
         let imagesURLs = self.images(from: pasteboard)
 
         onPaste?([

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -178,15 +178,31 @@ class RCTAztecView: Aztec.TextView {
     }
     
     // MARK: - Paste handling
+    private func read(from pasteboard: UIPasteboard, uti: String, documentType: DocumentType) -> String? {
+        guard let data = pasteboard.data(forPasteboardType: uti as String),
+            let attributedString = try? NSAttributedString(data: data, options: [.documentType: documentType], documentAttributes: nil),
+            let storage = self.textStorage as? TextStorage else {
+                return nil
+        }
+        return  storage.getHTML(from: attributedString)
+    }
+
     private func readHTML(from pasteboard: UIPasteboard) -> String? {
-        if let data = pasteboard.data(forPasteboardType: kUTTypeHTML as String) {
-            return String(data: data, encoding: .utf8)
+
+        if let flatRTFDString = read(from: pasteboard, uti: kUTTypeFlatRTFD as String, documentType: DocumentType.rtfd) {
+            return  flatRTFDString
         }
 
-        if let data = pasteboard.data(forPasteboardType: kUTTypeRTF as String),
-            let attributedString = try? NSAttributedString(data: data, options: [.documentType: DocumentType.rtf], documentAttributes: nil),
-            let storage = self.textStorage as? TextStorage {
-                return  storage.getHTML(from: attributedString)
+        if let rtfString = read(from: pasteboard, uti: kUTTypeRTF as String, documentType: DocumentType.rtf) {
+            return  rtfString
+        }
+
+        if let rtfdString = read(from: pasteboard, uti: kUTTypeRTFD as String, documentType: DocumentType.rtfd) {
+            return  rtfdString
+        }
+
+        if let data = pasteboard.data(forPasteboardType: kUTTypeHTML as String) {
+            return String(data: data, encoding: .utf8)
         }
 
         return nil

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -190,11 +190,7 @@ class RCTAztecView: Aztec.TextView {
     }
     
     private func readText(from pasteboard: UIPasteboard) -> String? {
-        if let data = pasteboard.data(forPasteboardType: kUTTypeUTF8PlainText as String) {
-            return String(data: data, encoding: .utf8)
-        }
-        
-        return nil
+        return pasteboard.string        
     }
 
     func saveToDisk(image: UIImage) -> URL? {

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -193,15 +193,7 @@ class RCTAztecView: Aztec.TextView {
         if let data = pasteboard.data(forPasteboardType: kUTTypeUTF8PlainText as String) {
             return String(data: data, encoding: .utf8)
         }
-
-        if let data = pasteboard.data(forPasteboardType: kUTTypePlainText as String) {
-            return String(data: data, encoding: .ascii)
-        }
-
-        if let data = pasteboard.data(forPasteboardType: kUTTypeText as String) {
-            return String(data: data, encoding: .ascii)
-        }
-
+        
         return nil
     }
 


### PR DESCRIPTION
Fixes #1045 

This PR improves the paste code by reading more UTI types when doing paste and processing them to HTML if possible.

**Note:** Make sure you run `yarn ios` to get the update of Aztec lib 

To test:
 - Start the demo app
 - Copy text with attributes (string, bold) from another app, for example Notes
 - Paste it on the demo app text block
 - Check that the content is pasted with attributes.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.