### PR TITLE
[iOS]Fix: Oddly formatted text hangs Gutenberg

### DIFF
--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -513,7 +513,6 @@ class RCTAztecView: Aztec.TextView {
             let oldFont = font(from: attributes)
             let newFont = applyFontConstraints(to: oldFont)
             
-            textStorage.removeAttribute(.font, range: subrange)
             textStorage.addAttribute(.font, value: newFont, range: subrange)
         }
         textStorage.endEditing()

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -508,12 +508,15 @@ class RCTAztecView: Aztec.TextView {
         
         let fullRange = NSRange(location: 0, length: textStorage.length)
         
+        textStorage.beginEditing()
         textStorage.enumerateAttributes(in: fullRange, options: []) { (attributes, subrange, stop) in
             let oldFont = font(from: attributes)
             let newFont = applyFontConstraints(to: oldFont)
             
+            textStorage.removeAttribute(.font, range: subrange)
             textStorage.addAttribute(.font, value: newFont, range: subrange)
         }
+        textStorage.endEditing()
         
         refreshTypingAttributesAndPlaceholderFont()
     }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1354

[WPiOS PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/12467)

**Root Cause Analysis**

I used Time Profiler to see what's taking so long and it turns out the enumeration on attributes was taking so long. So I put beginEditing/endEditing calls to make the updates as a batch.

This is still not perfect because it is a very long text but I observed that on a iPhone 6 simulator the opening of the page dropped from ~55secs to ~5secs.

**About Text Getting Invisible**
Also, you might observe that text appears as invisible. This is a [known iOS behavior](https://stackoverflow.com/questions/43703095/uitextview-is-not-showing-long-text) about rendering very long text inside a non-scrolling UITextView. If you split the block at some point you can observe that the text is visible again. The ideal world for iOS would be allowing the text scroll inside a smaller viewport, that way the text color doesn't get invisible. We had the same issue on HTML mode and I fixed it that way. Although as far as I know real devices are performing better compared to simulators about this, so we might not need to worry a lot currently. 

To test:

WPiOS App Tests

Checkout the branch of [WPiOS PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/12467)
Run `rake dependencies`
Follow the instructions in [the issue](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1354)
Verify that the screen is not hanging for a long time

Apart from this, some smoke test is done in paragraph/heading blocks to make sure we are not causing regression.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
