### PR TITLE
CircleCI: Better yarn caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,15 +6,15 @@ commands:
       - restore_cache:
           name: Restore Yarn Cache
           keys:
-            - yarn-v3-{{ arch }}-{{ checksum "yarn.lock" }}
+            - yarn-i18n-v1-{{ arch }}-{{ checksum "yarn.lock" }}
       - run:
           name: Yarn Install
-          command: YARN_CACHE_FOLDER=~/.cache/yarn yarn install --frozen-lockfile
+          command: yarn install --frozen-lockfile --prefer-offline
       - save_cache:
           name: Save Yarn Cache
-          key: yarn-v3-{{ arch }}-{{ checksum "yarn.lock" }}
+          key: yarn-i18n-v1-{{ arch }}-{{ checksum "yarn.lock" }}
           paths:
-            - ~/.cache/yarn
+            - node_modules
             - i18n-cache/data
   checkout-gutenberg:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,15 +6,16 @@ commands:
       - restore_cache:
           name: Restore Yarn Cache
           keys:
-            - yarn-v2-{{ arch }}-{{ checksum "yarn.lock" }}
+            - yarn-v3-{{ arch }}-{{ checksum "yarn.lock" }}
       - run:
           name: Yarn Install
           command: YARN_CACHE_FOLDER=~/.cache/yarn yarn install --frozen-lockfile
       - save_cache:
           name: Save Yarn Cache
-          key: yarn-v2-{{ arch }}-{{ checksum "yarn.lock" }}
+          key: yarn-v3-{{ arch }}-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
+            - i18n-cache/data
   checkout-gutenberg:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,13 @@ commands:
       - restore_cache:
           name: Restore Yarn Cache
           keys:
-            - yarn-i18n-v1-{{ arch }}-{{ checksum "yarn.lock" }}
+            - yarn-i18n-v1-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
       - run:
           name: Yarn Install
           command: yarn install --frozen-lockfile --prefer-offline
       - save_cache:
           name: Save Yarn Cache
-          key: yarn-i18n-v1-{{ arch }}-{{ checksum "yarn.lock" }}
+          key: yarn-i18n-v1-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
             - i18n-cache/data


### PR DESCRIPTION
This makes some small improvements to how we cache `yarn install` on CircleCI. I spotted it was slow even when cached when working on some other things earlier.

The improvement is modest but it adds up. Prior to this, restoring the cache and running `yarn install` took 40 seconds for `Check Correctness` and 80 seconds for `Test iOS on Device`. It now takes 20 and 40 seconds respectively.

This is what I changed:

- We now cache `i18n-cache/data` do it doesn't need to download each time.
- Cache `node_modules/` instead of `~/.cache/yarn`. Most of the time was spent copying files over from here.
- Add `--prefer-offline` to get the best speed we can.
- Use a separate cache for each job. It seems the images each create a slightly different `node_modules/`.

To test:

CI passes 😄 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
