### PR TITLE
720-Add support for giphy and pexel images

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 1.16.0
 ------
-* Add support for giphy and pexel images
+* Add support for giphy and pexels images
 
 1.15.0
 ------

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 1.16.0
 ------
-* Add support for giphy and pexels images
+* Add support for pexels images
 
 1.15.0
 ------

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.16.0
+------
+* Add support for giphy and pexel images
+
 1.15.0
 ------
 * Fix issue when multiple media selection adds only one image or video block on Android

--- a/android/app/src/main/java/com/gutenberg/MainApplication.java
+++ b/android/app/src/main/java/com/gutenberg/MainApplication.java
@@ -78,6 +78,21 @@ public class MainApplication extends Application implements ReactApplication {
             }
 
             @Override
+            public void getOtherMediaPickerOptions(OtherMediaOptionsReceivedCallback otherMediaOptionsReceivedCallback, MediaType mediaType) {
+
+            }
+
+            @Override
+            public void requestMediaPickFromStockMedia(MediaSelectedCallback mediaSelectedCallback, Boolean allowMultipleSelection) {
+
+            }
+
+            @Override
+            public void requestMediaPickFromGiphyMedia(MediaUploadCallback mediaSelectedCallback, Boolean allowMultipleSelection) {
+
+            }
+
+            @Override
             public void editorDidEmitLog(String message, LogLevel logLevel) {
                 switch (logLevel) {
                     case TRACE:

--- a/android/app/src/main/java/com/gutenberg/MainApplication.java
+++ b/android/app/src/main/java/com/gutenberg/MainApplication.java
@@ -37,7 +37,7 @@ public class MainApplication extends Application implements ReactApplication {
             }
 
             @Override
-            public void requestMediaImport(String url, MediaSelectedCallback mediaSelectedCallback) {
+            public void requestMediaImport(String url, MediaUploadCallback mediaUploadCallback) {
             }
 
             @Override
@@ -49,7 +49,7 @@ public class MainApplication extends Application implements ReactApplication {
             }
 
             @Override
-            public void requestMediaPickFromMediaLibrary(MediaSelectedCallback mediaSelectedCallback, Boolean allowMultipleSelection, MediaType mediaType) {
+            public void requestMediaPickFromMediaLibrary(MediaUploadCallback mediaUploadCallback, Boolean allowMultipleSelection, MediaType mediaType) {
             }
 
 
@@ -83,12 +83,7 @@ public class MainApplication extends Application implements ReactApplication {
             }
 
             @Override
-            public void requestMediaPickFromStockMedia(MediaSelectedCallback mediaSelectedCallback, Boolean allowMultipleSelection) {
-
-            }
-
-            @Override
-            public void requestMediaPickFromGiphyMedia(MediaUploadCallback mediaSelectedCallback, Boolean allowMultipleSelection) {
+            public void requestMediaPickFrom(String mediaSource, MediaUploadCallback mediaUploadCallback, Boolean allowMultipleSelection) {
 
             }
 

--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -97,11 +97,11 @@ dependencies {
     api ("com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:$aztecVersion")
     api ("com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:$aztecVersion")
     api ("com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader:$aztecVersion")
+    api "org.wordpress:utils:$wordpressUtilsVersion"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     implementation 'androidx.appcompat:appcompat:1.0.0'
-    implementation "org.wordpress:utils:$wordpressUtilsVersion"
 
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.gridlayout:gridlayout:1.0.0'

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -117,6 +117,9 @@ dependencies {
     implementation "org.webkit:android-jsc:r241213"
     implementation project(':react-native-aztec')
 
+    // For animated GIF support
+    implementation 'com.facebook.fresco:animated-gif:2.0.0'
+
     if (rootProject.ext.buildGutenbergFromSource) {
         println "using gutenberg from source"
         implementation project(':react-native-svg')

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
@@ -79,13 +79,13 @@ public interface GutenbergBridgeJS2Parent {
         }
     }
 
-    void requestMediaPickFromMediaLibrary(MediaUploadCallback mediaSelectedCallback, Boolean allowMultipleSelection, MediaType mediaType);
+    void requestMediaPickFromMediaLibrary(MediaUploadCallback mediaUploadCallback, Boolean allowMultipleSelection, MediaType mediaType);
 
     void requestMediaPickFromDeviceLibrary(MediaUploadCallback mediaUploadCallback, Boolean allowMultipleSelection, MediaType mediaType);
 
     void requestMediaPickerFromDeviceCamera(MediaUploadCallback mediaUploadCallback, MediaType mediaType);
 
-    void requestMediaImport(String url, MediaUploadCallback mediaSelectedCallback);
+    void requestMediaImport(String url, MediaUploadCallback mediaUploadCallback);
 
     void mediaUploadSync(MediaUploadCallback mediaUploadCallback);
 
@@ -101,5 +101,5 @@ public interface GutenbergBridgeJS2Parent {
 
     void getOtherMediaPickerOptions(OtherMediaOptionsReceivedCallback otherMediaOptionsReceivedCallback, MediaType mediaType);
 
-    void requestMediaPickFrom(String mediaSource, MediaUploadCallback mediaSelectedCallback, Boolean allowMultipleSelection);
+    void requestMediaPickFrom(String mediaSource, MediaUploadCallback mediaUploadCallback, Boolean allowMultipleSelection);
 }

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
@@ -3,6 +3,9 @@ package org.wordpress.mobile.ReactNativeGutenbergBridge;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.WritableMap;
 
+import org.wordpress.mobile.WPAndroidGlue.MediaOption;
+
+import java.util.ArrayList;
 import java.util.List;
 
 public interface GutenbergBridgeJS2Parent {
@@ -19,6 +22,10 @@ public interface GutenbergBridgeJS2Parent {
 
     interface MediaSelectedCallback {
         void onMediaSelected(List<RNMedia> mediaList);
+    }
+
+    interface OtherMediaOptionsReceivedCallback {
+        void onOtherMediaOptionsReceived(ArrayList<MediaOption> mediaList);
     }
 
     interface MediaUploadCallback {
@@ -95,4 +102,10 @@ public interface GutenbergBridgeJS2Parent {
     void editorDidEmitLog(String message, LogLevel logLevel);
 
     void editorDidAutosave();
+
+    void getOtherMediaPickerOptions(OtherMediaOptionsReceivedCallback otherMediaOptionsReceivedCallback, MediaType mediaType);
+
+    void requestMediaPickFromStockMedia(MediaSelectedCallback mediaSelectedCallback, Boolean allowMultipleSelection);
+
+    void requestMediaPickFromGiphyMedia(MediaUploadCallback mediaSelectedCallback, Boolean allowMultipleSelection);
 }

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
@@ -20,10 +20,6 @@ public interface GutenbergBridgeJS2Parent {
 
     void editorDidMount(ReadableArray unsupportedBlockNames);
 
-    interface MediaSelectedCallback {
-        void onMediaSelected(List<RNMedia> mediaList);
-    }
-
     interface OtherMediaOptionsReceivedCallback {
         void onOtherMediaOptionsReceived(ArrayList<MediaOption> mediaList);
     }
@@ -83,13 +79,13 @@ public interface GutenbergBridgeJS2Parent {
         }
     }
 
-    void requestMediaPickFromMediaLibrary(MediaSelectedCallback mediaSelectedCallback, Boolean allowMultipleSelection, MediaType mediaType);
+    void requestMediaPickFromMediaLibrary(MediaUploadCallback mediaSelectedCallback, Boolean allowMultipleSelection, MediaType mediaType);
 
     void requestMediaPickFromDeviceLibrary(MediaUploadCallback mediaUploadCallback, Boolean allowMultipleSelection, MediaType mediaType);
 
     void requestMediaPickerFromDeviceCamera(MediaUploadCallback mediaUploadCallback, MediaType mediaType);
 
-    void requestMediaImport(String url, MediaSelectedCallback mediaSelectedCallback);
+    void requestMediaImport(String url, MediaUploadCallback mediaSelectedCallback);
 
     void mediaUploadSync(MediaUploadCallback mediaUploadCallback);
 
@@ -105,7 +101,5 @@ public interface GutenbergBridgeJS2Parent {
 
     void getOtherMediaPickerOptions(OtherMediaOptionsReceivedCallback otherMediaOptionsReceivedCallback, MediaType mediaType);
 
-    void requestMediaPickFromStockMedia(MediaSelectedCallback mediaSelectedCallback, Boolean allowMultipleSelection);
-
-    void requestMediaPickFromGiphyMedia(MediaUploadCallback mediaSelectedCallback, Boolean allowMultipleSelection);
+    void requestMediaPickFrom(String mediaSource, MediaUploadCallback mediaSelectedCallback, Boolean allowMultipleSelection);
 }

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -13,14 +13,10 @@ import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 
-import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.MediaSelectedCallback;
 import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.MediaType;
 import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.OtherMediaOptionsReceivedCallback;
 import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.RNMedia;
 import org.wordpress.mobile.WPAndroidGlue.MediaOption;
-
-import static org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.MEDIA_SOURCE_GIPHY_MEDIA;
-import static org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.MEDIA_SOURCE_STOCK_MEDIA;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -116,7 +112,7 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
     public void requestMediaPickFrom(String mediaSource, ReadableArray filter, Boolean allowMultipleSelection, final Callback onUploadMediaSelected) {
         MediaType mediaType = getMediaTypeFromFilter(filter);
         if (mediaSource.equals(MEDIA_SOURCE_MEDIA_LIBRARY)) {
-            mGutenbergBridgeJS2Parent.requestMediaPickFromMediaLibrary(getNewMediaSelectedCallback(allowMultipleSelection, onUploadMediaSelected), allowMultipleSelection, mediaType);
+            mGutenbergBridgeJS2Parent.requestMediaPickFromMediaLibrary(getNewUploadMediaCallback(allowMultipleSelection, onUploadMediaSelected), allowMultipleSelection, mediaType);
         } else if (mediaSource.equals(MEDIA_SOURCE_DEVICE_LIBRARY)) {
             mGutenbergBridgeJS2Parent.requestMediaPickFromDeviceLibrary(getNewUploadMediaCallback(allowMultipleSelection, onUploadMediaSelected), allowMultipleSelection, mediaType);
         } else if (mediaSource.equals(MEDIA_SOURCE_DEVICE_CAMERA)) {
@@ -126,13 +122,7 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
 
     @ReactMethod
     public void requesOtherMediaPickFrom(String mediaSource, Boolean allowMultipleSelection, final Callback onUploadMediaSelected) {
-        if (mediaSource.equals(MEDIA_SOURCE_STOCK_MEDIA)) {
-            // For media stock we don't have information about upload process
-            // which means that we need to listen for MediaSelectedCallback ( and not  MediaUploadCallback )
-            mGutenbergBridgeJS2Parent.requestMediaPickFromStockMedia(getNewMediaSelectedCallback(allowMultipleSelection, onUploadMediaSelected), allowMultipleSelection);
-        } else if (mediaSource.equals(MEDIA_SOURCE_GIPHY_MEDIA)) {
-            mGutenbergBridgeJS2Parent.requestMediaPickFromGiphyMedia(getNewUploadMediaCallback(allowMultipleSelection, onUploadMediaSelected), allowMultipleSelection);
-        }
+        mGutenbergBridgeJS2Parent.requestMediaPickFrom(mediaSource, getNewUploadMediaCallback(allowMultipleSelection, onUploadMediaSelected), allowMultipleSelection);
     }
 
     private MediaType getMediaTypeFromFilter(ReadableArray filter) {
@@ -154,7 +144,7 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
 
     @ReactMethod
     public void requestMediaImport(String url, final Callback onUploadMediaSelected) {
-        mGutenbergBridgeJS2Parent.requestMediaImport(url, getNewMediaSelectedCallback(false, onUploadMediaSelected));
+        mGutenbergBridgeJS2Parent.requestMediaImport(url, getNewUploadMediaCallback(false, onUploadMediaSelected));
     }
 
     @ReactMethod
@@ -202,22 +192,6 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
                     writableArray.pushMap(mediaOption.toMap());
                 }
                 jsCallback.invoke(writableArray);
-            }
-        };
-    }
-
-    private MediaSelectedCallback getNewMediaSelectedCallback(final Boolean allowMultipleSelection, final Callback jsCallback) {
-        return new MediaSelectedCallback() {
-            @Override public void onMediaSelected(List<RNMedia> mediaList) {
-                if(allowMultipleSelection) {
-                    WritableArray writableArray = new WritableNativeArray();
-                    for (RNMedia media : mediaList) {
-                        writableArray.pushMap(media.toMap());
-                    }
-                    jsCallback.invoke(writableArray);
-                } else {
-                    jsCallback.invoke(mediaList.get(0).toMap());
-                }
             }
         };
     }

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -121,7 +121,7 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
     }
 
     @ReactMethod
-    public void requesOtherMediaPickFrom(String mediaSource, Boolean allowMultipleSelection, final Callback onUploadMediaSelected) {
+    public void requestOtherMediaPickFrom(String mediaSource, Boolean allowMultipleSelection, final Callback onUploadMediaSelected) {
         mGutenbergBridgeJS2Parent.requestMediaPickFrom(mediaSource, getNewUploadMediaCallback(allowMultipleSelection, onUploadMediaSelected), allowMultipleSelection);
     }
 

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/MediaOption.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/MediaOption.java
@@ -1,0 +1,33 @@
+package org.wordpress.mobile.WPAndroidGlue;
+
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeMap;
+
+public class MediaOption {
+
+    private static final String KEY_VALUE = "value";
+    private static final String KEY_LABEL = "label";
+
+    private String mId;
+    private String mName;
+
+    public MediaOption(String id, String name) {
+        mId = id;
+        mName = name;
+    }
+
+    public String getId() {
+        return mId;
+    }
+
+    public String getName() {
+        return mName;
+    }
+
+    public WritableMap toMap() {
+        WritableMap map = new WritableNativeMap();
+        map.putString(KEY_VALUE, mId);
+        map.putString(KEY_LABEL, mName);
+        return map;
+    }
+}

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -38,7 +38,6 @@ import org.wordpress.mobile.ReactNativeAztec.ReactAztecPackage;
 import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent;
 import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.MediaSelectedCallback;
 import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.MediaUploadCallback;
-import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.OtherMediaOptionsReceivedCallback;
 import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.RNMedia;
 import org.wordpress.mobile.ReactNativeGutenbergBridge.RNReactNativeGutenbergBridgePackage;
 

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -9,7 +9,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout.LayoutParams;

--- a/react-native-gutenberg-bridge/index.js
+++ b/react-native-gutenberg-bridge/index.js
@@ -93,8 +93,8 @@ export function getOtherMediaOptions( filter, callback ) {
 	return RNReactNativeGutenbergBridge.getOtherMediaOptions( filter, callback );
 }
 
-export function requesOtherMediaPickFrom( mediaSource, multiple, callback ) {
-	return RNReactNativeGutenbergBridge.requesOtherMediaPickFrom( mediaSource, multiple, callback );
+export function requestOtherMediaPickFrom( mediaSource, multiple, callback ) {
+	return RNReactNativeGutenbergBridge.requestOtherMediaPickFrom( mediaSource, multiple, callback );
 }
 
 export default RNReactNativeGutenbergBridge;

--- a/react-native-gutenberg-bridge/index.js
+++ b/react-native-gutenberg-bridge/index.js
@@ -89,4 +89,12 @@ export function requestImageUploadCancel( mediaId ) {
 	return RNReactNativeGutenbergBridge.requestImageUploadCancel( mediaId );
 }
 
+export function getOtherMediaOptions( filter, callback ) {
+	return RNReactNativeGutenbergBridge.getOtherMediaOptions( filter, callback );
+}
+
+export function requesOtherMediaPickFrom( mediaSource, multiple, callback ) {
+	return RNReactNativeGutenbergBridge.requesOtherMediaPickFrom( mediaSource, multiple, callback );
+}
+
 export default RNReactNativeGutenbergBridge;

--- a/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.m
+++ b/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.m
@@ -5,7 +5,7 @@
 RCT_EXTERN_METHOD(provideToNative_Html:(NSString *)html title:(NSString *)title changed:(BOOL)changed)
 RCT_EXTERN_METHOD(requestMediaPickFrom:(NSString *)source filter:(NSArray<NSString *> *)filter allowMultipleSelection:(BOOL)allowMultipleSelection callback:(RCTResponseSenderBlock)callback)
 RCT_EXTERN_METHOD(requestOtherMediaPickFrom:(NSString *)source allowMultipleSelection:(BOOL)allowMultipleSelection callback:(RCTResponseSenderBlock)callback)
-RCT_EXTERN_METHOD(getOtherMediaOptions:(NSArray<NSString *> *)filter allowMultipleSelection:(BOOL)allowMultipleSelection callback:(RCTResponseSenderBlock)callback)
+RCT_EXTERN_METHOD(getOtherMediaOptions:(NSArray<NSString *> *)filter callback:(RCTResponseSenderBlock)callback)
 RCT_EXTERN_METHOD(mediaUploadSync)
 RCT_EXTERN_METHOD(requestImageFailedRetryDialog:(int)mediaID)
 RCT_EXTERN_METHOD(requestImageUploadCancelDialog:(int)mediaID)

--- a/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.m
+++ b/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.m
@@ -4,6 +4,8 @@
 
 RCT_EXTERN_METHOD(provideToNative_Html:(NSString *)html title:(NSString *)title changed:(BOOL)changed)
 RCT_EXTERN_METHOD(requestMediaPickFrom:(NSString *)source filter:(NSArray<NSString *> *)filter allowMultipleSelection:(BOOL)allowMultipleSelection callback:(RCTResponseSenderBlock)callback)
+RCT_EXTERN_METHOD(requesOtherMediaPickFrom:(NSString *)source allowMultipleSelection:(BOOL)allowMultipleSelection callback:(RCTResponseSenderBlock)callback)
+RCT_EXTERN_METHOD(getOtherMediaOptions:(NSArray<NSString *> *)filter allowMultipleSelection:(BOOL)allowMultipleSelection callback:(RCTResponseSenderBlock)callback)
 RCT_EXTERN_METHOD(mediaUploadSync)
 RCT_EXTERN_METHOD(requestImageFailedRetryDialog:(int)mediaID)
 RCT_EXTERN_METHOD(requestImageUploadCancelDialog:(int)mediaID)

--- a/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.m
+++ b/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.m
@@ -4,7 +4,7 @@
 
 RCT_EXTERN_METHOD(provideToNative_Html:(NSString *)html title:(NSString *)title changed:(BOOL)changed)
 RCT_EXTERN_METHOD(requestMediaPickFrom:(NSString *)source filter:(NSArray<NSString *> *)filter allowMultipleSelection:(BOOL)allowMultipleSelection callback:(RCTResponseSenderBlock)callback)
-RCT_EXTERN_METHOD(requesOtherMediaPickFrom:(NSString *)source allowMultipleSelection:(BOOL)allowMultipleSelection callback:(RCTResponseSenderBlock)callback)
+RCT_EXTERN_METHOD(requestOtherMediaPickFrom:(NSString *)source allowMultipleSelection:(BOOL)allowMultipleSelection callback:(RCTResponseSenderBlock)callback)
 RCT_EXTERN_METHOD(getOtherMediaOptions:(NSArray<NSString *> *)filter allowMultipleSelection:(BOOL)allowMultipleSelection callback:(RCTResponseSenderBlock)callback)
 RCT_EXTERN_METHOD(mediaUploadSync)
 RCT_EXTERN_METHOD(requestImageFailedRetryDialog:(int)mediaID)

--- a/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -49,9 +49,8 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
     }
     
     @objc
-    func getOtherMediaOptions(filter: [String]?, callback: @escaping RCTResponseSenderBlock) {
+    func getOtherMediaOptions(_ filter: [String]?, callback: @escaping RCTResponseSenderBlock) {
         //TODO implement me
-        callback(nil)
     }
 
     @objc

--- a/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -42,6 +42,17 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
             })
         }
     }
+    
+    @objc
+    func requesOtherMediaPickFrom(_ source: String, allowMultipleSelection: Bool, callback: @escaping RCTResponseSenderBlock) {
+        //TODO implement me
+    }
+    
+    @objc
+    func getOtherMediaOptions(filter: [String]?, callback: @escaping RCTResponseSenderBlock) {
+        //TODO implement me
+        callback(nil)
+    }
 
     @objc
     func requestMediaImport(_ urlString: String, callback: @escaping RCTResponseSenderBlock) {

--- a/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -44,7 +44,7 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
     }
     
     @objc
-    func requesOtherMediaPickFrom(_ source: String, allowMultipleSelection: Bool, callback: @escaping RCTResponseSenderBlock) {
+    func requestOtherMediaPickFrom(_ source: String, allowMultipleSelection: Bool, callback: @escaping RCTResponseSenderBlock) {
         //TODO implement me
     }
     


### PR DESCRIPTION
Added support for giphy and pexels images

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/720

WPAndroid PR: https://github.com/wordpress-mobile/WordPress-Android/pull/10628
Gutenberg PR: https://github.com/WordPress/gutenberg/pull/18026

![ezgif com-video-to-gif (8)](https://user-images.githubusercontent.com/28219092/67114971-6cfb8480-f1dd-11e9-9330-dac50e80b554.gif)

**Note: works only on Android (@etoledom  will implement iOS part of it)**

To test:

1. Open WPAndroid application
2. Create a new post or open existing
3. Create a new image block
4. Open picker
5. Click on `Choose from Free Photo Library`
6. Confirm and see that it will be shown in the new post
7. Open picker
8. Click on `Choose from Giphy`
9. Confirm and see that it will be shown in the new post

![giphy_pexels](https://user-images.githubusercontent.com/28219092/67114626-a97ab080-f1dc-11e9-978a-79436b934b50.png)

**@iamthomasbishop I have two questions regarding UI/UX:**
1. Should we show some icons for Giphy and Pexels options in the picker?
2. Are you ok with strings which were reused from WPAndroid or you think we should put some new strings for gb-mobile?

![giphy_centered](https://user-images.githubusercontent.com/28219092/67118649-a2a46b80-f1e5-11e9-8368-2f17b6de26ed.png)

@iamthomasbishop also about this one. There are some giphy images that can be smaller than a size of the component. I have centered them, but do we want some background on unused space?

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
