### PR TITLE
Fix requestImport call to send the correct arguments.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.15.2
+------
+* Fix issue when copy/paste photos from other apps, was not inserting an image on the post.
+
 1.15.0
 ------
 * Fix issue when multiple media selection adds only one image or video block on Android

--- a/ios/gutenberg/GutenbergViewController.swift
+++ b/ios/gutenberg/GutenbergViewController.swift
@@ -74,15 +74,17 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
             switch currentFilter {
             case .image:
                 if(allowMultipleSelection) {
-                    callback([(1, "https://cldup.com/cXyG__fTLN.jpg", "image"), (3, "https://cldup.com/cXyG__fTLN.jpg", "image")])
+                    callback([MediaInfo(id: 1, url: "https://cldup.com/cXyG__fTLN.jpg", type: "image"),
+                              MediaInfo(id: 3, url: "https://cldup.com/cXyG__fTLN.jpg", type: "image")])
                 } else {
-                    callback([(1, "https://cldup.com/cXyG__fTLN.jpg", "image")])
+                    callback([MediaInfo(id: 1, url: "https://cldup.com/cXyG__fTLN.jpg", type: "image")])
                 }
             case .video:
                 if(allowMultipleSelection) {
-                    callback([(2, "https://i.cloudup.com/YtZFJbuQCE.mov", "video"), (4, "https://i.cloudup.com/YtZFJbuQCE.mov", "video")])
+                    callback([MediaInfo(id: 2, url: "https://i.cloudup.com/YtZFJbuQCE.mov", type: "video"),
+                              MediaInfo(id: 4, url: "https://i.cloudup.com/YtZFJbuQCE.mov", type: "video")])
                 } else {
-                    callback([(2, "https://i.cloudup.com/YtZFJbuQCE.mov", "video")])
+                    callback([MediaInfo(id: 2, url: "https://i.cloudup.com/YtZFJbuQCE.mov", type: "video")])
                 }
             default:
                 break
@@ -96,18 +98,18 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         }
     }
 
-    func gutenbergDidRequestImport(from url: URL, with callback: @escaping MediaPickerDidPickMediaCallback) {
+    func gutenbergDidRequestImport(from url: URL, with callback: @escaping MediaImportCallback) {
         let id = mediaUploadCoordinator.upload(url: url)
-        callback([(id, url.absoluteString, "image")])
+        callback(MediaInfo(id: id, url: url.absoluteString, type: "image"))
     }
 
     func pickAndUpload(from source: UIImagePickerController.SourceType, filter: MediaFilter, callback: @escaping MediaPickerDidPickMediaCallback) {
         mediaPickCoordinator = MediaPickCoordinator(presenter: self, filter: filter, callback: { (url) in
             guard let url = url, let mediaID = self.mediaUploadCoordinator.upload(url: url) else {
-                callback([(nil, nil, nil)])
+                callback([MediaInfo(id: nil, url: nil, type: nil)])
                 return
             }
-            callback([(mediaID, url.absoluteString, "image")])
+            callback([MediaInfo(id: mediaID, url: url.absoluteString, type: "image")])
             self.mediaPickCoordinator = nil
         } )
         mediaPickCoordinator?.pick(from: source)

--- a/react-native-gutenberg-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/react-native-gutenberg-bridge/ios/GutenbergBridgeDelegate.swift
@@ -1,7 +1,7 @@
 public struct MediaInfo {
-    let id: Int32?
-    let url: String?
-    let type: String?
+    public let id: Int32?
+    public let url: String?
+    public let type: String?
 
     public init(id: Int32?, url: String?, type: String?) {
         self.id = id

--- a/react-native-gutenberg-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/react-native-gutenberg-bridge/ios/GutenbergBridgeDelegate.swift
@@ -1,4 +1,18 @@
-public typealias MediaPickerDidPickMediaCallback = (_ media: [(Int32?,String?,String?)]?) -> Void
+public struct MediaInfo {
+    let id: Int32?
+    let url: String?
+    let type: String?
+
+    public init(id: Int32?, url: String?, type: String?) {
+        self.id = id
+        self.url = url
+        self.type = type
+    }
+}
+
+public typealias MediaPickerDidPickMediaCallback = (_ media: [MediaInfo]?) -> Void
+
+public typealias MediaImportCallback = (_ media: MediaInfo?) -> Void
 
 public enum MediaPickerSource: String {
     case mediaLibrary = "SITE_MEDIA_LIBRARY"
@@ -71,7 +85,7 @@ public protocol GutenbergBridgeDelegate: class {
     ///   - url: the url to import
     ///   - callback: A callback block to be called with an array of upload mediaIdentifiers and a placeholder images file url, use nil on both parameters to signal that the action has failed.
     //
-    func gutenbergDidRequestImport(from url: URL, with callback: @escaping MediaPickerDidPickMediaCallback)
+    func gutenbergDidRequestImport(from url: URL, with callback: @escaping MediaImportCallback)
 
     /// Tells the delegate that an image block requested to reconnect with media uploads coordinator.
     ///

--- a/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -27,17 +27,22 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
                     callback(nil)
                     return
                 }
-                if (allowMultipleSelection) {
-                    let formattedMedia = media.map { (id, url, type) in
-                        return [mediaDictKeys.IDKey: id, mediaDictKeys.URLKey: url, mediaDictKeys.TypeKey: type]
-                    }
-                    callback([formattedMedia])
+                let mediaToReturn: [MediaInfo]
+                if allowMultipleSelection {
+                    mediaToReturn = media
                 } else {
-                    guard let (mediaID, mediaURL, mediaType) = media.first else {
-                        callback(nil)
-                        return
-                    }
-                    callback([[mediaDictKeys.IDKey: mediaID, mediaDictKeys.URLKey: mediaURL, mediaDictKeys.TypeKey: mediaType]])
+                    mediaToReturn = Array(media.prefix(1))
+                }
+
+                let jsFormattedMedia = mediaToReturn.map { mediaInfo in
+                    return [mediaDictKeys.IDKey: mediaInfo.id as Any,
+                            mediaDictKeys.URLKey: mediaInfo.url as Any,
+                            mediaDictKeys.TypeKey: mediaInfo.type as Any]
+                }
+                if allowMultipleSelection {
+                    callback([jsFormattedMedia])
+                } else {
+                    callback(jsFormattedMedia)
                 }
             })
         }
@@ -50,12 +55,12 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
             return
         }
         DispatchQueue.main.async {
-            self.delegate?.gutenbergDidRequestImport(from: url, with: { mediaList in
-                guard let mediaList = mediaList else {
+            self.delegate?.gutenbergDidRequestImport(from: url, with: { mediaInfo in
+                guard let mediaInfo = mediaInfo else {
                     callback(nil)
                     return
-                }
-                callback(mediaList)
+                }                
+                callback([mediaInfo.id as Any, mediaInfo.url as Any])
             })
         }
     }

--- a/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -35,9 +35,7 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
                 }
 
                 let jsFormattedMedia = mediaToReturn.map { mediaInfo in
-                    return [mediaDictKeys.IDKey: mediaInfo.id as Any,
-                            mediaDictKeys.URLKey: mediaInfo.url as Any,
-                            mediaDictKeys.TypeKey: mediaInfo.type as Any]
+                    return mediaInfo.encodeForJS()
                 }
                 if allowMultipleSelection {
                     callback([jsFormattedMedia])
@@ -200,5 +198,16 @@ extension RNReactNativeGutenbergBridge {
         static let IDKey = "id"
         static let URLKey = "url"
         static let TypeKey = "type"
+    }
+}
+
+extension MediaInfo {
+
+    func encodeForJS() -> [String: Any] {
+        return [
+            RNReactNativeGutenbergBridge.mediaDictKeys.IDKey: id as Any,
+            RNReactNativeGutenbergBridge.mediaDictKeys.URLKey: url as Any,
+            RNReactNativeGutenbergBridge.mediaDictKeys.TypeKey: type as Any
+        ]
     }
 }


### PR DESCRIPTION
Beside fixing the request for import to send the correct parameters in
the callback, we are also improving the interface by replacing a tupple
for a structure to make parameters more explicit.

This can also be tested on the main app using this PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/12773

To test:
 - Start the demo app
 - On the image blocks check that the different sources work correctly
 - Try to copy one image from the photos app and paste inside a text block, check that an image block is added and you see an image upload simulation happening.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
