### PR TITLE
Update Aztec iOS to v1.8.1

### DIFF
--- a/react-native-aztec/ios/Cartfile
+++ b/react-native-aztec/ios/Cartfile
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.8.0"
+github "wordpress-mobile/AztecEditor-iOS" "1.8.1"

--- a/react-native-aztec/ios/Cartfile.resolved
+++ b/react-native-aztec/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.8.0"
+github "wordpress-mobile/AztecEditor-iOS" "1.8.1"


### PR DESCRIPTION
Simple PR that updates Aztec iOS to v1.8.1
This is the latest version that will be used on WPiOS 13.2.

There are no behavioral changes on this new Aztec version.

To test:
- `yarn preios`
- Build and Run
- Check that it runs correctly

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
