### PR TITLE
Feat: Navigation Upward in InnerBlocks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "gutenberg"]
 	path = gutenberg
-	url = git@github.com:callstack/gutenberg.git
+	url = ../../WordPress/gutenberg.git
 [submodule "react-native-aztec"]
 	path = react-native-aztec-old-submodule
 	url = ../react-native-aztec.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "gutenberg"]
 	path = gutenberg
-	url = https://github.com/callstack/gutenberg.git
+	url = git@github.com:callstack/gutenberg.git
 [submodule "react-native-aztec"]
 	path = react-native-aztec-old-submodule
 	url = ../react-native-aztec.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "gutenberg"]
 	path = gutenberg
-	url = ../../WordPress/gutenberg.git
+	url = https://github.com/callstack/gutenberg.git
 [submodule "react-native-aztec"]
 	path = react-native-aztec-old-submodule
 	url = ../react-native-aztec.git


### PR DESCRIPTION
Fixes #1315 

Please also refer to:
Merge it first gutenberg-mobile PR [Add FloatingToolbar component](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1362)
[Related gutenberg PR](https://github.com/WordPress/gutenberg/pull/17496)
[Related gutenberg-mobile issue](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1315)

It presents:
`Icon` on `Floating Toolbar` component witch allow to select parent of selected block. It is visible only when some of the `Inner Block` is selected

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
