### PR TITLE
Adding `navigator.userAgent` to our globals to solve a crash

### DIFF
--- a/src/globals.js
+++ b/src/globals.js
@@ -54,5 +54,7 @@ if ( ! global.window.matchMedia ) {
 	} );
 }
 
+global.window.navigator.userAgent = [];
+
 // Leverages existing console polyfill from react-native
 global.nativeLoggingHook = nativeLoggingHook;


### PR DESCRIPTION
This PR solves a crash updating the gutenberg ref to master.

The crashing code was introduced here:  https://github.com/WordPress/gutenberg/pull/16065/files
This line in particular: https://github.com/WordPress/gutenberg/blob/3279e116b9486099a681282a7aae050c96f563c6/packages/compose/src/hooks/use-reduced-motion/index.js#L11

The crash:

![IMG_2271](https://user-images.githubusercontent.com/9772967/60681666-6f390d80-9e90-11e9-8e12-d11d70acb059.PNG)

This PR also brings the gutenberg ref up to date with gutenberg master.

**To test:**
- Try to reproduce the error:
  - Check out develop
  - Update the gutenberg ref to master
  - A red screen should appear
- Check out this branch
- Run the app.
- Check that it doesn't crash.
