### PR TITLE
Hide block if being replaced

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 ------
 * Add rich text styling to video captions
 * Prevent keyboard dismissal when switching between caption and text block on Android
+* Blocks that would be replaced are now hidden when add block bottom sheet displays
 
 1.11.0
 ------


### PR DESCRIPTION
Fixes #1177 by hiding a block that would be replaced when the add block bottom sheet is presented.

Further description and testing steps are available in the [related gutenberg PR](https://github.com/WordPress/gutenberg/pull/16931).

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
