### PR TITLE
Include the block title in unsupported blocks

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.17.0
+------
+* Include block title in Unsupported block's UI
+
 1.16.0
 ------
 * [Android] Add support for pexels images


### PR DESCRIPTION
Fixes #479 

Includes the locally available block title in the "Unsupported block" UI for better clarity and context.

Work mostly performed by @illusaen. I'm opening a new set of PRs to land this fast while Wendy is temporarily away.

Gutenberg PR: https://github.com/WordPress/gutenberg/pull/18268

To test:

TBD

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
