### PR TITLE
Reduce iOS bridge logging

### DIFF
--- a/ios/gutenberg/GutenbergViewController.swift
+++ b/ios/gutenberg/GutenbergViewController.swift
@@ -159,6 +159,8 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
             print("Warn: \(message)")
         case .error:
             print("Error: \(message)")
+        case .fatal:
+            print("Fatal: \(message)")
         }
     }
 }

--- a/react-native-gutenberg-bridge/ios/Gutenberg.swift
+++ b/react-native-gutenberg-bridge/ios/Gutenberg.swift
@@ -29,6 +29,15 @@ public class Gutenberg: NSObject {
         return !bridge.isLoading
     }
 
+    public var logThreshold: LogLevel {
+        get {
+            return LogLevel(RCTGetLogThreshold())
+        }
+        set {
+            RCTSetLogThreshold(RCTLogLevel(newValue))
+        }
+    }
+
     private let bridgeModule = RNReactNativeGutenbergBridge()
     private unowned let dataSource: GutenbergBridgeDataSource
 
@@ -61,6 +70,8 @@ public class Gutenberg: NSObject {
     public init(dataSource: GutenbergBridgeDataSource, extraModules: [RCTBridgeModule] = []) {
         self.dataSource = dataSource
         self.extraModules = extraModules
+        super.init()
+        logThreshold = isPackagerRunning ? .trace : .error
     }
 
     public func invalidate() {
@@ -103,6 +114,10 @@ public class Gutenberg: NSObject {
         bridgeModule.sendEventIfNeeded(name: EventName.setFocusOnTitle, body: nil)
     }
 
+    private var isPackagerRunning: Bool {
+        let url = sourceURL(for: bridge)
+        return !(url?.isFileURL ?? true)
+    }
 }
 
 extension Gutenberg: RCTBridgeDelegate {

--- a/react-native-gutenberg-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/react-native-gutenberg-bridge/ios/GutenbergBridgeDelegate.swift
@@ -19,6 +19,32 @@ public enum LogLevel: Int {
     case info
     case warn
     case error
+    case fatal
+}
+
+// Avoid possible future problems due to log level int value changes.
+extension LogLevel {
+    init (_ rnLogLevel: RCTLogLevel) {
+        switch rnLogLevel {
+        case .trace: self = .trace
+        case .info: self = .info
+        case .warning: self = .warn
+        case .error: self = .error
+        case .fatal: self = .fatal
+        }
+    }
+}
+
+extension RCTLogLevel {
+    init(_ logLevel: LogLevel) {
+        switch logLevel {
+        case .trace: self = .trace
+        case .info: self = .info
+        case .warn: self = .warning
+        case .error: self = .error
+        case .fatal: self = .fatal
+        }
+    }
 }
 
 public protocol GutenbergBridgeDelegate: class {

--- a/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -93,8 +93,18 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
 
     @objc
     func editorDidEmitLog(_ message: String, logLevel: Int) {
-        guard let logLevel = LogLevel(rawValue: logLevel) else { return }
+        guard
+            shouldLog(with: logLevel),
+            let logLevel = LogLevel(rawValue: logLevel)
+        else {
+            return
+        }
+
         delegate?.gutenbergDidEmitLog(message: message, logLevel: logLevel)
+    }
+
+    private func shouldLog(with level: Int) -> Bool {
+        return level >= RCTGetLogThreshold().rawValue
     }
 
     override public func startObserving() {


### PR DESCRIPTION
This PR introduces a way to modify the level of logging. It also modifies the default log level threshold to `trace` if the packager is running (as it was before), and to `error` otherwise (the default for release builds). This help non-gutenberg devs to avoid the gutenberg verbose logs when they interact with the block editor.

**Note:** The sockets error messages are not managed by this PR :( 

To test:
- Launch the demo app from Xcode (ios/gutenberg.xcodeproj) with metro running.
- Check that you see the `Running application gutenberg` logs
  - There is one from JS side sent through the bridge and one directly from the native side.
- Check that you see some warnings when the content appears.
- Rebuild and lunch the app again.
- Stop the metro server while the app is building.
- Check that you don't see any of the previously mentioned logs.

**Note 2:** I'm able to launch the demo app without metro server. I'm not sure if that's the default for anybody now or is because I already launched the UI test suit locally.