### PR TITLE
Refactor: BottomSheet controls

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "gutenberg"]
 	path = gutenberg
-	url = git@github.com:callstack/gutenberg.git
+	url = ../../WordPress/gutenberg.git
 [submodule "react-native-aztec"]
 	path = react-native-aztec-old-submodule
 	url = ../react-native-aztec.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "gutenberg"]
 	path = gutenberg
-	url = ../../WordPress/gutenberg.git
+	url = git@github.com:callstack/gutenberg.git
 [submodule "react-native-aztec"]
 	path = react-native-aztec-old-submodule
 	url = ../react-native-aztec.git


### PR DESCRIPTION
Fixes #1365

Please also refer to:
Merge it first gutenberg-mobile PR [Feat: Cross platform InspectorControls](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1341) and [Feat: cover cross platform RangeControl](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1342)
[Related gutenberg PR](https://github.com/WordPress/gutenberg/pull/17569)
[Related gutenberg-mobile issue](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1365)

It presents:
New layer on top of `BottomSheet.Cells` to use controls placed in BottomSheet in the same way as in web version.

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
