### PR TITLE
Issue/562 add underline

### DIFF
--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -103,6 +103,7 @@ public class ReactAztecManager extends BaseViewManager<ReactAztecText, LayoutSha
                 new LinkFormatter.LinkStyle(
                         Color.parseColor("#016087"), true)
         ));
+        aztecText.addPlugin(new CssUnderlinePlugin());
         return aztecText;
     }
 
@@ -413,7 +414,6 @@ public class ReactAztecManager extends BaseViewManager<ReactAztecText, LayoutSha
             view.addPlugin(new VideoShortcodePlugin());
             view.addPlugin(new AudioShortcodePlugin());
             view.addPlugin(new HiddenGutenbergPlugin(view));
-            view.addPlugin(new CssUnderlinePlugin());
             view.setImageGetter(new GlideImageLoader(view.getContext()));
             view.setVideoThumbnailGetter(new GlideVideoThumbnailLoader(view.getContext()));
             // we need to restart the editor now

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -79,6 +79,7 @@ public class ReactAztecText extends AztecText {
             put(AztecTextFormat.FORMAT_ITALIC, "italic");
             put(AztecTextFormat.FORMAT_CITE, "italic");
             put(AztecTextFormat.FORMAT_STRIKETHROUGH, "strikethrough");
+            put(AztecTextFormat.FORMAT_UNDERLINE, "underline");
         }
     };
 
@@ -480,6 +481,9 @@ public class ReactAztecText extends AztecText {
                     break;
                 case "strikethrough":
                     newFormatsSet.add(AztecTextFormat.FORMAT_STRIKETHROUGH);
+                    break;
+                case "underline":
+                    newFormatsSet.add(AztecTextFormat.FORMAT_UNDERLINE);
                     break;
             }
         }

--- a/react-native-aztec/ios/Cartfile
+++ b/react-native-aztec/ios/Cartfile
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.9.0"
+github "wordpress-mobile/AztecEditor-iOS" "1.10.1"

--- a/react-native-aztec/ios/Cartfile.resolved
+++ b/react-native-aztec/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.9.0"
+github "wordpress-mobile/AztecEditor-iOS" "1.10.1"


### PR DESCRIPTION
Fixes #562 

Related GB PR: https://github.com/WordPress/gutenberg/pull/17483

![Simulator Screen Shot - iPhone Xʀ - 2019-09-19 at 14 43 18](https://user-images.githubusercontent.com/651601/65284661-252c0380-db32-11e9-8738-10497dc62b2e.png)


To test:
 - Run the demo app
 - Check that the underline option shows when selecting text blocks: Paragraph/Heading/List
 - Use the format button and check that underline is set on content

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
