### PR TITLE
Blur post title any time a new block is added

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 1.10.0
 ------
 * Adding a block from the post title now shows the add block here indicator.
+* Deselect post title any time a block is added
 
 1.9.0
 ------


### PR DESCRIPTION
[Related gutenberg PR](https://github.com/WordPress/gutenberg/pull/16642)

## Description
Fixes #932 , which was the problem that any time the post title was selected and a new image block was added, the post title would retain focus (i.e., the cursor). In fact, this issue occurred anytime a non-text block is added from the `post-title`. In particular, adding `image`, `video`, `more`, `seperator`, or `page break` blocks all leave focus with the post's title if it had focus immediately before the new block was added.

Before | After
---- | ----
![title-focus_before mp4](https://user-images.githubusercontent.com/4656348/61403953-668b0300-a8a4-11e9-948d-28746065aee0.gif) | ![title-focus_after mp4](https://user-images.githubusercontent.com/4656348/61403780-08f6b680-a8a4-11e9-9d4e-98d32db459ef.gif)


## Implementation and Alternative Approaches

This PR insures the post-title is not selected when a new block is created by updating the post title to not be selected any time there is a selected block in the redux store (the post's title itself is not considered a selected block).

An alternative approach would have been to have the `visual-editor` give the `block-list` a callback that would [set the `visual-editor`'s `isPostTitleSelected` prop to false](https://github.com/WordPress/gutenberg/blob/master/packages/edit-post/src/components/visual-editor/index.native.js#L34). The `block-list` could then execute that callback any time that a new block was added via its [`onBlockTypeSelected` method](https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/block-list/index.native.js#L58). I did not use this approach because the redux store already knows whether a block is selected, and I wanted to avoid communicating that same information in a second way.

Another approach would be to move the post title's selected state itself into the redux store. This would have the advantage of simplifying the passing of that state information. Currently, the `visual-editor` holds that state so it can pass it down to both the `block-list` and `post-title` components. In addition, we are passing a ref to the `post-title` all the way up to the `Editor` component ([post-title](https://github.com/WordPress/gutenberg/blob/master/packages%2Feditor%2Fsrc%2Fcomponents%2Fpost-title%2Findex.native.js#L33) -> [visual-editor](https://github.com/WordPress/gutenberg/blob/master/packages/edit-post/src/components/visual-editor/index.native.js#L48) -> [layout](https://github.com/WordPress/gutenberg/blob/master/packages%2Fedit-post%2Fsrc%2Fcomponents%2Flayout%2Findex.native.js#L95) -> [edit-post](https://github.com/WordPress/gutenberg/blob/master/packages/edit-post/src/editor.native.js#L149)) so that the post title [can be selected from the native side](https://github.com/WordPress/gutenberg/blob/master/packages/edit-post/src/editor.native.js#L76). I did not go with this approach because both of the reasons we need to share/update the post-title's state are mobile specific, so this would cause the store for mobile to be different from web.

Would appreciate any other opinions on how best to approach this.

## Testing

### Fixes #932 
1. Open a post
2. Select the post's title
3. Add any "non-text" block (`image`, `video`, `more`, `separator`, or `page break`)
4. Observe that there is no longer an active cursor on the post's title.

### [Regression check](https://github.com/wordpress-mobile/WordPress-iOS/issues/10594)
1. Open WPAndroid/WPiOS
2. Create a new (empty) post
3. Observe that the post's title is selected with an active cursor


#### 

## Update release notes

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
