### PR TITLE
Bridge iOS: Add mediaType to appendMedia event.

### DIFF
--- a/react-native-gutenberg-bridge/ios/Gutenberg.swift
+++ b/react-native-gutenberg-bridge/ios/Gutenberg.swift
@@ -105,8 +105,12 @@ public class Gutenberg: NSObject {
         bridgeModule.sendEventIfNeeded(name: EventName.mediaUpload, body: data)
     }
 
-    public func appendMedia(id: Int32, url: URL) {
-        let data: [String: Any] = ["mediaId": id, "mediaUrl": url.absoluteString];
+    public func appendMedia(id: Int32, url: URL, type: MediaType) {
+        let data: [String: Any] = [
+            "mediaId"  : id,
+            "mediaUrl" : url.absoluteString,
+            "mediaType": type.rawValue,
+        ]
         bridgeModule.sendEventIfNeeded(name: EventName.mediaAppend, body: data)
     }
 
@@ -152,4 +156,11 @@ extension Gutenberg {
         case reset = 4
     }
     
+}
+
+extension Gutenberg {
+    public enum MediaType: String {
+        case image
+        case video
+    }
 }


### PR DESCRIPTION
Fixes #1190 

This PR fixes an issue on WPiOS that crashes the app when trying to start a photo post from the 3D Touch shortcuts.

WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/12286

To test:
- On WPiOS, check out https://github.com/wordpress-mobile/WordPress-iOS/pull/12286
- Build and run on a iOS **device with 3D touch** (iPhone 6S family or later)
- When the app is running, send it to background
- Find the WordPress app icon, and "force touch" it to display the shortcut options.
- Select "New Photo Post"
- Choose an image (or a few)
- Press on "Insert" at the bottom right corner
- Check that the images are added to the post and there is no crash

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.