### PR TITLE
Nudge for adding tests, clearer language on the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,5 +5,4 @@ To test:
 PR submission checklist:
 
 - [ ] I have considered adding unit tests where possible.
-
 - [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,8 @@ Fixes #
 
 To test:
 
-Update release notes:
+PR submission checklist:
 
-- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
+- [ ] I have considered adding unit tests where possible.
+
+- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


### PR DESCRIPTION
Updates the PR template to match the main WP apps:
1. More clear language, indicating that the author _needs_ to check the checkboxes
2. Nudge for adding tests

Taken from https://github.com/wordpress-mobile/WordPress-Android/blob/db0bba0e3012be0a0533737ac054d74453e05a34/.github/PULL_REQUEST_TEMPLATE.md

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
