### PR TITLE
Remove references to node 9 errors in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,6 @@ nvm install --latest-npm
 yarn install
 ```
 
-Note: using node v9.x currently produces the following error:
-```
-error sane@3.1.0: The engine "node" is incompatible with this module. Expected version "6.* || 8.* || >= 10.*".
-```
-To be revisited, as we don't need to impose a limit in version per se.
-
 ## Run
 
 ```


### PR DESCRIPTION
Node 9.x doesn't really seem relevant anymore since we are now directing devs to setup with `nvm install --latest-npm` (currently v.12.6.0), so I thought we might as well remove these lines in order to avoid any possible confusion. I think they're just a remnant from when the project needed node 8.x instead of 9.x. 

Just let me know if you think there's any reason we should keep this in here.

To test: N/A
Update release notes: N/A