### PR TITLE
Extract caption component

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,8 @@
+1.12.0
+------
+* Add rich text styling to video captions
+* Prevent keyboard dismissal when switching between caption and text block on Android
+
 1.11.0
 ------
 * Toolbar scroll position now resets when its content changes

--- a/src/initial-html.js
+++ b/src/initial-html.js
@@ -54,11 +54,11 @@ else:
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"id":97629,"align":"full"} -->
-<figure class="wp-block-image alignfull"><img src="https://wordpress.org/gutenberg/files/2018/07/Screenshot-4-1.png" alt="" class="wp-image-97629"/></figure>
+<figure class="wp-block-image alignfull"><img src="https://wordpress.org/gutenberg/files/2018/07/Screenshot-4-1.png" alt="" class="wp-image-97629"/><figcaption><em>Gutenberg</em> on web</figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:video {"id":683} -->
-<figure class="wp-block-video"><video controls src="https://i.cloudup.com/YtZFJbuQCE.mov"></video></figure>
+<figure class="wp-block-video"><video controls src="https://i.cloudup.com/YtZFJbuQCE.mov"></video><figcaption>Videos too!</figcaption></figure>
 <!-- /wp:video -->
 
 <!-- wp:paragraph {"align":"left"} -->


### PR DESCRIPTION
This PR extract caption from image block to be shared with video block. This ports over both rich text styling and a keyboard-dismissal bug fix to the video block. It also adds the ability to select the video block when the video block's caption is selected without playing the video.

Further details and testing instructions are in the [related gutenberg PR](https://github.com/WordPress/gutenberg/pull/16825).

There are user facing changes, so I have added an item to `RELEASE-NOTES.txt`.
