### PR TITLE
Narrow blur on unmount to replaceable

### DIFF
--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -47,7 +47,6 @@ type PropsType = BlockType & {
 	isSelected: boolean,
 	isFirstBlock: boolean,
 	isLastBlock: boolean,
-	unstableShouldBlurOnUnmount: boolean,
 	showTitle: boolean,
 	borderStyle: Object,
 	focusedBorderColor: string,
@@ -145,7 +144,6 @@ export class BlockHolder extends React.Component<PropsType, StateType> {
 				mergeBlocks={ this.props.mergeBlocks }
 				onCaretVerticalPositionChange={ this.props.onCaretVerticalPositionChange }
 				clientId={ this.props.clientId }
-				unstableShouldBlurOnUnmount={ this.props.unstableShouldBlurOnUnmount }
 			/>
 		);
 	}

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -47,6 +47,7 @@ type PropsType = BlockType & {
 	isSelected: boolean,
 	isFirstBlock: boolean,
 	isLastBlock: boolean,
+	isReplaceable: boolean,
 	showTitle: boolean,
 	borderStyle: Object,
 	focusedBorderColor: string,

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -144,6 +144,7 @@ export class BlockHolder extends React.Component<PropsType, StateType> {
 				mergeBlocks={ this.props.mergeBlocks }
 				onCaretVerticalPositionChange={ this.props.onCaretVerticalPositionChange }
 				clientId={ this.props.clientId }
+				isReplaceable={ this.props.isReplaceable }
 			/>
 		);
 	}

--- a/src/block-management/block-holder.js
+++ b/src/block-management/block-holder.js
@@ -47,7 +47,7 @@ type PropsType = BlockType & {
 	isSelected: boolean,
 	isFirstBlock: boolean,
 	isLastBlock: boolean,
-	isReplaceable: boolean,
+	unstableShouldBlurOnUnmount: boolean,
 	showTitle: boolean,
 	borderStyle: Object,
 	focusedBorderColor: string,
@@ -145,7 +145,7 @@ export class BlockHolder extends React.Component<PropsType, StateType> {
 				mergeBlocks={ this.props.mergeBlocks }
 				onCaretVerticalPositionChange={ this.props.onCaretVerticalPositionChange }
 				clientId={ this.props.clientId }
-				isReplaceable={ this.props.isReplaceable }
+				unstableShouldBlurOnUnmount={ this.props.unstableShouldBlurOnUnmount }
 			/>
 		);
 	}

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -330,7 +330,7 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 					onCaretVerticalPositionChange={ this.onCaretVerticalPositionChange }
 					borderStyle={ this.blockHolderBorderStyle() }
 					focusedBorderColor={ styles.blockHolderFocused.borderColor }
-					isReplaceable={
+					unstableShouldBlurOnUnmount={
 						this.props.selectedBlock &&
 						this.props.selectedBlock.clientId === clientId &&
 						this.isReplaceable( this.props.selectedBlock ) }

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -330,6 +330,10 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 					onCaretVerticalPositionChange={ this.onCaretVerticalPositionChange }
 					borderStyle={ this.blockHolderBorderStyle() }
 					focusedBorderColor={ styles.blockHolderFocused.borderColor }
+					isReplaceable={
+						this.props.selectedBlock &&
+						this.props.selectedBlock.clientId === clientId &&
+						this.isReplaceable( this.props.selectedBlock ) }
 				/>
 				{ this.state.blockTypePickerVisible && this.props.isBlockSelected( clientId ) && (
 					<View style={ styles.containerStyleAddHere } >

--- a/src/block-management/block-manager.js
+++ b/src/block-management/block-manager.js
@@ -330,10 +330,6 @@ export class BlockManager extends React.Component<PropsType, StateType> {
 					onCaretVerticalPositionChange={ this.onCaretVerticalPositionChange }
 					borderStyle={ this.blockHolderBorderStyle() }
 					focusedBorderColor={ styles.blockHolderFocused.borderColor }
-					unstableShouldBlurOnUnmount={
-						this.props.selectedBlock &&
-						this.props.selectedBlock.clientId === clientId &&
-						this.isReplaceable( this.props.selectedBlock ) }
 				/>
 				{ this.state.blockTypePickerVisible && this.props.isBlockSelected( clientId ) && (
 					<View style={ styles.containerStyleAddHere } >


### PR DESCRIPTION
Fixes #1126 

Gutenberg PR: https://github.com/WordPress/gutenberg/pull/16151

To test:

1. Remove all the content
2. Insert an image
3. Remove the image
4. Ensure there's no crash

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
