### PR TITLE
[try] Image Size networking

### DIFF
--- a/ios/gutenberg/GutenbergViewController.swift
+++ b/ios/gutenberg/GutenbergViewController.swift
@@ -45,6 +45,7 @@ class GutenbergViewController: UIViewController {
 }
 
 extension GutenbergViewController: GutenbergBridgeDelegate {
+
     func editorDidAutosave() {
         print("➡️ Editor Did Autosave")
     }
@@ -177,6 +178,14 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
 }
 
 extension GutenbergViewController: GutenbergBridgeDataSource {
+    var siteSlug: String? {
+        return nil
+    }
+
+    var extraHTTPHeaders: [String : Any]? {
+        return nil
+    }
+
     
     func gutenbergLocale() -> String? {
         return Locale.preferredLanguages.first ?? "en"

--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
     "wd": "^1.11.1"
   },
   "husky": {
-      "hooks": {
-          "pre-commit": "yarn prettier:check"
-      }
+    "hooks": {
+      "pre-commit": "yarn prettier:check"
+    }
   },
   "scripts": {
     "start": "react-native start",

--- a/react-native-gutenberg-bridge/ios/Gutenberg.swift
+++ b/react-native-gutenberg-bridge/ios/Gutenberg.swift
@@ -63,6 +63,14 @@ public class Gutenberg: NSObject {
         if let translations = dataSource.gutenbergTranslations() {
             initialProps["translations"] = translations
         }
+
+        if let slug = dataSource.siteSlug {
+            initialProps["siteSlug"] = slug
+        }
+
+        if let extraHeaders = dataSource.extraHTTPHeaders {
+            initialProps["extraHTTPHeaders"] = extraHeaders
+        }
         
         return initialProps
     }

--- a/react-native-gutenberg-bridge/ios/GutenbergBridgeDataSource.swift
+++ b/react-native-gutenberg-bridge/ios/GutenbergBridgeDataSource.swift
@@ -35,13 +35,3 @@ public protocol GutenbergBridgeDataSource: class {
 
     var extraHTTPHeaders: [String: Any]? { get }
 }
-
-extension GutenbergBridgeDataSource {
-    var siteSlug: String? {
-        return nil
-    }
-
-    var extraHTTPHeaders: [String: Any]? {
-        return nil
-    }
-}

--- a/react-native-gutenberg-bridge/ios/GutenbergBridgeDataSource.swift
+++ b/react-native-gutenberg-bridge/ios/GutenbergBridgeDataSource.swift
@@ -30,4 +30,18 @@ public protocol GutenbergBridgeDataSource: class {
     ///
     /// - Returns: Gutenberg related localization key value pairs for the current locale.
     func gutenbergTranslations() -> [String : [String]]?
+
+    var siteSlug: String? { get }
+
+    var extraHTTPHeaders: [String: Any]? { get }
+}
+
+extension GutenbergBridgeDataSource {
+    var siteSlug: String? {
+        return nil
+    }
+
+    var extraHTTPHeaders: [String: Any]? {
+        return nil
+    }
 }

--- a/src/api-fetch-setup.js
+++ b/src/api-fetch-setup.js
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import { fetchRequest } from 'react-native-gutenberg-bridge';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+const fetchHandler = ( nextOptions, extraHeaders ) => {
+	const { url, ...remainingOptions } = nextOptions;
+
+	headers = { ...apiFetch.DEFAULT_HEADERS, ...extraHeaders };
+
+	const options = {
+		headers,
+		...remainingOptions,
+	};
+	const responsePromise = fetch( url, options );
+
+	const parseResponse = ( response ) => {
+		return response.json();
+	};
+
+	return responsePromise.then( parseResponse ).catch( ( error ) => {
+		return error;
+	} );
+};
+
+const wpcomPathMappingMiddleware = ( options, next, siteSlug ) => {
+	// wp/v2 namespace mapping
+	//
+	// Path rewrite example:
+	// 		/wp/v2/types/post →
+	//		/wp/v2/sites/example.wordpress.com/types/post
+	if ( /\/wp\/v2\//.test( options.path ) ) {
+		const path = options.path.replace( '/wp/v2/', `/wp/v2/sites/${ siteSlug }/` );
+
+		return next( { ...options, path } );
+	}
+	return next( options );
+};
+
+export default ( setupApiFetch = ( siteSlug = '', headers = {} ) => {
+	apiFetch.use( apiFetch.createRootURLMiddleware( 'https://public-api.wordpress.com/' ) );
+	apiFetch.use( ( options, next ) => wpcomPathMappingMiddleware( options, next, siteSlug ) );
+	apiFetch.setFetchHandler( ( options ) => fetchHandler( options, headers ) );
+} );

--- a/src/api-fetch-setup.js
+++ b/src/api-fetch-setup.js
@@ -5,40 +5,21 @@
  */
 
 /**
- * External dependencies
- */
-import { fetchRequest } from 'react-native-gutenberg-bridge';
-
-/**
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
 
-const fetchHandler = ( nextOptions, extraHeaders ) => {
-	const { url, ...remainingOptions } = nextOptions;
-
-	headers = { ...apiFetch.DEFAULT_HEADERS, ...extraHeaders };
-
-	const options = {
-		headers,
-		...remainingOptions,
-	};
-	const responsePromise = fetch( url, options );
-
-	const parseResponse = ( response ) => {
-		return response.json();
-	};
-
-	return responsePromise.then( parseResponse ).catch( ( error ) => {
-		return error;
-	} );
+const insertHeadersMiddleware = ( options, next, extraHeaders ) => {
+	const { optionsHeaders = {}, ...extraOptions } = options;
+	const headers = { ...optionsHeaders, ...extraHeaders };
+	return next( { ...options, headers } );
 };
 
 const wpcomPathMappingMiddleware = ( options, next, siteSlug ) => {
 	// wp/v2 namespace mapping
 	//
 	// Path rewrite example:
-	// 		/wp/v2/types/post →
+	//		/wp/v2/types/post →
 	//		/wp/v2/sites/example.wordpress.com/types/post
 	if ( /\/wp\/v2\//.test( options.path ) ) {
 		const path = options.path.replace( '/wp/v2/', `/wp/v2/sites/${ siteSlug }/` );
@@ -51,5 +32,5 @@ const wpcomPathMappingMiddleware = ( options, next, siteSlug ) => {
 export default ( setupApiFetch = ( siteSlug = '', headers = {} ) => {
 	apiFetch.use( apiFetch.createRootURLMiddleware( 'https://public-api.wordpress.com/' ) );
 	apiFetch.use( ( options, next ) => wpcomPathMappingMiddleware( options, next, siteSlug ) );
-	apiFetch.setFetchHandler( ( options ) => fetchHandler( options, headers ) );
+	apiFetch.use( ( options, next ) => insertHeadersMiddleware( options, next, headers ) );
 } );

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ import { setLocaleData } from '@wordpress/i18n';
 import './globals';
 import { getTranslation } from '../i18n-cache';
 import initialHtml from './initial-html';
+import setupApiFetch from './api-fetch-setup';
 
 const gutenbergSetup = () => {
 	const wpData = require( '@wordpress/data' );
@@ -53,6 +54,7 @@ export class RootComponent extends React.Component {
 	constructor( props ) {
 		super( props );
 		setupLocale( props.locale, props.translations );
+		setupApiFetch( props.siteSlug, props.extraHTTPHeaders );
 		require( '@wordpress/edit-post' ).initializeEditor();
 	}
 


### PR DESCRIPTION
This PR implements apiFetch to get the media object, and set the corresponding image URL when the image size is changed on an image block.

The wpcom specific code is located in this repo. And the needed information (authentication headers and site id/slug) are provided via initial props from the parent app.

This can only be tested on WPiOS for now, and only works on WPCom sites, as a first step.

gutenberg PR: https://github.com/WordPress/gutenberg/pull/17979
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/12706

To test:
- Follow the instructions on https://github.com/wordpress-mobile/WordPress-iOS/pull/12706

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
