### PR TITLE
Issue/fix layout bug in ios 13.2

### DIFF
--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -403,7 +403,7 @@ class RCTAztecView: Aztec.TextView {
             let end = selection["end"]  as? NSNumber {
             setSelection(start: start, end: end)
         }
-        // This signal the RN/JS system that the component needs to the relayout
+        // This signal the RN/JS system that the component needs to relayout
         setNeedsLayout()
     }
 

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -403,6 +403,8 @@ class RCTAztecView: Aztec.TextView {
             let end = selection["end"]  as? NSNumber {
             setSelection(start: start, end: end)
         }
+        // This signal the RN/JS system that the component needs to the relayout
+        setNeedsLayout()
     }
 
     override var textColor: UIColor? {

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -403,7 +403,7 @@ class RCTAztecView: Aztec.TextView {
             let end = selection["end"]  as? NSNumber {
             setSelection(start: start, end: end)
         }
-        // This signal the RN/JS system that the component needs to relayout
+        // This signals the RN/JS system that the component needs to relayout
         setNeedsLayout()
     }
 


### PR DESCRIPTION
Fixes #1534 

Bring this PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1535
to release 1.16.1

To test:
 - Start the demo app
 - Add a new list
 - Check that when adding new items to the list the block sizes correctly
 - Do the same checks with quotes and image captions

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
