### PR TITLE
Update react-native-svg version

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "react-native-modal": "^6.5.0",
     "react-native-recyclerview-list": "git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#eadaa2f62d2f488d4dc80f9148e52b62047297ab",
     "react-native-safe-area": "^0.5.0",
-    "react-native-svg": "git+https://github.com/wordpress-mobile/react-native-svg.git#466a40ec77080e1b64b5a1a3c779cdfdc04b3abe",
+    "react-native-svg": "git+https://github.com/wordpress-mobile/react-native-svg.git#f16e9adae71c6cf3158f2356cf95fff5c2075e0f",
     "react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#3a0e2fa6fc6bf1fe1a54adb2dbf94545b28c2bc4",
     "react-redux": "^5.0.7",
     "redux": "^3.7.2",

--- a/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json
+++ b/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json
@@ -1,13 +1,13 @@
 {
   "name": "RNSVG",
-  "version": "9.3.3",
+  "version": "9.3.3-gb",
   "summary": "SVG library for react-native",
   "license": "MIT",
   "homepage": "https://github.com/react-native-community/react-native-svg",
   "authors": "Horcrux Chen",
   "source": {
-    "git": "https://github.com/react-native-community/react-native-svg.git",
-    "tag": "9.3.3"
+    "git": "https://github.com/wordpress-mobile/react-native-svg.git",
+    "tag": "9.3.3-gb"
   },
   "source_files": "ios/**/*.{h,m}",
   "requires_arc": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10695,9 +10695,9 @@ react-native-sass-transformer@^1.1.1:
     css-to-react-native-transform "^1.8.1"
     semver "^5.6.0"
 
-"react-native-svg@git+https://github.com/wordpress-mobile/react-native-svg.git#466a40ec77080e1b64b5a1a3c779cdfdc04b3abe":
-  version "9.3.3"
-  resolved "git+https://github.com/wordpress-mobile/react-native-svg.git#466a40ec77080e1b64b5a1a3c779cdfdc04b3abe"
+"react-native-svg@git+https://github.com/wordpress-mobile/react-native-svg.git#f16e9adae71c6cf3158f2356cf95fff5c2075e0f":
+  version "9.3.3-gb"
+  resolved "git+https://github.com/wordpress-mobile/react-native-svg.git#f16e9adae71c6cf3158f2356cf95fff5c2075e0f"
 
 "react-native-video@git+https://github.com/wordpress-mobile/react-native-video.git#3a0e2fa6fc6bf1fe1a54adb2dbf94545b28c2bc4":
   version "4.4.1"


### PR DESCRIPTION
This updates the `react-native-svg` hash to include the fix from https://github.com/wordpress-mobile/react-native-svg/pull/5 (should be merged first). It ensures `pod install` doesn't use an old, cached version of `9.3.3`.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
