### PR TITLE
[FIX] Floating toolbar

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "gutenberg"]
 	path = gutenberg
-	url = ../../WordPress/gutenberg.git
+	url = https://github.com/callstack/gutenberg.git
 [submodule "react-native-aztec"]
 	path = react-native-aztec-old-submodule
 	url = ../react-native-aztec.git

--- a/src/_common.scss
+++ b/src/_common.scss
@@ -1,0 +1,5 @@
+/** @format */
+
+$floating-toolbar-height: 44;
+$block-padding-top: 12;
+$floating-toolbar-first-child-top: ($floating-toolbar-height - $block-padding-top);

--- a/src/_native.android.scss
+++ b/src/_native.android.scss
@@ -1,4 +1,5 @@
 /** @format */
+@import './_common';
 
 // Fonts
 $default-monospace-font: monospace;

--- a/src/_native.android.scss
+++ b/src/_native.android.scss
@@ -9,6 +9,3 @@ $title-block-padding-bottom: 0;
 $min-height-title: 53;
 $min-height-paragraph: 50;
 $min-height-heading: 60;
-
-$floating-toolbar-height: 44;
-$floating-toolbar-first-child-top: 32; // $floating-toolbar-height - padding

--- a/src/_native.android.scss
+++ b/src/_native.android.scss
@@ -11,3 +11,4 @@ $min-height-paragraph: 50;
 $min-height-heading: 60;
 
 $floating-toolbar-height: 44;
+$floating-toolbar-first-child-top: 32; // $floating-toolbar-height - padding

--- a/src/_native.ios.scss
+++ b/src/_native.ios.scss
@@ -1,4 +1,5 @@
 /** @format */
+@import './_common';
 
 // Fonts
 $default-monospace-font: courier;

--- a/src/_native.ios.scss
+++ b/src/_native.ios.scss
@@ -9,6 +9,3 @@ $title-block-padding-bottom: 12;
 $min-height-title: 30;
 $min-height-paragraph: 24;
 $min-height-heading: 30;
-
-$floating-toolbar-height: 44;
-$floating-toolbar-first-child-top: 32; // $floating-toolbar-height - padding

--- a/src/_native.ios.scss
+++ b/src/_native.ios.scss
@@ -11,3 +11,4 @@ $min-height-paragraph: 24;
 $min-height-heading: 30;
 
 $floating-toolbar-height: 44;
+$floating-toolbar-first-child-top: 32; // $floating-toolbar-height - padding


### PR DESCRIPTION
Fixes #
This is a phase 2 of https://github.com/WordPress/gutenberg/pull/17399
In this PR I fixed the floating toolbar for the first element in a group to be rendered above the block and be clickable.

Gutenberg PR - https://github.com/WordPress/gutenberg/pull/17769

To test:
Check if each of floating toolbar in a group block is clickable and rendered in the correct place
Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
