### PR TITLE
Improve copy paste of lists

### DIFF
--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -212,7 +212,10 @@ class RCTAztecView: Aztec.TextView {
     }
     
     private func readText(from pasteboard: UIPasteboard) -> String? {
-        return pasteboard.string
+        var text = pasteboard.string
+        // Text that comes from Aztec will have paragraphSeparator instead of line feed AKA as \n. The paste methods in GB are expecting \n so this line will fix that.
+        text = text?.replacingOccurrences(of: String(.paragraphSeparator), with: String(.lineFeed))
+        return text
     }
 
     func saveToDisk(image: UIImage) -> URL? {
@@ -332,7 +335,7 @@ class RCTAztecView: Aztec.TextView {
     // MARK: - Native-to-RN Value Packing Logic
 
     private func cleanHTML() -> String {
-        let html = getHTML(prettify: false)
+        let html = getHTML(prettify: false).replacingOccurrences(of: String(.paragraphSeparator), with: String(.lineFeed))
         return html
     }
     


### PR DESCRIPTION
This PR improves the copy paste of lists inside GB mobile by replacing paragraph separators for line feeds.
This allows the paste code in GB to recognize the lists better when pasting inside another block.

To test:
 - Start the demo app
 - Copy a list block by doing select all copy on it
 - Paste the resulting code inside another text block.
 - See that a list block is created.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
