### PR TITLE
Only report selection changes if text view is still first responder.

### DIFF
--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -571,6 +571,9 @@ class RCTAztecView: Aztec.TextView {
 extension RCTAztecView: UITextViewDelegate {
 
     func textViewDidChangeSelection(_ textView: UITextView) {
+        guard isFirstResponder else {
+            return
+        }
         guard isInsertingDictationResult == false else {
             return
         }

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -570,11 +570,8 @@ class RCTAztecView: Aztec.TextView {
 // MARK: UITextView Delegate Methods
 extension RCTAztecView: UITextViewDelegate {
 
-    func textViewDidChangeSelection(_ textView: UITextView) {
-        guard isFirstResponder else {
-            return
-        }
-        guard isInsertingDictationResult == false else {
+    func textViewDidChangeSelection(_ textView: UITextView) {        
+        guard isFirstResponder, isInsertingDictationResult == false else {
             return
         }
 


### PR DESCRIPTION
Fixes #1368 

This PR makes sure that no selection changes are propagated after the aztec text view is no longer the first responder. 
This way when the Link Modal interface is called and the URL input is activated (becomes the first responder) the selection change on the original Aztec content is not propagated to the link UI.

To test:
 - Open the demo app
 - Add or edit a text block, for example paragraph
 - Write some text
 - Select some of the text
 - Tap on the link button on the toolbar
 - Make sure the link text is pre-filled with the selected text

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
