### PR TITLE
Fix device rotation tests

### DIFF
--- a/__device-tests__/gutenberg-editor-paragraph.test.js
+++ b/__device-tests__/gutenberg-editor-paragraph.test.js
@@ -114,7 +114,7 @@ describe( 'Gutenberg Editor tests for Paragraph Block', () => {
 		}
 		await editorPage.sendTextToParagraphBlockAtPosition( 1, testData.longText );
 
-		for ( let i = 4; i > 0; i-- ) {
+		for ( let i = 3; i > 0; i-- ) {
 			await editorPage.removeParagraphBlockAtPosition( i );
 		}
 	} );

--- a/__device-tests__/gutenberg-editor-rotatation.test.js
+++ b/__device-tests__/gutenberg-editor-rotatation.test.js
@@ -58,6 +58,11 @@ describe( 'Gutenberg Editor tests', () => {
 		}
 
 		await editorPage.addNewParagraphBlock();
+
+		if ( isAndroid() ) {
+			await driver.hideDeviceKeyboard();
+		}
+
 		paragraphBlockElement = await editorPage.getParagraphBlockAtPosition( 2 );
 		await editorPage.sendTextToParagraphBlock( paragraphBlockElement, testData.mediumText );
 		await toggleOrientation( driver );

--- a/__device-tests__/helpers/test-data.js
+++ b/__device-tests__/helpers/test-data.js
@@ -2,10 +2,9 @@ exports.shortText = `Rock music approaches at high velocity.`;
 
 exports.mediumText = `The finer continuum interprets the polynomial rabbit. When can the geology cheat? An astronomer runs. Should a communist consent?`;
 
-exports.longText = `Beneath the busy continuum blinks the ineffective husband. Why a metric bow outside the official subway? How can the prompt crop exhaust his tree? The sample rolls! After an across gasp overflows the ethical attorney. A riot pilots an excess goldfish. 
-Does this chord crowd my emptied search? A theory bubbles under the cartoon. The discontinued speaker cracks every thick epic. Its extraordinary twin shifts behind the listener. An enlightened specimen stalls. The weapon apologizes?
-The finer continuum interprets the polynomial rabbit. When can the geology cheat? An astronomer runs. Should a communist consent?
-A parody guns the suffering pipeline. How does the sliced device amuse the tutorial? When will the beating companion dispose our average? The skull complains? An ink irons a paranoid into the earned juvenile.`;
+exports.longText = `Beneath the busy continuum blinks the ineffective husband. Why a metric bow outside the official subway? How can the prompt crop exhaust his tree 
+Does this chord crowd my emptied search? A theory bubbles under the cartoon. The discontinued speaker cracks every thick epic. Its extraordinary twin shifts behind
+The finer continuum interprets the polynomial rabbit. When can the geology cheat? An astronomer runs. Should a communist consent?`;
 
 exports.listItem1 = `Milk`;
 exports.listItem2 = `Honey`;


### PR DESCRIPTION
Fixes failing device rotation tests on develop

To test: device rotation tests should pass both locally and on CI

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
