### PR TITLE
PlainText based on RCTAztecView

### DIFF
--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -36,6 +36,9 @@ class RCTAztecView: Aztec.TextView {
 
     @objc var plainText: NSDictionary? {
         didSet {
+            guard plainText?["eventCount"] == nil else {
+                return
+            }
             self.text = plainText?["text"] as? String
             if let content = plainText {
                 setSelection(from: content)

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecViewManager.m
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecViewManager.m
@@ -21,6 +21,7 @@ RCT_EXPORT_VIEW_PROPERTY(placeholder, NSString)
 RCT_EXPORT_VIEW_PROPERTY(placeholderTextColor, UIColor)
 RCT_REMAP_VIEW_PROPERTY(color, textColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(linkTextColor, UIColor)
+RCT_EXPORT_VIEW_PROPERTY(plainText, NSDictionary)
 
 RCT_EXPORT_VIEW_PROPERTY(fontFamily, NSString)
 RCT_EXPORT_VIEW_PROPERTY(fontSize, CGFloat)

--- a/react-native-aztec/src/AztecView.js
+++ b/react-native-aztec/src/AztecView.js
@@ -172,7 +172,7 @@ class AztecView extends React.Component {
           // combination generate an infinite loop as described in https://github.com/wordpress-mobile/gutenberg-mobile/issues/302
           onFocus = { this._onAztecFocus } 
           onBlur = { this._onBlur }
-		      onBackspace = { this._onBackspace }
+          onBackspace = { this.props.onBackspace }
         />
       </TouchableWithoutFeedback>
     );


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1124
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1033

This PR updates the gutenberg ref to test https://github.com/WordPress/gutenberg/pull/16178

It also add changes to Aztec Wrapper to handle plain text, avoiding all html handling.

### The changes on Aztec are:

- New `plainText` prop:
This prop has the same structure than the `text/contents` prop, but by using it, Aztec will set the text content directly to its non-attributed text property, avoiding any html handling.

- onChange bubble event also changed:
When `plainText` is set, the Aztec wrapper will take the text content directly from the text property, again without any formatting or html handling.
It will be sent in the same structure than before, but with the name `plainText` for the text property.

These changes will need to be reproduced on Android if we decide to go with this solution.

Everything else is managed directly on PlaneText JS side.


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.