### PR TITLE
Hotfix - 1.10.1 - Update to android aztec v1.3.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gutenberg-mobile",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "private": true,
   "config": {
     "jsfiles": "./*.js src/*.js src/**/*.js src/**/**/*.js",

--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = '0fa41a08efef6092a6bd8c7b31e948cb21144d02'
+        aztecVersion = 'v1.3.29'
     }
 
     repositories {

--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = 'v1.3.28'
+        aztecVersion = '0fa41a08efef6092a6bd8c7b31e948cb21144d02'
     }
 
     repositories {


### PR DESCRIPTION
**Summary:**

While working on Chromebook issues we have made some fixes on https://github.com/wordpress-mobile/AztecEditor-Android repository and before we tag `v1.3.29`, we need to make sure that nothing has broken on Gutenberg level.

Main AztecEditor PR that bumps version to `v1.3.29`: https://github.com/wordpress-mobile/AztecEditor-Android/pull/841

PR's that were resolved: 

- https://github.com/wordpress-mobile/AztecEditor-Android/pull/840
- https://github.com/wordpress-mobile/AztecEditor-Android/pull/838
- https://github.com/wordpress-mobile/AztecEditor-Android/pull/835

**To test:**

We should test Block Editor in general so that we can be sure that above PR's didn't expose any regression.

- [x] when AztecEditor PR is merged: https://github.com/wordpress-mobile/AztecEditor-Android/pull/841 into `develop` branch and tagged with a new version, I will update Aztec reference on this PR.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
