### PR TITLE
Fix MaxListenersExceededWarning caused by dark-mode event emitter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,13 @@ commands:
       - restore_cache:
           name: Restore Yarn Cache
           keys:
-            - yarn-i18n-v3-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
+            - yarn-i18n-v4-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
       - run:
           name: Yarn Install
           command: yarn install --frozen-lockfile --prefer-offline
       - save_cache:
           name: Save Yarn Cache
-          key: yarn-i18n-v3-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
+          key: yarn-i18n-v4-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
             - i18n-cache/data


### PR DESCRIPTION
This PR fixes a warning caused by RNDarkMode event emitter:

`gutenberg` PR: https://github.com/WordPress/gutenberg/pull/17186

```
axListenersExceededWarning: Possible EventEmitter memory leak detected. 11 currentModeChanged listeners added. Use emitter.setMaxListeners() to increase limit
```

To test:
- Run the demo app.
- Check that the warning does not appear.