### PR TITLE
WP-Android  #8828 fix - Just upgrade Aztec version

### DIFF
--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = 'v1.3.31'
+        aztecVersion = '876ac04b4b55304cb81dab7b5025822e4ddec2f8'
     }
 
     repositories {

--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = 'v1.3.33'
+        aztecVersion = '876ac04b4b55304cb81dab7b5025822e4ddec2f8'
     }
 
     repositories {


### PR DESCRIPTION
This PR does only update the Aztec version used in gb-mobile to be in par with the version used in WP-Android in this PR https://github.com/wordpress-mobile/WordPress-Android/pull/10620

To test:
Testing steps in the parent PR.

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
