### PR TITLE
Add/mobile fullscreen image preview

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "gutenberg"]
 	path = gutenberg
-	url = ../../WordPress/gutenberg.git
+	url = ../../cameronvoell/gutenberg.git
 [submodule "react-native-aztec"]
 	path = react-native-aztec-old-submodule
 	url = ../react-native-aztec.git


### PR DESCRIPTION
Fixes #1286 *
gutenberg PR: https://github.com/WordPress/gutenberg/pull/17109

*Image fullscreen functionality is behind __DEV__ flag until we fix Android rotation issues, or limit this feature to iOS and enable an alternative fullscreen preview on Android. 

To test:

1. Open article in the block editor.
2. Navigate to an image block with an image loaded, or add a new image block and add an image
3. Select the image block and notice the blue border shows around the image
4. Press the image while the image block is selected and notice the image will be viewed in fullscreen.
5. Press outside the boundaries of the image in fullscreen mode, or swipe the image down to exit the fullscreen image preview.

Update release notes:

- [ x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
