### PR TITLE
Correct path to the jest binary for test debugger

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "ios": "react-native run-ios",
     "test": "cross-env NODE_ENV=test jest --verbose --config jest.config.js",
     "test:inside-gb": "cross-env NODE_ENV=test jest --verbose --config jest_gb.config.js",
-    "test:debug": "cross-env NODE_ENV=test node --inspect-brk jest --runInBand --verbose --config jest.config.js",
+    "test:debug": "cross-env NODE_ENV=test node --inspect-brk node_modules/.bin/jest --runInBand --verbose --config jest.config.js",
     "device-tests": "cross-env NODE_ENV=test jest --no-cache --maxWorkers=3 --reporters=default --reporters=jest-junit --verbose --config jest_ui.config.js",
     "device-tests:local": "cross-env NODE_ENV=test jest --runInBand --reporters=default --reporters=jest-junit --detectOpenHandles --verbose --config jest_ui.config.js",
     "device-tests:debug": "cross-env NODE_ENV=test node $NODE_DEBUG_OPTION --inspect-brk node_modules/jest/bin/jest --runInBand --reporters=default --reporters=jest-junit --detectOpenHandles --verbose --config jest_ui.config.js",


### PR DESCRIPTION
Fixes #1556

To test:

0. Place a `debugger;` statement at https://github.com/wordpress-mobile/gutenberg-mobile/blob/6b11d521a51459ac342faf06a704ed4c40124cb2/src/index.js#L55
1. Run `yarn test:debug` on the CLI
2. Open Chrome, and visit: `chrome://inspect` and hit "Inspect" on the `jest file:///` target
3. The debugger will stop at a `const importLocal = require('import-local');` line, which is normal
4. Press "Play" to let the debugger continue
5. Allow some time and the debugger should stop at the `debugger` statement placed in step 0 🎉 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
