### PR TITLE
Show "add block here" placeholder when adding block from title

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.10.0
+------
+* Adding a block from the post title now shows the add block here indicator.
+
 1.9.0
 ------
 * Enable video block on Android platform


### PR DESCRIPTION
## Summary

Fixes #632 : "Add Block Here" (ABH) indicator isn't shown when title field is focused.

[Related gutenberg PR](https://github.com/WordPress/gutenberg/pull/16539)

Before | After
----- | -----
![image](https://user-images.githubusercontent.com/4656348/61056660-c293ea00-a3c1-11e9-83e7-8a067f6e19d6.png) | ![image](https://user-images.githubusercontent.com/4656348/61056739-e5be9980-a3c1-11e9-98ed-a5d9fb2ee3f9.png)


### Remaining Issue

The ABH indicator is still not shown when a new post is created and a new block is added _before_ the user has interacted with the post content (i.e. if the user either tries to add a block first thing or only interacts with the post title, then adding a new block will not display the ABH indicator). This is because the ABH indicator is attached to our block holders, but until the user taps on the "Start writing..." placeholder text in a new post, the post does not actually contain any blocks (it just has a `RichText` field that is replaced with a block `onTouch`). This actually may not be a bad thing since in that scenario we replace the entire "Start writing..." text with whatever block is added, but it is inconsistent with how we handle other similar scenarios. I will reach out for some design feedback in [the issue](https://github.com/wordpress-mobile/gutenberg-mobile/issues/632) and make any needed updates to address this edge case in a separate PR.

## To Test

### Main Functionality
1. Open demo app (or if using the full app, open a post that is _not_ empty in order to avoid ⬆️Remaining Issue⬆️)
2. Tap on the post's title
3. Tap the ➕ to bring up the add post bottom sheet
4. Observe the ABH indicator is shown immediately below the title and above the first block in the post

### Regression check 
1. Open demo app (or if using the full app, open a post that is _not_ empty in order to avoid ⬆️Remaining Issue⬆️)
2. Add an empty paragraph block
3. Insure that new empty paragraph block is selected
4. Tap the ➕ to bring up the add post bottom sheet
5. Observe that the ABH indicator appears *above* the selected empty paragraph block
6. Dismiss the add post bottom sheet
7. Add some content to the paragraph block so that it is not empty
8. Tap the ➕ to bring up the add post bottom sheet
9. Observe that the ABH indicator appears *below* the selected non-empty paragraph block

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
