### PR TITLE
Link target option on Image Block

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 ------
 * Fix issue when multiple media selection adds only one image or video block on Android
 * Fix issue when force Touch app shortcut doesn't work properly selecting "New Photo Post" on iOS
+* Add Link Target (Open in new tab) to Image Block.
 
 1.14.0
 ------


### PR DESCRIPTION
Resolves part of wordpress-mobile/gutenberg-mobile#1337

This PR add an extra setting to Image Settings bottom sheet to be able to open links on a new tab (Link target).

**More info:** 
Gutenberg side PR: https://github.com/WordPress/gutenberg/pull/17675

![link_target](https://user-images.githubusercontent.com/9772967/65955130-bad76500-e447-11e9-9c5b-d4ae17b6ea37.png)

## To test:
- Build and run the mobile example app.
- On an image block, set a link and turn "Open in a new tab" ON.
- Close the bottom sheet and open the settings again.
- Check that the settings were saved and display as before.
- Press `Clear All Settings`.
- Check that all settings are removed.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
