### PR TITLE
Implement link text color as a stand-alone ReactProp in Android

### DIFF
--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,9 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = 'v1.3.27'
+        aztecVersion = '26aaa61059661eb83db84111841577e99870adf6'
+
+
     }
 
     repositories {

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -171,9 +171,7 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
 
     @ReactProp(name = "text")
     public void setText(ReactAztecText view, ReadableMap inputMap) {
-        String linkTextColor = inputMap.getString("linkTextColor");
         if (!inputMap.hasKey("eventCount")) {
-            view.setLinkStyle(parseLinkTextColor(linkTextColor));
             setTextfromJS(view, inputMap.getString("text"), inputMap.getMap("selection"));
         } else {
             // Don't think there is necessity of this branch, but justin case we want to
@@ -181,10 +179,14 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
             int eventCount = inputMap.getInt("eventCount");
 
             if (view.mNativeEventCount < eventCount) {
-                view.setLinkStyle(parseLinkTextColor(linkTextColor));
                 setTextfromJS(view, inputMap.getString("text"), inputMap.getMap("selection"));
             }
         }
+    }
+
+    @ReactProp(name = "linkTextColor")
+    public void setLinkTextColor(ReactAztecText view, String linkTextColor) {
+        view.setLinkStyle(parseLinkTextColor(linkTextColor));
     }
 
     private void setTextfromJS(ReactAztecText view, String text, @Nullable ReadableMap selection) {

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -171,7 +171,9 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
 
     @ReactProp(name = "text")
     public void setText(ReactAztecText view, ReadableMap inputMap) {
+        String linkTextColor = inputMap.getString("linkTextColor");
         if (!inputMap.hasKey("eventCount")) {
+            view.setLinkStyle(parseLinkTextColor(linkTextColor));
             setTextfromJS(view, inputMap.getString("text"), inputMap.getMap("selection"));
         } else {
             // Don't think there is necessity of this branch, but justin case we want to
@@ -179,6 +181,7 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
             int eventCount = inputMap.getInt("eventCount");
 
             if (view.mNativeEventCount < eventCount) {
+                view.setLinkStyle(parseLinkTextColor(linkTextColor));
                 setTextfromJS(view, inputMap.getString("text"), inputMap.getMap("selection"));
             }
         }
@@ -340,6 +343,13 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
             newColor = color;
         }
         view.setTextColor(newColor);
+    }
+
+    private int parseLinkTextColor(String linkTextColor) {
+        if (!TextUtils.isEmpty(linkTextColor)) {
+            return Color.parseColor(linkTextColor);
+        }
+        return Color.BLUE;
     }
 
     @ReactProp(name = "blockType")

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -25,6 +25,7 @@ import com.facebook.react.views.textinput.ScrollWatcher;
 import org.wordpress.aztec.AztecText;
 import org.wordpress.aztec.AztecTextFormat;
 import org.wordpress.aztec.ITextFormat;
+import org.wordpress.aztec.formatting.LinkFormatter;
 import org.wordpress.aztec.plugins.IAztecPlugin;
 import org.wordpress.aztec.plugins.IToolbarButton;
 
@@ -320,6 +321,10 @@ public class ReactAztecText extends AztecText {
         UIManagerModule uiManager = reactContext.getNativeModule(UIManagerModule.class);
         final ReactTextInputLocalData localData = new ReactTextInputLocalData(this);
         uiManager.setViewLocalData(getId(), localData);
+    }
+
+    public void setLinkStyle(Integer color) {
+       linkFormatter.setLinkStyle(new LinkFormatter.LinkStyle(color, true));
     }
 
     //// Text changed events

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -193,7 +193,7 @@ class RCTAztecView: Aztec.TextView {
     }
 
     private func cleanHTML() -> String {
-        let html = getHTML(prettify: false)
+        let html = getHTML(prettify: false).replacingOccurrences(of: String(.paragraphSeparator), with: String(.lineSeparator))
         return html
     }
 
@@ -220,13 +220,13 @@ class RCTAztecView: Aztec.TextView {
         let imagesURLs = images.compactMap({ saveToDisk(image: $0)?.absoluteString })
         return imagesURLs
     }
-    
+
     override func paste(_ sender: Any?) {
         let start = selectedRange.location
         let end = selectedRange.location + selectedRange.length
         
         let pasteboard = UIPasteboard.general
-        let text = self.text(from: pasteboard) ?? ""
+        let text = self.text(from: pasteboard)?.replacingOccurrences(of: String(.paragraphSeparator), with: String(.lineFeed)) ?? ""
         let html = self.html(from: pasteboard) ?? ""
         let imagesURLs = self.images(from: pasteboard)
 

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -193,7 +193,7 @@ class RCTAztecView: Aztec.TextView {
     }
 
     private func cleanHTML() -> String {
-        let html = getHTML(prettify: false).replacingOccurrences(of: String(.paragraphSeparator), with: String(.lineSeparator))
+        let html = getHTML(prettify: false)
         return html
     }
 
@@ -220,13 +220,13 @@ class RCTAztecView: Aztec.TextView {
         let imagesURLs = images.compactMap({ saveToDisk(image: $0)?.absoluteString })
         return imagesURLs
     }
-
+    
     override func paste(_ sender: Any?) {
         let start = selectedRange.location
         let end = selectedRange.location + selectedRange.length
         
         let pasteboard = UIPasteboard.general
-        let text = self.text(from: pasteboard)?.replacingOccurrences(of: String(.paragraphSeparator), with: String(.lineFeed)) ?? ""
+        let text = self.text(from: pasteboard) ?? ""
         let html = self.html(from: pasteboard) ?? ""
         let imagesURLs = self.images(from: pasteboard)
 


### PR DESCRIPTION
This implements the Android side of this PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1086

This work is based on and supersedes @marecar3's work in this PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1101 but [the changes on the Gutenberg side for that PR](https://github.com/WordPress/gutenberg/pull/16050) are no longer necessary for this PR. This PR's Gutenberg companion PR is the same as its target: https://github.com/WordPress/gutenberg/pull/16016.

This PR will also need a new Aztec release after this Aztec PR is merged: https://github.com/wordpress-mobile/AztecEditor-Android/commit/26aaa61059661eb83db84111841577e99870adf6, so that the `build.gradle` can reference a tag, rather than a hash.

To test:

Follow testing steps here: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1086#issue-285808669.

Optionally, change the values temporarily here: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1086/files#diff-7a9f35e48834f298dc343aeea78d0778R99 to something that stands out (like #ff0000) and see that the changes take effect.
