### PR TITLE
Update vscode extension config to prevent VSCode to show a warning on project opening

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
     "recommendations": [
         "gcazaciuc.vscode-flow-ide",
-        "vsmobile.vscode-react-native"
+        "msjsdiag.vscode-react-native"
     ]
 }


### PR DESCRIPTION
Update vscode extension config to prevent VSCode to show a warning on project opening.

I noticed this warning in VSCode:

<img width="480" alt="Screenshot 2019-07-23 at 11 06 39" src="https://user-images.githubusercontent.com/40213/61699462-3f688180-ad3b-11e9-9fbf-a191fb0af0c3.png">

In version 0.9.3, they changed extension publisher from `vsmobile` to `msjsdiag`, see release notes there: https://github.com/microsoft/vscode-react-native/blob/master/CHANGELOG.md#093

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
