### PR TITLE
[FIX] Fix button component

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "gutenberg"]
 	path = gutenberg
-	url = ../../WordPress/gutenberg.git
+	url = https://github.com/callstack/gutenberg.git
 [submodule "react-native-aztec"]
 	path = react-native-aztec-old-submodule
 	url = ../react-native-aztec.git


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/17768
There is the wrong assumption that the child is always an array. https://github.com/WordPress/gutenberg/blob/master/packages/components/src/button/index.native.js#L96
When we pass only one component like View to the button it will be not rendered

Gutenberg PR - https://github.com/WordPress/gutenberg/pull/17766
To test:
Pass only one component as a child to Button and check if it is rendered correctly

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
