### PR TITLE
Work around for link selection.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gutenberg-mobile",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "private": true,
   "config": {
     "jsfiles": "./*.js src/*.js src/**/*.js src/**/**/*.js",

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -598,4 +598,13 @@ extension RCTAztecView: UITextViewDelegate {
     func textViewDidEndEditing(_ textView: UITextView) {
         onBlur?([:])
     }
+
+    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {        
+        // Sergio Estevao: This shouldn't happen in an editable textView, but it looks we have a system bug in iOS13 so we need this workaround
+        let position = characterRange.location
+        textView.selectedRange = NSRange(location: position, length: 0)
+        textView.typingAttributes = textView.attributedText.attributes(at: position, effectiveRange: nil)
+        textView.delegate?.textViewDidChangeSelection?(textView)
+        return false
+    }
 }


### PR DESCRIPTION
Hotfix for the link selection bug on iOS13.

This PR was initially used to create a tag for hotfix version 1.11.1 and then it was altered to be merged to master to create version 1.13.1

To test:
 - Check if links in content are tappable without opening a Safari instance.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
