### PR TITLE
Tapping on an empty editor area creates a new paragraph block

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.9.0
+------
+* Tapping on an empty editor area will create a new paragraph block
+
 1.8.0
 ------
 * Fix pasting simple text on Post Title


### PR DESCRIPTION
This PR introduces tappable empty editor area which creates a new paragraph block.

It's the first iteration of https://github.com/wordpress-mobile/gutenberg-mobile/issues/358 intended for the Beta release. 
Next iteration would cover more complex UI: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1020

Following gutenberg PR: https://github.com/WordPress/gutenberg/pull/16439

To test: 

1. Open the Gutenberg Editor
2. Tap on the empty editor area

Result: New paragraph block should be created

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.