### PR TITLE
Reset toolbar scroll on change

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.11.0
+------
+* Toolbar scroll position now resets when its content changes
+
 1.10.0
 ------
 * Adding a block from the post title now shows the add block here indicator.


### PR DESCRIPTION
Fixes #934 by resetting the toolbar's scroll position any time it's content changes. Additional information and test steps are available in the [related gutenberg PR](https://github.com/WordPress/gutenberg/pull/16945).

Release notes have been updated.
