### PR TITLE
Remove custom paragraph options for media-text

### DIFF
--- a/src/initial-html.js
+++ b/src/initial-html.js
@@ -9,7 +9,7 @@ export default `
 <!-- /wp:image -->
 
 <!-- wp:media-text -->
-<div class="wp-block-media-text is-stacked-on-mobile"><figure class="wp-block-media-text__media"></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
+<div class="wp-block-media-text is-stacked-on-mobile"><figure class="wp-block-media-text__media"></figure><div class="wp-block-media-text__content"><!-- wp:paragraph -->
 <p class="has-large-font-size"></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:media-text -->


### PR DESCRIPTION
Gutenberg PR: https://github.com/WordPress/gutenberg/pull/18284
Fixes #1531

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
