### PR TITLE
Move MediaUploadPorgress to its own component folder

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "gutenberg"]
 	path = gutenberg
-	url = git@github.com:geriux/gutenberg.git
+	url = ../../WordPress/gutenberg.git
 [submodule "react-native-aztec"]
 	path = react-native-aztec-old-submodule
 	url = ../react-native-aztec.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "gutenberg"]
 	path = gutenberg
-	url = ../../WordPress/gutenberg.git
+	url = git@github.com:geriux/gutenberg.git
 [submodule "react-native-aztec"]
 	path = react-native-aztec-old-submodule
 	url = ../react-native-aztec.git


### PR DESCRIPTION
Gutenberg PR https://github.com/WordPress/gutenberg/pull/17392

## Description
This small PR moves `MediaUploadProgress` out of `image` (native) to its own component folder. In favor of https://github.com/wordpress-mobile/gutenberg-mobile/issues/1313 to be able to reuse this for the Media & Text block.

To test it:

- Add an image block and check it works as expected: upload bar, placeholder.
- Add a video block and check it works as expected: upload bar, placeholder.