### PR TITLE
Removes empty lines lists and quotes

### DIFF
--- a/react-native-aztec/ios/Cartfile
+++ b/react-native-aztec/ios/Cartfile
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "e2bf4374be6c06682c85d7e01561427d2b968fb8"
+github "wordpress-mobile/AztecEditor-iOS" "4d5551e044e49ad2bd82c910c2d50ef1765e61a3"

--- a/react-native-aztec/ios/Cartfile
+++ b/react-native-aztec/ios/Cartfile
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "e0ce66538ded26ee2d2812e31d3cc80320b008f6"
+github "wordpress-mobile/AztecEditor-iOS" "e2bf4374be6c06682c85d7e01561427d2b968fb8"

--- a/react-native-aztec/ios/Cartfile
+++ b/react-native-aztec/ios/Cartfile
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.7.0"
+github "wordpress-mobile/AztecEditor-iOS" "e0ce66538ded26ee2d2812e31d3cc80320b008f6"

--- a/react-native-aztec/ios/Cartfile.resolved
+++ b/react-native-aztec/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "e2bf4374be6c06682c85d7e01561427d2b968fb8"
+github "wordpress-mobile/AztecEditor-iOS" "4d5551e044e49ad2bd82c910c2d50ef1765e61a3"

--- a/react-native-aztec/ios/Cartfile.resolved
+++ b/react-native-aztec/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "e0ce66538ded26ee2d2812e31d3cc80320b008f6"
+github "wordpress-mobile/AztecEditor-iOS" "e2bf4374be6c06682c85d7e01561427d2b968fb8"

--- a/react-native-aztec/ios/Cartfile.resolved
+++ b/react-native-aztec/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.7.0"
+github "wordpress-mobile/AztecEditor-iOS" "e0ce66538ded26ee2d2812e31d3cc80320b008f6"

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -135,7 +135,7 @@ class RCTAztecView: Aztec.TextView {
         if #available(iOS 11.0, *) {
             textDragInteraction?.isEnabled = false
         }
-        storage.htmlConverter.characterToReplaceLastEmtpyLine = Character(.zeroWidthSpace)
+        storage.htmlConverter.characterToReplaceLastEmptyLine = Character(.zeroWidthSpace)
     }
 
     func addPlaceholder() {

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -401,7 +401,9 @@ class RCTAztecView: Aztec.TextView {
 
     @objc var placeholder: String {
         set {
-            placeholderLabel.text = newValue
+            var placeholderAttributes = typingAttributes
+            placeholderAttributes[.foregroundColor] = placeholderTextColor
+            placeholderLabel.attributedText = NSAttributedString(string: newValue, attributes: placeholderAttributes)
         }
 
         get {
@@ -435,7 +437,7 @@ class RCTAztecView: Aztec.TextView {
     }
     
     func updatePlaceholderVisibility() {
-        placeholderLabel.isHidden = !self.text.isEmpty
+        placeholderLabel.isHidden = !self.text.replacingOccurrences(of: String(.zeroWidthSpace), with: "").isEmpty
     }
     
     // MARK: - Font Setters

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -135,6 +135,7 @@ class RCTAztecView: Aztec.TextView {
         if #available(iOS 11.0, *) {
             textDragInteraction?.isEnabled = false
         }
+        storage.htmlConverter.characterToReplaceLastEmtpyLine = Character(.zeroWidthSpace)
     }
 
     func addPlaceholder() {
@@ -335,7 +336,7 @@ class RCTAztecView: Aztec.TextView {
     // MARK: - Native-to-RN Value Packing Logic
 
     private func cleanHTML() -> String {
-        let html = getHTML(prettify: false).replacingOccurrences(of: String(.paragraphSeparator), with: String(.lineFeed))
+        let html = getHTML(prettify: false).replacingOccurrences(of: String(.paragraphSeparator), with: String(.lineFeed)).replacingOccurrences(of: String(.zeroWidthSpace), with: "")
         return html
     }
     


### PR DESCRIPTION
Fixes #954

This PR addresses the issues iOS were empty lines are being added to new lists or quotes blocks.
It also fixes the placeholders visibility  and style on both blocks.

![Simulator Screen Shot - iPhone Xʀ - 2019-06-13 at 12 56 47](https://user-images.githubusercontent.com/651601/59430656-c93b3b80-8dda-11e9-8552-92fa92f1c4bd.png)


To test:
 - Start the demo app
 - Add a new list block
 - Check if placeholder info code shows up.
 - Edit the list and add new list elements and check that no new empty line shows up in the end
 - Split lists
 - Indent and outdent
 - Add new quote block
 - Check that placeholder text shows up
 - Edit the quote and check that no extra empty lines show up when editing

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
