### PR TITLE
Fix content loss in Group block

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 1.9.0
 ------
 * Tapping on an empty editor area will create a new paragraph block
+* Fix content loss issue when loading blocks containing inner blocks.
 
 1.8.0
 ------

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 1.9.0
 ------
 * Tapping on an empty editor area will create a new paragraph block
-* Fix content loss issue when loading blocks containing inner blocks.
+* Fix content loss issue when loading unsupported blocks containing inner blocks.
 
 1.8.0
 ------


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1206

Gutenberg side PR: https://github.com/WordPress/gutenberg/pull/14443

To test:
- Boot the demo app with the following value in `initial-html.js`
```
<!-- wp:group -->
<div class="wp-block-group"><div class="wp-block-group__inner-container">
<!-- wp:paragraph -->
<p>hello world</p>
<!-- /wp:paragraph -->
</div></div>
<!-- /wp:group -->
```
- switch to html and notice the value is preserved.
- Try the repro step on https://github.com/wordpress-mobile/gutenberg-mobile/issues/1206 on WPiOS and WPAndroid to make sure no content is loss.

Update release notes:

- [ ] If there are user facing changes, I have added an item to RELEASE-NOTES.txt.
