### PR TITLE
CircleCI: Speed up iOS device tests by caching gutenberg.app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,13 @@ jobs:
         command: |
           echo 'export TEST_RN_PLATFORM=ios' >> $BASH_ENV
           echo 'export TEST_ENV=sauce' >> $BASH_ENV
+    - run:
+        name: Prepare build cache key
+        command: find yarn.lock ios react-native-aztec/ios react-native-gutenberg-bridge/ios -type f -print0 | sort -z | xargs -0 shasum | tee ios-checksums.txt
+    - restore_cache:
+        name: Restore Build Cache
+        keys:
+          - ios-build-cache-{{ checksum "ios-checksums.txt" }}
     - restore_cache:
         name: Restore Dependencies Cache
         keys:
@@ -108,8 +115,8 @@ jobs:
         - dependencies-{{ checksum "react-native-aztec/ios/Cartfile.resolved" }}
         - dependencies-
     - run:
-        name: Yarn preios
-        command: yarn preios
+        name: Yarn preios (if needed)
+        command: test -e ios/build/gutenberg/Build/Products/Release-iphonesimulator/gutenberg.app || yarn preios
     - save_cache:
         name: Save Dependencies Cache
         key: dependencies-{{ checksum "react-native-aztec/ios/Cartfile.resolved" }}-{{
@@ -117,9 +124,15 @@ jobs:
         paths:
         - react-native-aztec/ios/Carthage
         - ~/.rncache
+    - run: 
+        name: Build (if needed)
+        command: test -e ios/build/gutenberg/Build/Products/Release-iphonesimulator/gutenberg.app || yarn react-native run-ios --configuration Release --no-packager
     - run:
-        name: Bundle iOS and Generate debug .app file for testing
-        command: yarn test:e2e:build-app:ios
+        name: Bundle iOS
+        command: yarn test:e2e:bundle:ios
+    - run:
+        name: Generate .app file for testing
+        command: WORK_DIR=$(pwd) && cd ./ios/build/gutenberg/Build/Products/Release-iphonesimulator && zip -r $WORK_DIR/ios/Gutenberg.app.zip gutenberg.app
     - run:
         name: Upload .app to sauce labs
         command: |
@@ -132,6 +145,14 @@ jobs:
           JEST_JUNIT_OUTPUT: "reports/test-results/ios-test-results.xml"
     - store_test_results:
         path: ./reports/test-results
+    - run:
+        name: Prepare build cache
+        command: rm ios/build/gutenberg/Build/Products/Release-iphonesimulator/gutenberg.app/main.jsbundle
+    - save_cache:
+        name: Save Build Cache
+        key: ios-build-cache-{{ checksum "ios-checksums.txt" }}
+        paths:
+          - ios/build/gutenberg/Build/Products/Release-iphonesimulator/gutenberg.app
 
 workflows:
   gutenberg-mobile:


### PR DESCRIPTION
This reduces the typical time to run iOS device tests on a PR from ~17 minutes to ~9 minutes. It does this by caching `gutenberg.app` and skipping the compiling steps if no native iOS code has changed.

To test:

- See that the device tests ran correctly on this PR.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
