### PR TITLE
[iOS] Implement client-defined media options.

### DIFF
--- a/ios/gutenberg/GutenbergViewController.swift
+++ b/ios/gutenberg/GutenbergViewController.swift
@@ -64,8 +64,8 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         print("↳ HTML: \(html)")
     }
 
-    func gutenbergDidRequestMedia(from source: MediaPickerSource, filter: [MediaFilter]?, allowMultipleSelection: Bool, with callback: @escaping MediaPickerDidPickMediaCallback) {
-        guard let currentFilter = filter?.first else {
+    func gutenbergDidRequestMedia(from source: Gutenberg.MediaSource, filter: [Gutenberg.MediaType], allowMultipleSelection: Bool, with callback: @escaping MediaPickerDidPickMediaCallback) {
+        guard let currentFilter = filter.first else {
             return
         }
         switch source {
@@ -95,6 +95,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         case .deviceCamera:
             print("Gutenberg did request a device media picker, opening the camera picker")
             pickAndUpload(from: .camera, filter: currentFilter, callback: callback)
+        default: break
         }
     }
 
@@ -103,7 +104,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         callback(MediaInfo(id: id, url: url.absoluteString, type: "image"))
     }
 
-    func pickAndUpload(from source: UIImagePickerController.SourceType, filter: MediaFilter, callback: @escaping MediaPickerDidPickMediaCallback) {
+    func pickAndUpload(from source: UIImagePickerController.SourceType, filter: Gutenberg.MediaType, callback: @escaping MediaPickerDidPickMediaCallback) {
         mediaPickCoordinator = MediaPickCoordinator(presenter: self, filter: filter, callback: { (url) in
             guard let url = url, let mediaID = self.mediaUploadCoordinator.upload(url: url) else {
                 callback([MediaInfo(id: nil, url: nil, type: nil)])

--- a/ios/gutenberg/MediaPickCoordinator.swift
+++ b/ios/gutenberg/MediaPickCoordinator.swift
@@ -8,10 +8,10 @@ class MediaPickCoordinator: NSObject, UIImagePickerControllerDelegate, UINavigat
   
   private let presenter: UIViewController
   private let callback: (URL?) -> Void
-  private let filter: MediaFilter
+  private let filter: Gutenberg.MediaType
   
   init(presenter: UIViewController,
-       filter: MediaFilter,
+       filter: Gutenberg.MediaType,
        callback: @escaping (URL?) -> Void) {
       self.presenter = presenter
       self.callback = callback

--- a/react-native-gutenberg-bridge/ios/Gutenberg.swift
+++ b/react-native-gutenberg-bridge/ios/Gutenberg.swift
@@ -163,6 +163,14 @@ extension Gutenberg {
     public enum MediaType: String {
         case image
         case video
+        case audio
+        case other
+    }
+}
+
+extension Gutenberg.MediaType {
+    init(fromJSString rawValue: String) {
+        self = Gutenberg.MediaType(rawValue: rawValue) ?? .other
     }
 }
 
@@ -174,8 +182,8 @@ extension Gutenberg {
         /// A unique identifier of this media source option.
         let id: String
 
-        /// The type of media this source can provide.
-        let type: MediaType
+        /// The types of media this source can provide.
+        let types: Set<MediaType>
 
         var jsRepresentation: [String: String] {
             return [
@@ -187,9 +195,9 @@ extension Gutenberg {
 }
 
 public extension Gutenberg.MediaSource {
-    public init(id: String, label: String, type: Gutenberg.MediaType) {
+    public init(id: String, label: String, types: [Gutenberg.MediaType]) {
         self.id = id
         self.label = label
-        self.type = type
+        self.types = Set(types)
     }
 }

--- a/react-native-gutenberg-bridge/ios/Gutenberg.swift
+++ b/react-native-gutenberg-bridge/ios/Gutenberg.swift
@@ -167,7 +167,7 @@ extension Gutenberg {
 }
 
 extension Gutenberg {
-    public struct MediaSource {
+    public struct MediaSource: Hashable {
         /// The label string that will be shown to the user.
         let label: String
 
@@ -188,6 +188,8 @@ extension Gutenberg {
 
 public extension Gutenberg.MediaSource {
     public init(id: String, label: String, type: Gutenberg.MediaType) {
-        self.init(id: id, label: label, type: type)
+        self.id = id
+        self.label = label
+        self.type = type
     }
 }

--- a/react-native-gutenberg-bridge/ios/Gutenberg.swift
+++ b/react-native-gutenberg-bridge/ios/Gutenberg.swift
@@ -71,6 +71,7 @@ public class Gutenberg: NSObject {
         self.dataSource = dataSource
         self.extraModules = extraModules
         super.init()
+        bridgeModule.dataSource = dataSource
         logThreshold = isPackagerRunning ? .trace : .error
     }
 
@@ -162,5 +163,31 @@ extension Gutenberg {
     public enum MediaType: String {
         case image
         case video
+    }
+}
+
+extension Gutenberg {
+    public struct MediaSource {
+        /// The label string that will be shown to the user.
+        let label: String
+
+        /// A unique identifier of this media source option.
+        let id: String
+
+        /// The type of media this source can provide.
+        let type: MediaType
+
+        var jsRepresentation: [String: String] {
+            return [
+                "label": label,
+                "value": id,
+            ]
+        }
+    }
+}
+
+public extension Gutenberg.MediaSource {
+    public init(id: String, label: String, type: Gutenberg.MediaType) {
+        self.init(id: id, label: label, type: type)
     }
 }

--- a/react-native-gutenberg-bridge/ios/GutenbergBridgeDataSource.swift
+++ b/react-native-gutenberg-bridge/ios/GutenbergBridgeDataSource.swift
@@ -30,4 +30,13 @@ public protocol GutenbergBridgeDataSource: class {
     ///
     /// - Returns: Gutenberg related localization key value pairs for the current locale.
     func gutenbergTranslations() -> [String : [String]]?
+
+    /// Asks the delegate for a list of Media Sources to show on the Media Source Picker.
+    func gutenbergMediaSources() -> [Gutenberg.MediaSource]
+}
+
+public extension GutenbergBridgeDataSource {
+    func gutenbergMediaSources() -> [Gutenberg.MediaSource] {
+        return []
+    }
 }

--- a/react-native-gutenberg-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/react-native-gutenberg-bridge/ios/GutenbergBridgeDelegate.swift
@@ -17,9 +17,9 @@ public typealias MediaImportCallback = (_ media: MediaInfo?) -> Void
 /// Label and Type are not relevant since they are delcared on the JS side.
 /// Hopefully soon, this will need to be declared on the client side.
 extension Gutenberg.MediaSource {
-    public static let mediaLibrary = Gutenberg.MediaSource(id: "SITE_MEDIA_LIBRARY", label: "", type: .image)
-    public static let deviceLibrary = Gutenberg.MediaSource(id: "DEVICE_MEDIA_LIBRARY", label: "", type: .image)
-    public static let deviceCamera = Gutenberg.MediaSource(id: "DEVICE_CAMERA", label: "", type: .image)
+    public static let mediaLibrary = Gutenberg.MediaSource(id: "SITE_MEDIA_LIBRARY", label: "", types: [.image, .video])
+    public static let deviceLibrary = Gutenberg.MediaSource(id: "DEVICE_MEDIA_LIBRARY", label: "", types: [.image, .video])
+    public static let deviceCamera = Gutenberg.MediaSource(id: "DEVICE_CAMERA", label: "", types: [.image, .video])
 
     static var registeredInternalSources: [Gutenberg.MediaSource] {
         return [
@@ -28,13 +28,6 @@ extension Gutenberg.MediaSource {
             .mediaLibrary,
         ]
     }
-}
-
-public enum MediaFilter: String {
-    case image
-    case video
-    case audio
-    case other
 }
 
 /// Ref. https://github.com/facebook/react-native/blob/master/Libraries/polyfills/console.js#L376
@@ -87,7 +80,7 @@ public protocol GutenbergBridgeDelegate: class {
     ///     - source: the source from where the picker will get the media
     ///     - callback: A callback block to be called with an array of upload mediaIdentifiers and a placeholder images file url, use nil on both parameters to signal that the action was canceled.
     ///
-    func gutenbergDidRequestMedia(from source: Gutenberg.MediaSource, filter: [MediaFilter]?, allowMultipleSelection: Bool, with callback: @escaping MediaPickerDidPickMediaCallback)
+    func gutenbergDidRequestMedia(from source: Gutenberg.MediaSource, filter: [Gutenberg.MediaType], allowMultipleSelection: Bool, with callback: @escaping MediaPickerDidPickMediaCallback)
 
     /// Tells the delegate that gutenberg JS requested the import of media item based on the provided URL
     ///

--- a/react-native-gutenberg-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/react-native-gutenberg-bridge/ios/GutenbergBridgeDelegate.swift
@@ -11,13 +11,23 @@ public struct MediaInfo {
 }
 
 public typealias MediaPickerDidPickMediaCallback = (_ media: [MediaInfo]?) -> Void
-
 public typealias MediaImportCallback = (_ media: MediaInfo?) -> Void
 
-public enum MediaPickerSource: String {
-    case mediaLibrary = "SITE_MEDIA_LIBRARY"
-    case deviceLibrary = "DEVICE_MEDIA_LIBRARY"
-    case deviceCamera = "DEVICE_CAMERA"
+/// Declare internal Media Sources.
+/// Label and Type are not relevant since they are delcared on the JS side.
+/// Hopefully soon, this will need to be declared on the client side.
+extension Gutenberg.MediaSource {
+    public static let mediaLibrary = Gutenberg.MediaSource(id: "SITE_MEDIA_LIBRARY", label: "", type: .image)
+    public static let deviceLibrary = Gutenberg.MediaSource(id: "DEVICE_MEDIA_LIBRARY", label: "", type: .image)
+    public static let deviceCamera = Gutenberg.MediaSource(id: "DEVICE_CAMERA", label: "", type: .image)
+
+    static var registeredInternalSources: [Gutenberg.MediaSource] {
+        return [
+            .deviceCamera,
+            .deviceLibrary,
+            .mediaLibrary,
+        ]
+    }
 }
 
 public enum MediaFilter: String {
@@ -77,7 +87,7 @@ public protocol GutenbergBridgeDelegate: class {
     ///     - source: the source from where the picker will get the media
     ///     - callback: A callback block to be called with an array of upload mediaIdentifiers and a placeholder images file url, use nil on both parameters to signal that the action was canceled.
     ///
-    func gutenbergDidRequestMedia(from source: MediaPickerSource, filter: [MediaFilter]?, allowMultipleSelection: Bool, with callback: @escaping MediaPickerDidPickMediaCallback)
+    func gutenbergDidRequestMedia(from source: Gutenberg.MediaSource, filter: [MediaFilter]?, allowMultipleSelection: Bool, with callback: @escaping MediaPickerDidPickMediaCallback)
 
     /// Tells the delegate that gutenberg JS requested the import of media item based on the provided URL
     ///

--- a/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -1,8 +1,10 @@
 @objc (RNReactNativeGutenbergBridge)
 public class RNReactNativeGutenbergBridge: RCTEventEmitter {
     weak var delegate: GutenbergBridgeDelegate?
+    weak var dataSource: GutenbergBridgeDataSource?
     private var isJSLoading = true
     private var hasObservers = false
+
     // MARK: - Messaging methods
 
     @objc
@@ -50,10 +52,15 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
     func requestOtherMediaPickFrom(_ source: String, allowMultipleSelection: Bool, callback: @escaping RCTResponseSenderBlock) {
         //TODO implement me
     }
-    
+
     @objc
     func getOtherMediaOptions(_ filter: [String]?, callback: @escaping RCTResponseSenderBlock) {
-        //TODO implement me
+        guard let dataSource = dataSource else {
+            return callback([])
+        }
+        let mediaSources = dataSource.gutenbergMediaSources()
+        let mediaSourcesString = mediaSources.map{ $0.jsRepresentation }
+        callback([mediaSourcesString])
     }
 
     @objc

--- a/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -16,9 +16,8 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
     
     @objc
     func requestMediaPickFrom(_ source: String, filter: [String]?, allowMultipleSelection: Bool, callback: @escaping RCTResponseSenderBlock) {
-        let allMediaSources = Gutenberg.MediaSource.registeredInternalSources + (dataSource?.gutenbergMediaSources() ?? [])
-        let mediaSource = allMediaSources.first{ $0.id == source } ?? .deviceLibrary
-        let mediaFilter = mediaTypes(from: filter)
+        let mediaSource = getMediaSource(withId: source)
+        let mediaFilter = getMediaTypes(from: filter)
 
         DispatchQueue.main.async {
             self.delegate?.gutenbergDidRequestMedia(from: mediaSource, filter: mediaFilter, allowMultipleSelection: allowMultipleSelection, with: { media in
@@ -45,10 +44,6 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
         }
     }
 
-    private func mediaTypes(from jsMediaTypes: [String]?) -> [Gutenberg.MediaType] {
-        return (jsMediaTypes ?? []).map { Gutenberg.MediaType(fromJSString: $0) }
-    }
-    
     @objc
     func requestOtherMediaPickFrom(_ source: String, allowMultipleSelection: Bool, callback: @escaping RCTResponseSenderBlock) {
         requestMediaPickFrom(source, filter: nil, allowMultipleSelection: allowMultipleSelection, callback: callback)
@@ -61,7 +56,7 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
         }
 
         let mediaSources = dataSource.gutenbergMediaSources()
-        let allowedTypes = mediaTypes(from: filter)
+        let allowedTypes = getMediaTypes(from: filter)
         let filteredSources = mediaSources.filter {
             return $0.types.intersection(allowedTypes).isEmpty == false
         }
@@ -207,12 +202,20 @@ extension RNReactNativeGutenbergBridge {
 // MARK: - Helpers
 
 extension RNReactNativeGutenbergBridge {
-    
     func optionalArray(from optionalString: String?) -> [String]? {
         guard let string = optionalString else {
             return nil
         }
         return [string]
+    }
+
+    private func getMediaSource(withId mediaSourceID: String) -> Gutenberg.MediaSource {
+        let allMediaSources = Gutenberg.MediaSource.registeredInternalSources + (dataSource?.gutenbergMediaSources() ?? [])
+        return allMediaSources.first{ $0.id == mediaSourceID } ?? .deviceLibrary
+    }
+
+    private func getMediaTypes(from jsMediaTypes: [String]?) -> [Gutenberg.MediaType] {
+        return (jsMediaTypes ?? []).map { Gutenberg.MediaType(fromJSString: $0) }
     }
 }
 

--- a/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -16,7 +16,9 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
     
     @objc
     func requestMediaPickFrom(_ source: String, filter: [String]?, allowMultipleSelection: Bool, callback: @escaping RCTResponseSenderBlock) {
-        let mediaSource: MediaPickerSource = MediaPickerSource(rawValue: source) ?? .deviceLibrary
+        let allMediaSources = Gutenberg.MediaSource.registeredInternalSources + (dataSource?.gutenbergMediaSources() ?? [])
+        let mediaSource = allMediaSources.first{ $0.id == source } ?? .deviceLibrary
+
         let mediaFilter: [MediaFilter]? = filter?.map({
             if let type = MediaFilter(rawValue: $0) {
                 return type
@@ -50,7 +52,7 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
     
     @objc
     func requestOtherMediaPickFrom(_ source: String, allowMultipleSelection: Bool, callback: @escaping RCTResponseSenderBlock) {
-        //TODO implement me
+        requestMediaPickFrom(source, filter: nil, allowMultipleSelection: allowMultipleSelection, callback: callback)
     }
 
     @objc


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/720

This PR implements the iOS Bridge code needed for Stock Photos (Pexels) and https://github.com/wordpress-mobile/gutenberg-mobile/issues/1265

`WPiOS` PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/12858

![pexels](https://user-images.githubusercontent.com/9772967/68203818-fa551c00-ffc6-11e9-9382-8139ca0967cc.gif)

**Note:**
- The "Free Photo Library" is the same as used on Aztec.
- I decided to make the Free Photos Library multi-selectable, even though we haven't activated this feature on iOS yet. I can keep it single selectable if we decide that this is better.

- There are some few small changes on the bridge media picker/upload methods, so it would be good to test all options on all media related blocks. (cc @pinarol)

- I noticed that we could improve some things in the JS side, but opted to keep this PR focused on adopting the current implementation to avoid the need of Android changes.

**To test:**
- Test on WPiOS running: https://github.com/wordpress-mobile/WordPress-iOS/pull/12858

Image Block:
- Add an Image block.
- Check that the "Free Photo Library" option is there.
- Open the Free Photo Library.
- Choose one (or many) images.
- Check that all images selected are added.
- Check that you can select only images in all other options.

Video Block:
- Add a video block.
- Check that "Free Photo Library" is NOT in the options.
- Check that you can only select videos in all other options.

Media&Text:
- Add an Media&Text block.
- Check that the "Free Photo Library" option is there.
- Open the Free Photo Library.
- Choose one (or many) images. (Multi-select is also possible on Android)
- Check that all images selected are added. (Extra images will be added as Image Block)
- Check that you can select images and videos in all other options.

cc @marecar3 

Update release notes:
- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
