### PR TITLE
Fix iOS13 link tap bug

### DIFF
--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -135,6 +135,7 @@ class RCTAztecView: Aztec.TextView {
         textDragInteraction?.isEnabled = false        
         storage.htmlConverter.characterToReplaceLastEmptyLine = Character(.zeroWidthSpace)
         shouldNotifyOfNonUserChanges = false
+        disableLinkTapRecognizer()
     }
 
     func addPlaceholder() {
@@ -145,6 +146,13 @@ class RCTAztecView: Aztec.TextView {
             placeholderLabel.topAnchor.constraint(equalTo: topAnchor, constant: topConstant),
             placeholderLabel.widthAnchor.constraint(equalTo: widthAnchor),
         ])
+    }
+
+    func disableLinkTapRecognizer() {
+        guard let recognizer = gestureRecognizers?.first(where: { $0.name == "UITextInteractionNameLinkTap" }) else {
+            return
+        }
+        recognizer.isEnabled = false
     }
 
     // MARK - View Height: Match to content height
@@ -624,21 +632,5 @@ extension RCTAztecView: UITextViewDelegate {
 
     func textViewDidEndEditing(_ textView: UITextView) {
         onBlur?([:])
-    }
-
-    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
-        if #available(iOS 13.1, *) {
-            return false
-        } else if #available(iOS 13.0.0, *) {
-            // Sergio Estevao: This shouldn't happen in an editable textView, but it looks we have a system bug in iOS13 so we need this workaround
-            let position = characterRange.location
-            textView.selectedRange = NSRange(location: position, length: 0)
-            textView.typingAttributes = textView.attributedText.attributes(at: position, effectiveRange: nil)
-            textView.delegate?.textViewDidChangeSelection?(textView)
-        } else {
-            return false
-        }
-
-        return false
     }
 }

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -148,6 +148,15 @@ class RCTAztecView: Aztec.TextView {
         ])
     }
 
+    /**
+     This handles a bug introduced by iOS 13.0 (tested up to 13.2) where link interactions don't respect what the documentation says.
+
+     The documenatation for textView(_:shouldInteractWith:in:interaction:) says:
+
+     > Links in text views are interactive only if the text view is selectable but noneditable.
+
+     Our Aztec Text views are selectable and editable, and yet iOS was opening links on Safari when tapped.
+     */
     func disableLinkTapRecognizer() {
         guard let recognizer = gestureRecognizers?.first(where: { $0.name == "UITextInteractionNameLinkTap" }) else {
             return


### PR DESCRIPTION
It seems #1373 is back on iOS 13.2. The latest workaround we had was working fine up to iOS 13.1, but after an upgrade you wouldn't be able to select links anymore.

The previous workaround fixed the selection issues, but was causing random crashes https://github.com/wordpress-mobile/WordPress-iOS/issues/12730

The new approach avoids implementing the problematic `textView(_:shouldInteractWith:in:interaction:)` method, and tries to disable the system gesture recognizer that handles taps on links 🙈 

To test:

- Open a post with links
- Tapping a link should not open Safari
- Tapping a link should position the cursor in the link and allow selection like in regular text
- (Bonus) Long press on a link will bring up the link preview sheet

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
