### PR TITLE
[DO NOT MERGE] Update `rn-cli.config.js` to load from an outer folder

### DIFF
--- a/rn-cli.config.js
+++ b/rn-cli.config.js
@@ -8,10 +8,22 @@ const blacklistElements = blacklist( [
 	new RegExp( path.basename( __dirname ) + '/gutenberg/gutenberg-mobile/.*' ),
 	new RegExp( path.basename( __dirname ) + '/react-native-aztec-old-submodule/.*' ),
 ] );
+
+function extend(obj, src) {
+    Object.keys(src).forEach(function(key) { obj[key] = src[key]; });
+    return obj;
+}
+
 const enm = require( './extra-node-modules.config.js' );
 
 module.exports = {
-	extraNodeModules: enm,
+	watchFolders:[ '/Users/pinarolguc/Development/mobile-gutenberg-plugin-starter-test/plugins/gutenberg-plugin-hello-world' ],
+	extraNodeModules: extend (
+    {
+      '@wordpress-mobile/gutenberg-plugin-hello-world': '/Users/pinarolguc/Development/mobile-gutenberg-plugin-starter-test/plugins/gutenberg-plugin-hello-world'
+  	},
+    enm
+  ),
 	resolver: {
 		blacklistRE: blacklistElements,
 		sourceExts: [ 'js', 'json', 'scss', 'sass' ],

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,18 @@ const editorSetup = () => {
 	const editPost = require( '@wordpress/edit-post' );
 
 	editPost.initializeEditor();
+	exposeGlobals();
+	require( '@wordpress-mobile/gutenberg-plugin-hello-world' );
+};
+
+const exposeGlobals = () => {
+	window.wp = {
+		blocks: require( '@wordpress/blocks' ),
+		data: require( '@wordpress/data' ),
+		editor: require( '@wordpress/editor' ),
+		element: require( '@wordpress/element' ),
+		i18n: require( '@wordpress/i18n' ),
+	};
 };
 
 const setupLocale = ( locale, extraTranslations ) => {


### PR DESCRIPTION
Fixes #

To test:

clone https://github.com/wordpress-mobile/gutenberg-plugin-hello-world

cd to gutenberg-plugin-hello-world

`npm install`
`npm run start`

Replace plugin directories in `rn-cli.config` with your own.

run `yarn start` at gutenberg-mobile dir

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
