### PR TITLE
Force block inserter to re-render on device rotation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.15.2
+------
+* Fix issue where the block inserter layout wasn't correct after device rotation.
+
 1.15.0
 ------
 * Fix issue when multiple media selection adds only one image or video block on Android


### PR DESCRIPTION
This PR uses onLayout and the internal State of inserter menu to force a re-render of the component on device rotation.

gutenberg PR: https://github.com/WordPress/gutenberg/pull/18101

Fixes: wordpress-mobile/gutenberg-mobile#1491

- Run the example app (iOS and Android).
- Press (+) to show the block inserter.
- Check that the layout looks fine.
- Rotate the device.
- Check that the layout rearranges.

**Note:** There's a small jump after the rotation while the layout changes. As a hotfix is probably good enough, but I'd like to check this out later on.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
