### PR TITLE
Fix/1268 content is missing on long posts in html mode

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,9 +1,7 @@
-1.12.0
-------
-* Fix missing content on long posts in html mode on Android
 1.11.0
 ------
 * Toolbar scroll position now resets when its content changes
+* Fix missing content on long posts in html mode on Android
 
 1.10.0
 ------

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,4 @@
-1.11.0
+1.12.0
 ------
 * Fix missing content on long posts in html mode on Android
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.11.0
+------
+* Fix missing content on long posts in html mode on Android
+
 1.10.0
 ------
 * Adding a block from the post title now shows the add block here indicator.

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -255,6 +255,7 @@ public class WPAndroidGlueCode {
                              Application application, boolean isDebug, boolean buildGutenbergFromSource,
                              boolean isNewPost, String localeString, Bundle translations) {
         mReactRootView = new ReactRootView(new MutableContextWrapper(initContext));
+        mReactRootView.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
 
         ReactInstanceManagerBuilder builder =
                 ReactInstanceManager.builder()


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1268

To test:

1. Open WPAndroid app
2. Create new Post
3. Toggle HTML editor mode
4. Copy content: https://gist.github.com/hypest/25e6d96b9c45ce92770f3c4c7ccafa9d
5. Paste into HTML editor

Result: Content should be visible

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
