### PR TITLE
Revert when inserting block from title replace block if appropriate

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * Deselect post title any time a block is added
 * Fix merging of empty paragraph blocks when added from a post's title
 * Fix loss of center alignment in image captions on Android
+* Fix loss of center alignment in image captions
 
 1.9.0
 ------


### PR DESCRIPTION
Reverting change that made it so that multiple empty paragraph blocks could not be inserted from the post title. [Related gutenber PR](https://github.com/WordPress/gutenberg/pull/16773).

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
