### PR TITLE
Intercept paste without formatting command.

### DIFF
--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -245,14 +245,23 @@ class RCTAztecView: Aztec.TextView {
     }
     
     override func paste(_ sender: Any?) {
-        let start = selectedRange.location
-        let end = selectedRange.location + selectedRange.length
-        
         let pasteboard = UIPasteboard.general
         let text = readText(from: pasteboard) ?? ""
         let html = readHTML(from: pasteboard) ?? ""
         let imagesURLs = readImages(from: pasteboard)
+        sendPasteCallback(text: text, html: html, imagesURLs: imagesURLs);
+    }
 
+    override func pasteWithoutFormatting(_ sender: Any?) {
+        let pasteboard = UIPasteboard.general
+        let text = readText(from: pasteboard) ?? ""
+        let imagesURLs = readImages(from: pasteboard)
+        sendPasteCallback(text: text, html: "", imagesURLs: imagesURLs);
+    }
+
+    private func sendPasteCallback(text: String, html: String, imagesURLs: [String]) {
+        let start = selectedRange.location
+        let end = selectedRange.location + selectedRange.length
         onPaste?([
             "currentContent": cleanHTML(),
             "selectionStart": start,


### PR DESCRIPTION
Fixes #1311

This PR changes the code in the RNAztecView in order to override the `pasteWithoutFormatting` the same way we do with `paste` and do the paste action in GB instead of relying in the Aztec paste.

To test: Follow the instructions on the ticket #1311.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
