### PR TITLE
Add/image size options

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "gutenberg"]
 	path = gutenberg
-	url = ../../WordPress/gutenberg.git
+	url = ../../cameronvoell/gutenberg.git
 [submodule "react-native-aztec"]
 	path = react-native-aztec-old-submodule
 	url = ../react-native-aztec.git


### PR DESCRIPTION
Fixes #1329  

To test:
1. Build Example app 
2. Click on an Image block (that already has an image)
3. Press the gear button to bring up Image Options menu
4. Verify new Size option exists, click size options
5. Verify size options are shown and choose one.
6. Re-open Image options menu and verify previously selected size is now shown as selected.

For verifying changes are correctly submitted to web backend:

1. Run the metro bundler for this branch and build either Android or iOS WordPress app
2. Use a wordpress.com account and navigate to a post, and begin editing in Gutenberg editor.
3. Follow steps above to update Image Size options. Click Update.
4. One the web, log in to the wordpress.com account, navigate to the article, and verify that the new Image size setting is shown.


Update release notes (hidden behind `__DEV__` flag until networking for updating image urls is completed):

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
