### PR TITLE
Generate installable builds for demo app on Android

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,11 @@ jobs:
           name: Bundle Android and Generate debug .apk file for testing
           command: yarn test:e2e:build-app:android
       - run:
+          name: Attach artifacts
+          command: |
+            mkdir -p Artifacts
+            mv ./android/app/build/outputs/apk/debug/app-debug.apk "Artifacts/Gutenberg-$SAUCE_FILENAME.apk"
+      - run:
           name: Upload apk to sauce labs
           command: |
             source bin/sauce-pre-upload.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,9 @@ jobs:
             JEST_JUNIT_OUTPUT: "reports/test-results/android-test-results.xml"
       - store_test_results:
           path: ./reports/test-results
+      - store_artifacts:
+          path: Artifacts
+          destination: Artifacts
   ios-device-checks:
     macos:
       xcode: "10.2.0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
           name: Attach artifacts
           command: |
             mkdir -p Artifacts
-            cp ./android/app/build/outputs/apk/debug/app-debug.apk "Artifacts/Gutenberg-$SAUCE_FILENAME.apk"
+            cp ./android/app/build/outputs/apk/debug/app-debug.apk "Artifacts/Gutenberg-$CIRCLE_BUILD_NUM.apk"
       - run:
           name: Upload apk to sauce labs
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
           name: Attach artifacts
           command: |
             mkdir -p Artifacts
-            mv ./android/app/build/outputs/apk/debug/app-debug.apk "Artifacts/Gutenberg-$SAUCE_FILENAME.apk"
+            cp ./android/app/build/outputs/apk/debug/app-debug.apk "Artifacts/Gutenberg-$SAUCE_FILENAME.apk"
       - run:
           name: Upload apk to sauce labs
           command: |


### PR DESCRIPTION
Adds installable builds for demo app on Android

To test: 
1. Peril should generate a url to the apk for the demo app
2. Download the apk and make sure it's ok 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
