### PR TITLE
Insert blocks at top of post when post title is selected

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 ------
 * Tapping on an empty editor area will create a new paragraph block
 * Fix content loss issue when loading unsupported blocks containing inner blocks.
+* Adding a block from the Post Title now inserts the block at the top of the Post.
 
 1.8.0
 ------


### PR DESCRIPTION
### Summary
This PR updates the behavior when inserting a block which the post's title is selected. Previously, the block would be inserted at the bottom of the post, but now it will be inserted at the top of the post. This work is being done in advance of addressing #632 (missing "Add New Block" indicator when inserting a block from the post's title) so that we're inserting the post at the proper location before we add an "Add New Block" indicator for the insertion position.

[Related gutenberg PR](https://github.com/WordPress/gutenberg/pull/16440)

Before | After
---- | ----
![before mp4](https://user-images.githubusercontent.com/4656348/60742997-93065d00-9f3d-11e9-9284-3de45f48b7b5.gif) | ![after mp4](https://user-images.githubusercontent.com/4656348/60742875-065b9f00-9f3d-11e9-8e81-c0e217e651d6.gif)

### Testing

#### Post Title selected scenario
1. Load demo app
2. Tap on the post Title to select it
3. Add any block
4. Observe that the newly added block is inserted at the **top** of the post

#### No block selected scenario
1. Load demo app
2. Do **NOT** select any block
3. Add any block
4. Observe that the newly added block is inserted at the **bottom** of the post

#### Any block selected scenario
1. Load demo app
2. Select any block **other than the post's Title**
3. Add any block
4. Observe that the newly added block is inserted below the previously selected block

### Update release notes

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
