### PR TITLE
Fixed flaky issues with Android device tests

### DIFF
--- a/__device-tests__/gutenberg-editor-rotatation.test.js
+++ b/__device-tests__/gutenberg-editor-rotatation.test.js
@@ -64,6 +64,10 @@ describe( 'Gutenberg Editor tests', () => {
 		}
 
 		paragraphBlockElement = await editorPage.getParagraphBlockAtPosition( 2 );
+		while ( ! paragraphBlockElement ) {
+			await driver.hideDeviceKeyboard();
+			paragraphBlockElement = await editorPage.getParagraphBlockAtPosition( 2 );
+		}
 		await editorPage.sendTextToParagraphBlock( paragraphBlockElement, testData.mediumText );
 		await toggleOrientation( driver );
 

--- a/__device-tests__/helpers/utils.js
+++ b/__device-tests__/helpers/utils.js
@@ -216,7 +216,9 @@ const tapCopyAboveElement = async ( driver: wd.PromiseChainWebdriver, element: w
 	const action = await new wd.TouchAction( driver );
 	const x = location.x + 220;
 	const y = location.y - 50;
+	action.wait( 2000 );
 	action.press( { x, y } );
+	action.wait( 2000 );
 	action.release();
 	await action.perform();
 };
@@ -225,7 +227,9 @@ const tapCopyAboveElement = async ( driver: wd.PromiseChainWebdriver, element: w
 const tapPasteAboveElement = async ( driver: wd.PromiseChainWebdriver, element: wd.PromiseChainWebdriver.Element ) => {
 	const location = await element.getLocation();
 	const action = await new wd.TouchAction( driver );
+	action.wait( 2000 );
 	action.press( { x: location.x + 100, y: location.y - 50 } );
+	action.wait( 2000 );
 	action.release();
 	await action.perform();
 };


### PR DESCRIPTION
This PR patches 2 things on Android
1. when running the Copy/Paste test locally, the click of `Select all` can sometimes accidentally touch the element before the next context menu appears. 
2. When running the device test locally, it could fail to find the paragraph block while the keyboard is being hidden

Tested on: Pixel and Pixel 2 XL emulators and on Pixel 3a physical device

To test: Run the full e2e test suite locally, they should pass 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
