### PR TITLE
iOS dark mode improvements

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * Fix issue when multiple media selection adds only one image or video block on Android
 * Fix issue when force Touch app shortcut doesn't work properly selecting "New Photo Post" on iOS
 * Add Link Target (Open in new tab) to Image Block.
+* [iOS] DarkMode improvements.
 
 1.14.0
 ------

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -407,18 +407,36 @@ class RCTAztecView: Aztec.TextView {
         }
     }
 
+    override var textColor: UIColor? {
+        didSet {
+            typingAttributes[NSAttributedString.Key.foregroundColor] = self.textColor
+        }
+    }
+
+    override var typingAttributes: [NSAttributedString.Key : Any] {
+        didSet {
+            // Keep placeholder attributes in sync with typing attributes.
+            placeholderLabel.attributedText = NSAttributedString(string: placeholderLabel.text ?? "", attributes: placeholderAttributes)
+        }
+    }
+
     // MARK: - Placeholder
 
     @objc var placeholder: String {
         set {
-            var placeholderAttributes = typingAttributes
-            placeholderAttributes[.foregroundColor] = placeholderTextColor
             placeholderLabel.attributedText = NSAttributedString(string: newValue, attributes: placeholderAttributes)
         }
 
         get {
             return placeholderLabel.text ?? ""
         }
+    }
+
+    /// Attributes to use on the placeholder.
+    var placeholderAttributes: [NSAttributedString.Key: Any] {
+        var placeholderAttributes = typingAttributes
+        placeholderAttributes[.foregroundColor] = placeholderTextColor
+        return placeholderAttributes
     }
 
     @objc var placeholderTextColor: UIColor {


### PR DESCRIPTION
Fixes #1391 by the changes on https://github.com/WordPress/gutenberg/pull/17802

This PR also fixes another DarkMode issue I found while testing this:
- Typing attributes won't update appropriately when textColor changes.

![dark-mode-issue](https://user-images.githubusercontent.com/9772967/66303472-5d399180-e8fb-11e9-8bb9-6d63a23f3d52.gif)

To test:
- Checkout `gutenberg-mobile` PR: TBD
- Run the project on iOS 13 with dark mode.
- Add a List block.
- Check that the placeholder is properly lied out.
--
- Switch to light mode.
- Create a new List block.
- Write some text on it.
- Switch to dark mode.
- Delete the text and write new text.
- Check that the text color is white.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
