### PR TITLE
Fix icons for Media & Text in dark mode

### DIFF
--- a/src/initial-html.js
+++ b/src/initial-html.js
@@ -8,6 +8,12 @@ export default `
 <figure class="wp-block-image"><img alt=""/></figure>
 <!-- /wp:image -->
 
+<!-- wp:media-text -->
+<div class="wp-block-media-text is-stacked-on-mobile"><figure class="wp-block-media-text__media"></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
+<p class="has-large-font-size"></p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:media-text -->
+
 <!-- wp:image -->
 <figure class="wp-block-image"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
 <!-- /wp:image -->


### PR DESCRIPTION
Fixes #1411 

To test: See https://github.com/WordPress/gutenberg/pull/17936

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
