### PR TITLE
When inserting block from title replace block if appropriate

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 ------
 * Adding a block from the post title now shows the add block here indicator.
 * Deselect post title any time a block is added
+* Fix merging of empty paragraph blocks when added from a post's title
 
 1.9.0
 ------


### PR DESCRIPTION
### Summary
Fixes an issue where inserting a block from the post title would not replace an empty paragraph block if that block was the first block in the post. Instead it would add a second empty paragraph block at the beginning of the post.

See [related gutenberg PR](https://github.com/WordPress/gutenberg/pull/16574) for further detail and testing instructions

### Update release notes:

~~I did not update the release notes because this seemed like a minor fix for an issue that was just introduced in 1.9, and which very few users would ever encounter. Just let me know if anyone thinks this should go in the release notes.~~

Release notes updated.
