### PR TITLE
Fix/1141 align init html content with gutenberg changes in heading block

### DIFF
--- a/src/app/initial-html.js
+++ b/src/app/initial-html.js
@@ -85,8 +85,8 @@ else:
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:heading {"align":"left"} -->
-<h2 style="text-align:left">Meet your new best friends, Blocks</h2>
+<!-- wp:heading {"level":2,"textAlign":"left"} -->
+<h2 class="has-text-align-left">Meet your new best friends, Blocks</h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"align":"left"} -->
@@ -109,8 +109,8 @@ else:
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:heading {"align":"left"} -->
-<h2 style="text-align:left">Be your own builder</h2>
+<!-- wp:heading {"level":2,"textAlign":"left"} -->
+<h2 class="has-text-align-left">Be your own builder</h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"align":"left"} -->
@@ -125,8 +125,8 @@ else:
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:heading {"align":"left"} -->
-<h2 style="text-align:left">Gutenberg ❤️ Developers</h2>
+<!-- wp:heading {"level":2,"textAlign":"left"} -->
+<h2 class="has-text-align-left">Gutenberg ❤️ Developers</h2>
 <!-- /wp:heading -->
 
 <!-- wp:columns {"className":"gutenberg-landing\u002d\u002ddevelopers-columns"} -->
@@ -163,8 +163,8 @@ else:
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:heading {"align":"left"} -->
-<h2 style="text-align:left">The editor is just the beginning</h2>
+<!-- wp:heading {"level":2,"textAlign":"left"} -->
+<h2 class="has-text-align-left">The editor is just the beginning</h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"align":"left"} -->
@@ -199,8 +199,8 @@ else:
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:heading {"align":"left"} -->
-<h2 style="text-align:left">Dig in deeper</h2>
+<!-- wp:heading {"level":2,"textAlign":"left""} -->
+<h2 class="has-text-align-left">Dig in deeper</h2>
 <!-- /wp:heading -->
 
 <!-- wp:list -->


### PR DESCRIPTION
Fixes #1141 

To test:

Run the `gutenberg-mobile` demo application and there shouldn't be a `red screen`
