### PR TITLE
Enforce Prettier (add CI and pre-commit hook)

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,25 +1,22 @@
+/** @format */
+
 module.exports = function( api ) {
 	api.cache( true );
 	return {
-		presets: [
-			'module:metro-react-native-babel-preset',
-		],
+		presets: [ 'module:metro-react-native-babel-preset' ],
 		plugins: [
 			'@babel/plugin-proposal-async-generator-functions',
 			'@babel/plugin-transform-runtime',
 			[
 				'react-native-platform-specific-extensions',
 				{
-					extensions: [
-						'css',
-						'scss',
-						'sass',
-					],
+					extensions: [ 'css', 'scss', 'sass' ],
 				},
 			],
 		],
 		overrides: [
-			{ // Transforms JSX into JS function calls and use `createElement` instead of the default `React.createElement`
+			{
+				// Transforms JSX into JS function calls and use `createElement` instead of the default `React.createElement`
 				plugins: [
 					[
 						'@babel/plugin-transform-react-jsx',
@@ -31,7 +28,8 @@ module.exports = function( api ) {
 				],
 				exclude: /node_modules\/react-native/,
 			},
-			{ // Auto-add `import { createElement } from '@wordpress/element';` when JSX is found
+			{
+				// Auto-add `import { createElement } from '@wordpress/element';` when JSX is found
 				plugins: [
 					[
 						'./gutenberg/packages/babel-plugin-import-jsx-pragma',
@@ -48,9 +46,7 @@ module.exports = function( api ) {
 		],
 		env: {
 			development: {
-				plugins: [
-					'@babel/transform-react-jsx-source',
-				],
+				plugins: [ '@babel/transform-react-jsx-source' ],
 			},
 		},
 	};

--- a/bin/ci-checks-js.sh
+++ b/bin/ci-checks-js.sh
@@ -16,7 +16,7 @@ fi
 if [ "$CHECK_CORRECTNESS" = true ] ; then
   yarn flow || pFail
   yarn lint || pFail
-  yarn prettier:check || { echo "ERROR: 'yarn prettier:check' found a problem"; pFail; }
+  yarn prettier:check || pFail
 fi
 
 if [ "$GUTENBERG_AS_PARENT" = true ] ; then

--- a/bin/ci-checks-js.sh
+++ b/bin/ci-checks-js.sh
@@ -16,6 +16,7 @@ fi
 if [ "$CHECK_CORRECTNESS" = true ] ; then
   yarn flow || pFail
   yarn lint || pFail
+  yarn prettier:check || { echo "ERROR: 'yarn prettier:check' found a problem"; pFail; }
 fi
 
 if [ "$GUTENBERG_AS_PARENT" = true ] ; then

--- a/jest.config.js
+++ b/jest.config.js
@@ -33,7 +33,10 @@ module.exports = {
 		'/__device-tests__/',
 	],
 	testURL: 'http://localhost/',
-	modulePathIgnorePatterns: [ '<rootDir>/gutenberg/gutenberg-mobile', 'react-native-aztec-old-submodule' ],
+	modulePathIgnorePatterns: [
+		'<rootDir>/gutenberg/gutenberg-mobile',
+		'react-native-aztec-old-submodule',
+	],
 	moduleDirectories: [ 'node_modules', 'symlinked-packages' ],
 	moduleNameMapper: {
 		// Mock the CSS modules. See https://facebook.github.io/jest/docs/en/webpack.html#handling-static-assets
@@ -41,16 +44,9 @@ module.exports = {
 	},
 	haste: {
 		defaultPlatform: rnPlatform,
-		platforms: [
-			'android',
-			'ios',
-			'native',
-		],
+		platforms: [ 'android', 'ios', 'native' ],
 		hasteImplModulePath: '<rootDir>/node_modules/react-native/jest/hasteImpl.js',
-		providesModuleNodeModules: [
-			'react-native',
-			'react-native-svg',
-		],
+		providesModuleNodeModules: [ 'react-native', 'react-native-svg' ],
 	},
 	transformIgnorePatterns: [
 		// This is required for now to have jest transform some of our modules
@@ -59,8 +55,6 @@ module.exports = {
 		// https://github.com/facebook/react-native/blob/master/jest-preset.json#L20
 		'node_modules/(?!(simple-html-tokenizer|(jest-)?react-native|react-clone-referenced-element))',
 	],
-	snapshotSerializers: [
-		'enzyme-to-json/serializer',
-	],
+	snapshotSerializers: [ 'enzyme-to-json/serializer' ],
 	reporters: [ 'default', 'jest-junit' ],
 };

--- a/libdefs.js
+++ b/libdefs.js
@@ -8,5 +8,5 @@ declare module 'react-native' {
 }
 
 declare module 'react-native/lib/TextInputState' {
-    declare module.exports: any;
+	declare module.exports: any;
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint-plugin-react-native": "^3.6.0",
     "eslint-plugin-wordpress": "git://github.com/WordPress-Coding-Standards/eslint-plugin-wordpress.git#552af1454d175e15f6d25aadc2ccde30a1922d4f",
     "flow-bin": "0.92.0",
+    "husky": "^3.0.2",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^24.1.0",
     "jest-junit": "^6.3.0",
@@ -49,6 +50,11 @@
     "rungen": "^0.3.2",
     "sprintf-js": "^1.1.1",
     "wd": "^1.11.1"
+  },
+  "husky": {
+      "hooks": {
+          "pre-commit": "yarn prettier:check || { echo '\nERROR: `yarn prettier:check` found a problem\n'; exit 1; }"
+      }
   },
   "scripts": {
     "start": "react-native start",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "test:e2e:install-app:ios": "yarn test:e2e:build-app:ios",
     "flow": "flow",
     "prettier": "prettier-eslint --write $npm_package_config_jsfiles $npm_package_config_scssfiles",
+    "prettier:check": "prettier-eslint --list-different $npm_package_config_jsfiles $npm_package_config_scssfiles",
     "clean": "yarn clean:aztec; yarn cache clean; yarn clean:haste; yarn clean:jest; yarn clean:metro; yarn clean:react; yarn clean:watchman; yarn clean:node;",
     "clean:runtime": "yarn clean:haste; yarn clean:react; yarn clean:metro; yarn clean:jest; yarn clean:watchman; yarn clean:babel-cache",
     "clean:aztec": "cd react-native-aztec && yarn clean && cd example && yarn clean",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "husky": {
       "hooks": {
-          "pre-commit": "yarn prettier:check || { echo '\nERROR: `yarn prettier:check` found a problem\n'; exit 1; }"
+          "pre-commit": "yarn prettier:check"
       }
   },
   "scripts": {
@@ -107,7 +107,7 @@
     "test:e2e:install-app:ios": "yarn test:e2e:build-app:ios",
     "flow": "flow",
     "prettier": "prettier-eslint --write $npm_package_config_jsfiles $npm_package_config_scssfiles",
-    "prettier:check": "prettier-eslint --list-different $npm_package_config_jsfiles $npm_package_config_scssfiles",
+    "prettier:check": "prettier-eslint --list-different $npm_package_config_jsfiles $npm_package_config_scssfiles || { echo '\nERROR: `yarn prettier:check` found a formatting problem.\nNo files have been changed. Try running `yarn prettier` to fix any formatting issues.\n'; exit 1; }",
     "clean": "yarn clean:aztec; yarn cache clean; yarn clean:haste; yarn clean:jest; yarn clean:metro; yarn clean:react; yarn clean:watchman; yarn clean:node;",
     "clean:runtime": "yarn clean:haste; yarn clean:react; yarn clean:metro; yarn clean:jest; yarn clean:watchman; yarn clean:babel-cache",
     "clean:aztec": "cd react-native-aztec && yarn clean && cd example && yarn clean",

--- a/rn-cli-inside-gb.config.js
+++ b/rn-cli-inside-gb.config.js
@@ -3,7 +3,9 @@ const path = require( 'path' );
 const blacklist = require( 'metro-config/src/defaults/blacklist' );
 // Blacklist the nested GB filetree so modules are not resolved in duplicates,
 //  both in the nested directory and the parent directory.
-const blacklistElements = blacklist( [ new RegExp( path.basename( __dirname ) + '/gutenberg/.*' ) ] );
+const blacklistElements = blacklist( [
+	new RegExp( path.basename( __dirname ) + '/gutenberg/.*' ),
+] );
 
 const enm = require( './extra-node-modules.config.js' );
 
@@ -19,7 +21,9 @@ const mapper = function( accu, v ) {
 };
 
 const wppackages = wppackagenames.reduce( mapper, {} );
-const alternateRoots = [ path.resolve( __dirname, '../node_modules' ) ].concat( Object.values( wppackages ) );
+const alternateRoots = [ path.resolve( __dirname, '../node_modules' ) ].concat(
+	Object.values( wppackages )
+);
 
 module.exports = {
 	extraNodeModules: Object.assign( enm, wppackages ),

--- a/sass-transformer-inside-gb.js
+++ b/sass-transformer-inside-gb.js
@@ -62,9 +62,7 @@ if ( reactNativeMinorVersion >= 56 ) {
 }
 
 // TODO: need to find a way to pass the include paths and the default asset files via some config
-const autoImportIncludePaths = [
-	path.join( path.dirname( __filename ), '../assets/stylesheets' ),
-];
+const autoImportIncludePaths = [ path.join( path.dirname( __filename ), '../assets/stylesheets' ) ];
 const autoImportAssets = [
 	'_colors.scss',
 	'_breakpoints.scss',

--- a/src/_colors.scss
+++ b/src/_colors.scss
@@ -94,22 +94,22 @@ $blue-500: #016087;
 
 // Grays
 $gray: #87a6bc;
-$gray-light: lighten( $gray, 33% ); //#f3f6f8
-$gray-dark: darken( $gray, 38% ); //#2e4453
-$gray-900: #1A1A1A;
+$gray-light: lighten($gray, 33%); //#f3f6f8
+$gray-dark: darken($gray, 38%); //#2e4453
+$gray-900: #1a1a1a;
 
 // $gray-text: ideal for standard, non placeholder text
 // $gray-text-min: minimum contrast needed for WCAG 2.0 AA on white background
 $gray-text: $gray-dark;
-$gray-text-min: darken( $gray, 18% ); //#537994
+$gray-text-min: darken($gray, 18%); //#537994
 
 // Shades of gray
-$gray-lighten-10: lighten( $gray, 10% ); // #a8bece
-$gray-lighten-20: lighten( $gray, 20% ); // #c8d7e1
-$gray-lighten-30: lighten( $gray, 30% ); // #e9eff3
-$gray-darken-10: darken( $gray, 10% ); // #668eaa
-$gray-darken-20: darken( $gray, 20% ); // #4f748e
-$gray-darken-30: darken( $gray, 30% ); // #3d596d
+$gray-lighten-10: lighten($gray, 10%); // #a8bece
+$gray-lighten-20: lighten($gray, 20%); // #c8d7e1
+$gray-lighten-30: lighten($gray, 30%); // #e9eff3
+$gray-darken-10: darken($gray, 10%); // #668eaa
+$gray-darken-20: darken($gray, 20%); // #4f748e
+$gray-darken-30: darken($gray, 30%); // #3d596d
 
 //
 // See wordpress.com/design-handbook/colors/ for more info.

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,11 @@
 /**
  * External dependencies
+ *
+ * @format
+ */
+
+/**
+ * External dependencies
  */
 import { AppRegistry, I18nManager, YellowBox } from 'react-native';
 import React from 'react';

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,4 +1,3 @@
-
 /** @format */
 
 /**
@@ -45,32 +44,32 @@ describe( 'RootComponent', () => {
 	it( 'Code block is a TextInput', () => {
 		const app = renderer.create( <RootComponent /> );
 
-		app.root.findAllByType( BlockListBlock )
-			.forEach( ( blockHolder ) => {
-				if ( 'core/code' === blockHolder.props.name ) {
-					// TODO: hardcoded indices are ugly and error prone. Can we do better here?
-					const blockHolderContainer = blockHolder.children[ 0 ].children[ 0 ].children[ 0 ].children[ 0 ].children[ 0 ];
-					const contentComponent = blockHolderContainer.children[ 0 ];
-					const inputComponent =
-						contentComponent.children[ 0 ].children[ 0 ].children[ 0 ].children[ 0 ].children[ 0 ]
-							.children[ 0 ].children[ 0 ].children[ 0 ].children[ 0 ].children[ 0 ].children[ 0 ].children[ 0 ];
+		app.root.findAllByType( BlockListBlock ).forEach( ( blockHolder ) => {
+			if ( 'core/code' === blockHolder.props.name ) {
+				// TODO: hardcoded indices are ugly and error prone. Can we do better here?
+				const blockHolderContainer =
+					blockHolder.children[ 0 ].children[ 0 ].children[ 0 ].children[ 0 ].children[ 0 ];
+				const contentComponent = blockHolderContainer.children[ 0 ];
+				const inputComponent =
+					contentComponent.children[ 0 ].children[ 0 ].children[ 0 ].children[ 0 ].children[ 0 ]
+						.children[ 0 ].children[ 0 ].children[ 0 ].children[ 0 ].children[ 0 ].children[ 0 ]
+						.children[ 0 ];
 
-					expect( inputComponent.type ).toBe( 'TextInput' );
-				}
-			} );
+				expect( inputComponent.type ).toBe( 'TextInput' );
+			}
+		} );
 
 		app.unmount();
 	} );
 
 	it( 'Heading block test', () => {
 		const app = renderer.create( <RootComponent /> );
-		app.root.findAllByType( BlockListBlock )
-			.forEach( ( blockHolder ) => {
-				if ( 'core/heading' === blockHolder.props.name ) {
-					const aztec = blockHolder.findByType( 'RCTAztecView' );
-					expect( aztec.props.text.text ).toBe( '<h2>What is Gutenberg?</h2>' );
-				}
-			} );
+		app.root.findAllByType( BlockListBlock ).forEach( ( blockHolder ) => {
+			if ( 'core/heading' === blockHolder.props.name ) {
+				const aztec = blockHolder.findByType( 'RCTAztecView' );
+				expect( aztec.props.text.text ).toBe( '<h2>What is Gutenberg?</h2>' );
+			}
+		} );
 		app.unmount();
 	} );
 } );

--- a/src/jsdom-patches.js
+++ b/src/jsdom-patches.js
@@ -2,18 +2,18 @@
  * @format */
 
 /**
-* This file is used in src/globals.js to patch jsdom-jscore.
-*
-* Node.prototype.contains is implemented as a simple recursive function.
-*
-* Node.prototype.insertBefore is re-implemented (code copied) with the
-* WrongDocumentError exception disabled.
-*
-* Element.prototype.matches is aliased to Element.prototype.matchesSelector.
-*
-* Getters are defined on the Node.prototype for the following properties:
-* parentElement, previousElementSibling, nextElementSibling.
-*/
+ * This file is used in src/globals.js to patch jsdom-jscore.
+ *
+ * Node.prototype.contains is implemented as a simple recursive function.
+ *
+ * Node.prototype.insertBefore is re-implemented (code copied) with the
+ * WrongDocumentError exception disabled.
+ *
+ * Element.prototype.matches is aliased to Element.prototype.matchesSelector.
+ *
+ * Getters are defined on the Node.prototype for the following properties:
+ * parentElement, previousElementSibling, nextElementSibling.
+ */
 
 /**
  * External dependencies
@@ -28,17 +28,10 @@ const { core } = jsdomLevel1Core.dom.level1;
 const { Node, Element, CharacterData } = core;
 
 // Exception codes
-const {
-	NO_MODIFICATION_ALLOWED_ERR,
-	HIERARCHY_REQUEST_ERR,
-	NOT_FOUND_ERR,
-} = core;
+const { NO_MODIFICATION_ALLOWED_ERR, HIERARCHY_REQUEST_ERR, NOT_FOUND_ERR } = core;
 
 // Node types
-const {
-	ATTRIBUTE_NODE,
-	DOCUMENT_FRAGMENT_NODE,
-} = Node;
+const { ATTRIBUTE_NODE, DOCUMENT_FRAGMENT_NODE } = Node;
 
 /**
  * Simple recursive implementation of Node.contains method
@@ -51,10 +44,12 @@ const {
  * expectation that this is implemented (as it is in the browser environment).
  */
 Node.prototype.contains = function( otherNode ) {
-	return this === otherNode ||
+	return (
+		this === otherNode ||
 		Array.prototype.some.call( this._childNodes, ( childNode ) => {
 			return childNode.contains( otherNode );
-		} );
+		} )
+	);
 };
 
 /**
@@ -71,7 +66,10 @@ Node.prototype.contains = function( otherNode ) {
  */
 Node.prototype.insertBefore = function( /* Node */ newChild, /* Node*/ refChild ) {
 	if ( this._readonly === true ) {
-		throw new core.DOMException( NO_MODIFICATION_ALLOWED_ERR, 'Attempting to modify a read-only node' );
+		throw new core.DOMException(
+			NO_MODIFICATION_ALLOWED_ERR,
+			'Attempting to modify a read-only node'
+		);
 	}
 
 	// Adopt unowned children, for weird nodes like DocumentType

--- a/yarn.lock
+++ b/yarn.lock
@@ -1728,6 +1728,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.2.tgz#a5ccec6abb6060d5f20d256fb03ed743e9774999"
   integrity sha512-gojym4tX0FWeV2gsW4Xmzo5wxGjXGm550oVUII7f7G5o4BV6c7DBdiG1RRQd+y1bvqRyYtPfMK85UM95vsapqQ==
 
+"@types/normalize-package-data@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
+  integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
+
 "@types/prop-types@*":
   version "15.7.1"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
@@ -4011,7 +4016,7 @@ cosmiconfig@3.1.0:
     parse-json "^3.0.0"
     require-from-string "^2.0.1"
 
-cosmiconfig@^5.0.5:
+cosmiconfig@^5.0.5, cosmiconfig@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
   integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
@@ -5548,6 +5553,14 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
+find-up@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
+  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
+  dependencies:
+    locate-path "^5.0.0"
+    path-exists "^4.0.0"
+
 fkill@^6.0.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/fkill/-/fkill-6.2.0.tgz#a5c0ab65e0469578d0b648a86ac8526fc5ab5fa2"
@@ -5803,6 +5816,11 @@ get-stdin@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
   integrity sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=
+
+get-stdin@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-7.0.0.tgz#8d5de98f15171a125c5e516643c7a6d0ea8a96f6"
+  integrity sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==
 
 get-stream@3.0.0, get-stream@^3.0.0:
   version "3.0.0"
@@ -6180,6 +6198,23 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
+
+husky@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-3.0.2.tgz#e78fd2ae16edca59fc88e56aeb8d70acdcc1c082"
+  integrity sha512-WXCtaME2x0o4PJlKY4ap8BzLA+D0zlvefqAvLCPriOOu+x0dpO5uc5tlB7CY6/0SE2EESmoZsj4jW5D09KrJoA==
+  dependencies:
+    chalk "^2.4.2"
+    cosmiconfig "^5.2.1"
+    execa "^1.0.0"
+    get-stdin "^7.0.0"
+    is-ci "^2.0.0"
+    opencollective-postinstall "^2.0.2"
+    pkg-dir "^4.2.0"
+    please-upgrade-node "^3.1.1"
+    read-pkg "^5.1.1"
+    run-node "^1.0.0"
+    slash "^3.0.0"
 
 iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@^0.4.5, iconv-lite@~0.4.13:
   version "0.4.24"
@@ -7580,6 +7615,11 @@ lie@~3.3.0:
   dependencies:
     immediate "~3.0.5"
 
+lines-and-columns@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
+  integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
+
 linked-list@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/linked-list/-/linked-list-0.1.0.tgz#798b0ff97d1b92a4fd08480f55aea4e9d49d37bf"
@@ -7645,6 +7685,13 @@ locate-path@^3.0.0:
   dependencies:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
+
+locate-path@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
+  integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
+  dependencies:
+    p-locate "^4.1.0"
 
 lodash-es@^4.2.1:
   version "4.17.14"
@@ -8875,7 +8922,7 @@ nopt@^4.0.1, nopt@~4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
-normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
+normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
   integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
@@ -9099,6 +9146,11 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+opencollective-postinstall@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
+  integrity sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==
+
 openssl-wrapper@^0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/openssl-wrapper/-/openssl-wrapper-0.3.4.tgz#c01ec98e4dcd2b5dfe0b693f31827200e3b81b07"
@@ -9213,7 +9265,7 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.0.0:
+p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
   integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==
@@ -9233,6 +9285,13 @@ p-locate@^3.0.0:
   integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
   dependencies:
     p-limit "^2.0.0"
+
+p-locate@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
+  integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
+  dependencies:
+    p-limit "^2.2.0"
 
 p-reduce@^1.0.0:
   version "1.0.0"
@@ -9343,6 +9402,16 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
+parse-json@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.0.0.tgz#73e5114c986d143efa3712d4ea24db9a4266f60f"
+  integrity sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
+    lines-and-columns "^1.1.6"
+
 parse-listing@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/parse-listing/-/parse-listing-1.1.3.tgz#aa546f57fdc129cfbf9945cd4b757b14b06182dd"
@@ -9391,6 +9460,11 @@ path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
   integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
+
+path-exists@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -9549,6 +9623,20 @@ pkg-dir@^3.0.0:
   integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
   dependencies:
     find-up "^3.0.0"
+
+pkg-dir@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
+  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
+  dependencies:
+    find-up "^4.0.0"
+
+please-upgrade-node@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz#ed320051dfcc5024fae696712c8288993595e8ac"
+  integrity sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==
+  dependencies:
+    semver-compare "^1.0.0"
 
 plist@^3.0.0, plist@^3.0.1:
   version "3.0.1"
@@ -10301,6 +10389,16 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
+read-pkg@^5.1.1:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.2.0.tgz#7bf295438ca5a33e56cd30e053b34ee7250c93cc"
+  integrity sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==
+  dependencies:
+    "@types/normalize-package-data" "^2.4.0"
+    normalize-package-data "^2.5.0"
+    parse-json "^5.0.0"
+    type-fest "^0.6.0"
+
 readable-stream@^1.0.31:
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
@@ -10798,6 +10896,11 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
+run-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
+  integrity sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==
+
 rungen@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/rungen/-/rungen-0.3.2.tgz#400c09ebe914e7b17e0b6ef3263400fc2abc7cb3"
@@ -10975,6 +11078,11 @@ selenium-webdriver@3.x:
     rimraf "^2.5.4"
     tmp "0.0.30"
     xml2js "^0.4.17"
+
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
 "semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0:
   version "5.7.0"
@@ -11202,6 +11310,11 @@ slash@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
   integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
+
+slash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
+  integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
 slice-ansi@1.0.0:
   version "1.0.0"
@@ -11949,6 +12062,11 @@ type-fest@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"
   integrity sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==
+
+type-fest@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
+  integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
 type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"


### PR DESCRIPTION
Fixes #816 by adding a prettier check to our CI builds and as a pre-commit hook.

This was tested by verifying that the "Check Correctness" check on CI [failed](https://circleci.com/gh/wordpress-mobile/gutenberg-mobile/10121?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) before updating the code in this repo to comply with prettier, and the commit adding those changes caused the check to then [succeed](https://circleci.com/gh/wordpress-mobile/gutenberg-mobile/10124?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link).

It may be easier to review this PR by looking at the commits so you can see the changes that are not solely prettier formatting updates separately. The vast majority of the changes in this PR are just formatting changes.

One mildly annoying aspect of this is the running prettier with the `--list-different` flag (which is needed to get a usable exit code) is that the console output seems rather unclear to me about whether it failed or succeeded ("success!" -> "error!"):

![Screen Shot 2019-07-29 at 5 06 25 PM](https://user-images.githubusercontent.com/4656348/62082684-3ee05700-b223-11e9-94c4-37f20ae30954.png)

That is why I decided to also echo some error messages to the console and make it clear what was occurring. Certainly open to other thoughts though.

### Update release notes
Not applicable because there are no user facing changes.
