### PR TITLE
Add content alignment options to paragraph block

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,19 +1,17 @@
 1.17.0
 ------
-* [iOS] Add support for Preformatted block.
 * Include block title in Unsupported block's UI
 * Show new-block-indicator when no blocks at all and when at the last block
 * Use existing links in the clipboard to prefill url field when inserting new link.
 * Media & Text block alignment options
+* Add alignment controls for paragraph blocks
 * [iOS] Fix issue where the keyboard would not capitalize sentences correctly on some cases.
 * [iOS] Support for Pexels image library
+* [iOS] Add support for Preformatted block.
 
 1.16.1
 ------
 * [iOS] Fix tap on links bug that reappear on iOS 13.2
-1.16.1
-------
-* Add alignment controls for paragraph blocks
 
 1.16.0
 ------

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,9 @@
 1.16.1
 ------
 * [iOS] Fix tap on links bug that reappear on iOS 13.2
+1.16.1
+------
+* Add alignment controls for paragraph blocks
 
 1.16.0
 ------

--- a/react-native-aztec/ios/Cartfile
+++ b/react-native-aztec/ios/Cartfile
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.11.0"
+github "wordpress-mobile/AztecEditor-iOS" "1.12.0"

--- a/react-native-aztec/ios/Cartfile.resolved
+++ b/react-native-aztec/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.11.0"
+github "wordpress-mobile/AztecEditor-iOS" "1.12.0"

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -88,6 +88,13 @@ class RCTAztecView: Aztec.TextView {
         )
     }()
 
+    private lazy var placeholderWidthConstraint: NSLayoutConstraint = {
+        // width needs to be shrunk on both the left and the right by the textInset in order for
+        // the placeholder to be appropriately positioned with right alignment.
+        let placeholderWidthInset = 2 * leftTextInset
+        return placeholderLabel.widthAnchor.constraint(equalTo: widthAnchor, constant: -placeholderWidthInset)
+    }()
+
     /// If a dictation start with an empty UITextView,
     /// the dictation engine refreshes the TextView with an empty string when the dictation finishes.
     /// This helps to avoid propagating that unwanted empty string to RN. (Solving #606)
@@ -143,8 +150,8 @@ class RCTAztecView: Aztec.TextView {
         let topConstant = contentInset.top + textContainerInset.top
         NSLayoutConstraint.activate([
             placeholderHorizontalConstraint,
-            placeholderLabel.topAnchor.constraint(equalTo: topAnchor, constant: topConstant),
-            placeholderLabel.widthAnchor.constraint(equalTo: widthAnchor),
+            placeholderWidthConstraint,
+            placeholderLabel.topAnchor.constraint(equalTo: topAnchor, constant: topConstant)
         ])
     }
 


### PR DESCRIPTION
Fixes #1266 . Further details available in the related [gutenberg PR](https://github.com/WordPress/gutenberg/pull/17577). Newer Gutenberg PR that targets the 1.17 release: https://github.com/WordPress/gutenberg/pull/18433

Because this includes an update to the AztecEditor-iOS version, merging this also needs to be coordinated with merging that update into WPiOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/12929

### Release Notes

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
