### PR TITLE
[Android] Revert missing toggle editor mode call

### DIFF
--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -548,6 +548,7 @@ public class WPAndroidGlueCode {
                 mReactRootView.setLayerType(View.LAYER_TYPE_HARDWARE, null);
             }
         }
+        mRnReactNativeGutenbergBridgePackage.getRNReactNativeGutenbergBridgeModule().toggleEditorMode();
     }
 
     public void appendMediaFiles(ArrayList<Media> mediaList) {


### PR DESCRIPTION
Fixes: For some unexpected reason, the line of the code which toggles editor mode is missing in this PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1410/files#diff-f2e1dfe800569dfb4ee4830f88779890R540

To test:

Toggle editor mode (Html -> Visual and Visual -> Html) should work as expected.

Hey, @hypest since you will probably wrangle release `1.15.0`, just to let you know that this PR must be included in the `1.15.0` release.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
