### PR TITLE
Hardcode link text color in Android

### DIFF
--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -37,6 +37,7 @@ import com.facebook.react.views.textinput.ReactTextInputEvent;
 import com.facebook.react.views.textinput.ReactTextInputManager;
 import com.facebook.react.views.textinput.ScrollWatcher;
 
+import org.wordpress.aztec.formatting.LinkFormatter;
 import org.wordpress.aztec.glideloader.GlideImageLoader;
 import org.wordpress.aztec.glideloader.GlideVideoThumbnailLoader;
 import org.wordpress.aztec.plugins.CssUnderlinePlugin;
@@ -94,6 +95,10 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
         aztecText.setFocusableInTouchMode(false);
         aztecText.setFocusable(false);
         aztecText.setCalypsoMode(false);
+        aztecText.setLinkFormatter(new LinkFormatter(aztecText,
+                new LinkFormatter.LinkStyle(
+                        Color.parseColor("#016087"), true)
+        ));
         return aztecText;
     }
 

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -95,6 +95,8 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
         aztecText.setFocusableInTouchMode(false);
         aztecText.setFocusable(false);
         aztecText.setCalypsoMode(false);
+        // This is a temporary hack that sets the correct GB link color and underline
+        // see: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1109
         aztecText.setLinkFormatter(new LinkFormatter(aztecText,
                 new LinkFormatter.LinkStyle(
                         Color.parseColor("#016087"), true)


### PR DESCRIPTION
This PR does implement the Android side of the PR here #1086 by making an hardcode reference to the default GB link color. 

As agreed in Slack conversation, this is a required hack for Android until we find a better solution that works fine on all devices without requiring a repaint of the screen. Ref: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1106 and https://github.com/wordpress-mobile/gutenberg-mobile/pull/1101

Follow testing steps here: #1086 (comment).

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
