### PR TITLE
Update debug configuration for VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,30 +5,10 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Debug Android",
-            "program": "${workspaceRoot}/.vscode/launchReactNative.js",
-            "type": "reactnative",
-            "request": "launch",
-            "platform": "android",
-            "sourceMaps": true,
-            "outDir": "${workspaceRoot}/.vscode/.react"
-        },
-        {
-            "name": "Debug iOS",
-            "program": "${workspaceRoot}/.vscode/launchReactNative.js",
-            "type": "reactnative",
-            "request": "launch",
-            "platform": "ios",
-            "sourceMaps": true,
-            "outDir": "${workspaceRoot}/.vscode/.react"
-        },
-        {
             "name": "Attach to packager",
-            "program": "${workspaceRoot}/.vscode/launchReactNative.js",
+            "cwd": "${workspaceFolder}",
             "type": "reactnative",
-            "request": "attach",
-            "sourceMaps": true,
-            "outDir": "${workspaceRoot}/.vscode/.react"
+            "request": "attach"
         },
     ]
 }


### PR DESCRIPTION
It seems the old config was broken with newer versions of the extension. I removed the config and inserted the default entries.

I've also removed the options to launch iOS and Android since they are not working right now

To test:

- Open VSCode
- Run `yarn start`
- Launch the demo app on the simulator
- From VSCode, choose Debug > Start Debugging
- From the simulator, launch the dev menu and choose Debug JS Remotely

The bottom bar on VSCode should turn red, and you should be able to set breakpoints and use the debugger

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
