### PR TITLE
Show new block indicator in default appender too

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 1.17.0
 ------
-* Show new-block-indicator when no blocks at all too
+* Show new-block-indicator when no blocks at all and when at the last block
 
 1.16.0
 ------

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.17.0
+------
+* Show new-block-indicator when no blocks at all too
+
 1.16.0
 ------
 * [Android] Add support for pexels images


### PR DESCRIPTION
Fixes #632 

Addresses [the subcase in #632](https://github.com/wordpress-mobile/gutenberg-mobile/issues/632#issuecomment-513213114) where the new-block indicator wasn't shown when the block list was empty and not interacted with yet.

Also, showing the indicator when at the last block of the list.

Gutenberg PR: https://github.com/WordPress/gutenberg/pull/18289

To test:

1. Locally edit the `initial-html.js` file to have an empty block list
2. Run the demo app
3. Tap on the "+" button to insert a new block
4. Notice the "ADD BLOCK HERE" indicator right below the title block 🎉

To test 2:

1. Locally edit the `initial-html.js` file to have an empty block list
2. Run the demo app
3. Type some text in the "Start writing" prompt
4. Tap on the "+" button to insert a new block
4. Notice the "ADD BLOCK HERE" indicator right below the paragraph block 🎉

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
