### PR TITLE
Fix/1268 content is missing on long posts in html mode

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 ------
 * Fix a bug on iOS 13.0 were tapping on a link opens Safari
 * Fix a link editing issue, where trying to add a empty link at the start of another link would remove the existing link.
+* Fix missing content on long posts in html mode on Android
 
 1.12.0
 ------

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
 import android.content.MutableContextWrapper;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -521,7 +522,17 @@ public class WPAndroidGlueCode {
         }
     }
 
-    public void toggleEditorMode() {
+    public void toggleEditorMode(boolean htmlModeEnabled) {
+        // Turn off hardware acceleration for Oreo
+        // see https://github.com/wordpress-mobile/gutenberg-mobile/issues/1268#issuecomment-535887390
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+            && Build.VERSION.SDK_INT <= Build.VERSION_CODES.O_MR1) {
+            if (htmlModeEnabled) {
+                mReactRootView.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+            } else {
+                mReactRootView.setLayerType(View.LAYER_TYPE_HARDWARE, null);
+            }
+        }
         mRnReactNativeGutenbergBridgePackage.getRNReactNativeGutenbergBridgeModule().toggleEditorMode();
     }
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1268

To test:

1. Open WPAndroid app
2. Create new Post
3. Toggle HTML editor mode
4. Copy content: https://gist.github.com/daniloercoli/d69efa84392ae1c5c4ceb7cf6f5dc2d8
5. Paste into HTML editor

Result: Content should be visible

This is an alternative to: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1277

Note: This is targetting v.1.14.0. 
WP-Android PR https://github.com/wordpress-mobile/WordPress-Android/pull/10563

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
