### PR TITLE
Expose WordPressUtils for consumption by react-native-gutenberg-bridge

### DIFF
--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -97,11 +97,11 @@ dependencies {
     api ("com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:$aztecVersion")
     api ("com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:$aztecVersion")
     api ("com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader:$aztecVersion")
+    api "org.wordpress:utils:$wordpressUtilsVersion"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     implementation 'androidx.appcompat:appcompat:1.0.0'
-    implementation "org.wordpress:utils:$wordpressUtilsVersion"
 
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.gridlayout:gridlayout:1.0.0'


### PR DESCRIPTION
This PR is in preparation for [WPAndroid updating to Gradle 5.4.1](https://github.com/wordpress-mobile/WordPress-Android/pull/10583). This update causes a build failure when `BUILD_GUTENBERG_FROM_SOURCE` is set to `true`. 

The issue is that react-native-gutenberg-bridge can not access the WordPressUtils. In particular, the WPAndroidGlueCode class fails to compile because it cannot import org.wordpress.android.util.AppLog. Switching WordPressUtils from an implementation dependency to an api dependency in react-native-aztec makes WordPressUtils available to react-native-gutenberg-bridge.

### To Test:
#### Mobile-Gutenberg
Insure that `yarn android` successfully builds the mobile-gutenberg demo app

#### WPAndroid
1. Check out WPAndroid commit [91c1af7](https://github.com/wordpress-mobile/WordPress-Android/commit/91c1af7f293234ddcbd0f0ede4c6fb826321587b), which includes:
    a. the [WPAndroid updates to use Gradle 5.4.1](https://github.com/wordpress-mobile/WordPress-Android/pull/10583), 
    b. with develop merged in (needed to avoid a different compilation error), and 
    c. the gutenberg-mobile submodule ref updated to point to this PR's commit
2. Run `git submodule update --init-recursive` (or otherwise check out this change in the mobile-gutenberg submodule)
2. Add `wp.BUILD_GUTENBERG_FROM_SOURCE=true` to `gradle.properties`
3. Insure that `./gradlew assembleWasabiDebug` completes successfully

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
