### PR TITLE
Update GB reference to support copy of url in clipboard.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.17.0
+------
+* Use existing links in the clipboard to prefill url field when inserting new link.
+
 1.16.0
 ------
 * [Android] Add support for pexels images


### PR DESCRIPTION
Fixes #680 

GB PR: https://github.com/WordPress/gutenberg/pull/18279

To test:
 - Start the demo app
 - Switch to Safari and copy a link from the url bar
 - Switch to GB demo app
 - Select a text block
 - Select a bit of text
 - Tap on the link button
 - Check that the URL that you copied from Safari is added to the URL field in the link modal
 - Edit an already existing link and check that the link in the clipboard does not override the one already existing.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
