### PR TITLE
Copy i18n-cache folder too on publishing to Bintray

### DIFF
--- a/bin/update-bintray-repo.sh
+++ b/bin/update-bintray-repo.sh
@@ -56,6 +56,7 @@ jfrog bt config
 echo "Running yarn install in '${TMP_WORKING_DIRECTORY}'..."
 cp "package.json" "${TMP_WORKING_DIRECTORY}/"
 cp "yarn.lock" "${TMP_WORKING_DIRECTORY}/"
+cp -Ra "i18n-cache" "${TMP_WORKING_DIRECTORY}/"
 cd "${TMP_WORKING_DIRECTORY}"
 yarn install --silent
 


### PR DESCRIPTION
Fixes #1114 

To test:

Try running `./bin/update-bintray-repo.sh` to publish to Bintray, and it should work by reporting that the versions on the mirror are already there.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
