### PR TITLE
Set link text color and link underline from JS

### DIFF
--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,9 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = 'v1.3.27'
+        aztecVersion = '26aaa61059661eb83db84111841577e99870adf6'
+
+
     }
 
     repositories {

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -171,7 +171,9 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
 
     @ReactProp(name = "text")
     public void setText(ReactAztecText view, ReadableMap inputMap) {
+        String linkTextColor = inputMap.getString("linkTextColor");
         if (!inputMap.hasKey("eventCount")) {
+            view.setLinkStyle(parseLinkTextColor(linkTextColor));
             setTextfromJS(view, inputMap.getString("text"), inputMap.getMap("selection"));
         } else {
             // Don't think there is necessity of this branch, but justin case we want to
@@ -179,6 +181,7 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
             int eventCount = inputMap.getInt("eventCount");
 
             if (view.mNativeEventCount < eventCount) {
+                view.setLinkStyle(parseLinkTextColor(linkTextColor));
                 setTextfromJS(view, inputMap.getString("text"), inputMap.getMap("selection"));
             }
         }
@@ -340,6 +343,13 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
             newColor = color;
         }
         view.setTextColor(newColor);
+    }
+
+    private int parseLinkTextColor(String linkTextColor) {
+        if (!TextUtils.isEmpty(linkTextColor)) {
+            return Color.parseColor(linkTextColor);
+        }
+        return Color.BLUE;
     }
 
     @ReactProp(name = "blockType")

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -25,6 +25,7 @@ import com.facebook.react.views.textinput.ScrollWatcher;
 import org.wordpress.aztec.AztecText;
 import org.wordpress.aztec.AztecTextFormat;
 import org.wordpress.aztec.ITextFormat;
+import org.wordpress.aztec.formatting.LinkFormatter;
 import org.wordpress.aztec.plugins.IAztecPlugin;
 import org.wordpress.aztec.plugins.IToolbarButton;
 
@@ -320,6 +321,10 @@ public class ReactAztecText extends AztecText {
         UIManagerModule uiManager = reactContext.getNativeModule(UIManagerModule.class);
         final ReactTextInputLocalData localData = new ReactTextInputLocalData(this);
         uiManager.setViewLocalData(getId(), localData);
+    }
+
+    public void setLinkStyle(Integer color) {
+       linkFormatter.setLinkStyle(new LinkFormatter.LinkStyle(color, true));
     }
 
     //// Text changed events


### PR DESCRIPTION
It is Android update for PR : https://github.com/wordpress-mobile/gutenberg-mobile/pull/1086

With this PR we are allowing JS side to change the link text color on Android, which will also turn on the underline option on the link.

In order to achieve this, I have created a branch on `AztecEditorAndroid` repo with change which allows us to set link style: https://github.com/wordpress-mobile/AztecEditor-Android/compare/fix/make_link_style_public

Currently, there is a problem with how props are propagated to native code. With this line of code https://github.com/WordPress/gutenberg/pull/16016/files#diff-4828a21853e899e5a36faecfa96d83e8R817 , Android native code will receive `linkTextColor` prop after `text` prop, which means it's too late to change link style as text is already drawn on the screen.

The only solution that came on my mind was to add `linkTextColor` as property in `text` prop: https://github.com/WordPress/gutenberg/pull/16050/files .

@SergioEstevao suggested that we try to set text again when we receive `linkTextColor` prop, which I tried and it's working, but I think it's not the best option for Android regarding performance, as we will force to setText on components that don't have a link (as `linkTextColor` prop is always passed from JS side) and if we want to set a text only on components that has a link, we would need to check if each component has it which also seems an impact on performance.

Let's open discussion here @daniloercoli @hypest , maybe we can figure out a better solution than this.


