### PR TITLE
Cleanup block list

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * Add rich text styling to video captions
 * Prevent keyboard dismissal when switching between caption and text block on Android
 * Blocks that would be replaced are now hidden when add block bottom sheet displays
+* Tapping on empty editor area now always inserts new block at end of post
 
 1.11.0
 ------


### PR DESCRIPTION
Fixes an issue where tapping on the empty area at the end of a post to add a new block would add the block after the currently selected block instead of at the end of the post.

Additional info and test steps in the [related gutenberg PR](https://github.com/WordPress/gutenberg/pull/16934)

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
