### PR TITLE
Update Aztec version on Android

### DIFF
--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = 'v1.3.29'
+        aztecVersion = 'af810509fad5e2c180efb9ae5fea014614bb9230'
     }
 
     repositories {

--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = 'af810509fad5e2c180efb9ae5fea014614bb9230'
+        aztecVersion = 'v1.3.30'
     }
 
     repositories {


### PR DESCRIPTION
This PR updates the Aztec version used in the Aztec wrapper for Android.
Changes made to Aztec are minimal, and added a couple of methods to keep track of toolbar button pressed, and undo/redo events.  https://github.com/wordpress-mobile/AztecEditor-Android/pull/843

**Note**: Undo/Redo buttons live outside Aztec at the moment of this PR, so we could track tapping on those directly in the host apps, but we've agree to consider those buttons as they were part of the aztec-editor toolbar. We wanted to be "location" agnostic and be ready to move the undo/redo into the toolbar quickly if necessary.

To test:
Use this PR here: https://github.com/wordpress-mobile/WordPress-Android/pull/10389

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
