### PR TITLE
Track unsupported blocks

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.9.0
+------
+* Tapping on an empty editor area will create a new paragraph block
+
 1.8.0
 ------
 * Fix pasting simple text on Post Title

--- a/android/app/src/main/java/com/gutenberg/MainApplication.java
+++ b/android/app/src/main/java/com/gutenberg/MainApplication.java
@@ -5,6 +5,7 @@ import android.util.Log;
 
 import com.facebook.react.ReactApplication;
 import com.brentvatne.react.ReactVideoPackage;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.devsupport.interfaces.DevOptionHandler;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.horcrux.svg.SvgPackage;
@@ -69,7 +70,7 @@ public class MainApplication extends Application implements ReactApplication {
             }
 
             @Override
-            public void editorDidMount(boolean hasUnsupportedBlocks) {
+            public void editorDidMount(ReadableArray unsupportedBlockNames) {
             }
 
             @Override

--- a/ios/gutenberg/GutenbergViewController.swift
+++ b/ios/gutenberg/GutenbergViewController.swift
@@ -50,8 +50,8 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         gutenberg.setFocusOnTitle()
     }
 
-    func gutenbergDidMount(hasUnsupportedBlocks: Bool) {
-        print("gutenbergDidMount(hasUnsupportedBlocks: \(hasUnsupportedBlocks))")
+    func gutenbergDidMount(unsupportedBlockNames: [String]) {
+        print("gutenbergDidMount(unsupportedBlockNames: \(unsupportedBlockNames))")
     }
 
     func gutenbergDidProvideHTML(title: String, html: String, changed: Bool) {

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
@@ -1,9 +1,11 @@
 package org.wordpress.mobile.ReactNativeGutenbergBridge;
 
+import com.facebook.react.bridge.ReadableArray;
+
 public interface GutenbergBridgeJS2Parent {
     void responseHtml(String title, String html, boolean changed);
 
-    void editorDidMount(boolean hasUnsupportedBlocks);
+    void editorDidMount(ReadableArray unsupportedBlockNames);
 
     interface MediaSelectedCallback {
         void onMediaSelected(int mediaId, String mediaUrl);

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -96,8 +96,8 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
     }
 
     @ReactMethod
-    public void editorDidMount(boolean hasUnsupportedBlocks) {
-        mGutenbergBridgeJS2Parent.editorDidMount(hasUnsupportedBlocks);
+    public void editorDidMount(ReadableArray unsupportedBlockNames) {
+        mGutenbergBridgeJS2Parent.editorDidMount(unsupportedBlockNames);
     }
 
     @ReactMethod

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -21,6 +21,7 @@ import com.facebook.react.ReactInstanceManagerBuilder;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.ReactRootView;
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.LifecycleState;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.shell.MainPackageConfig;
@@ -114,7 +115,7 @@ public class WPAndroidGlueCode {
     }
 
     public interface OnEditorMountListener {
-        void onEditorDidMount(boolean hasUnsupportedBlocks);
+        void onEditorDidMount(ReadableArray unsupportedBlockNames);
     }
 
     public interface OnAuthHeaderRequestedListener {
@@ -200,8 +201,8 @@ public class WPAndroidGlueCode {
             }
 
             @Override
-            public void editorDidMount(boolean hasUnsupportedBlocks) {
-                mOnEditorMountListener.onEditorDidMount(hasUnsupportedBlocks);
+            public void editorDidMount(ReadableArray unsupportedBlockNames) {
+                mOnEditorMountListener.onEditorDidMount(unsupportedBlockNames);
                 mIsEditorMounted = true;
                 if (TextUtils.isEmpty(mTitle) && TextUtils.isEmpty(mContentHtml)) {
                     setFocusOnTitle();

--- a/react-native-gutenberg-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/react-native-gutenberg-bridge/ios/GutenbergBridgeDelegate.swift
@@ -95,8 +95,10 @@ public protocol GutenbergBridgeDelegate: class {
     func gutenbergDidLayout()
 
     /// Tells the delegate that the editor view has completed the initial render.
+    /// - Parameters:
+    ///   - unsupportedBlockNames: A list of loaded block names that are not supported.
     ///
-    func gutenbergDidMount(hasUnsupportedBlocks: Bool)
+    func gutenbergDidMount(unsupportedBlockNames: [String])
 
     /// Tells the delegate that logger method is called.
     ///

--- a/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.m
+++ b/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.m
@@ -10,7 +10,7 @@ RCT_EXTERN_METHOD(requestImageUploadCancelDialog:(int)mediaID)
 RCT_EXTERN_METHOD(requestImageUploadCancel:(int)mediaID)
 RCT_EXTERN_METHOD(requestMediaImport:(NSString *)sourceURL callback:(RCTResponseSenderBlock)callback)
 RCT_EXTERN_METHOD(editorDidLayout)
-RCT_EXTERN_METHOD(editorDidMount:(BOOL)hasUnsupportedBlocks)
+RCT_EXTERN_METHOD(editorDidMount:(NSArray *)unsupportedBlockNames)
 RCT_EXTERN_METHOD(editorDidEmitLog:(NSString *)message logLevel:(int)logLevel)
 
 @end

--- a/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -85,9 +85,10 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
     }
 
     @objc
-    func editorDidMount(_ hasUnsupportedBlocks: Bool) {
+    func editorDidMount(_ unsupportedBlockNames: [AnyObject]) {
+        let unsupportedNames = unsupportedBlockNames.compactMap { $0 as? String }
         DispatchQueue.main.async {
-            self.delegate?.gutenbergDidMount(hasUnsupportedBlocks: hasUnsupportedBlocks)
+            self.delegate?.gutenbergDidMount(unsupportedBlockNames: unsupportedNames)
         }
     }
 


### PR DESCRIPTION
This PR fixes #1174 by receiving the list of unsupported blocks from GB when opening a post. 
Basically this PR updates the native bridge and the Android glue code to deal with the changes made in GB. Previously GB was only sending a flag to the bridge, to notify the presence or not of unsupported blocks.

GB side PR: https://github.com/WordPress/gutenberg/pull/16434

I will update `wp-android` and bump the analytics accordingly to the new signature when this PR  is merged. 

To test:
- Open the demo post in the demo app
- Put a breakpoint [here](https://github.com/wordpress-mobile/gutenberg-mobile/compare/issue/1174-track-unsupported-blocks?expand=1#diff-790122ff7222773fbfe709696f8eedc5R73) and check the the array of unsupported block is correct

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
