### PR TITLE
Add Android native handling of api calls

### DIFF
--- a/android/app/src/main/java/com/gutenberg/MainApplication.java
+++ b/android/app/src/main/java/com/gutenberg/MainApplication.java
@@ -3,6 +3,8 @@ package com.gutenberg;
 import android.app.Application;
 import android.util.Log;
 
+import androidx.core.util.Consumer;
+
 import com.facebook.react.ReactApplication;
 import com.brentvatne.react.ReactVideoPackage;
 import com.facebook.react.bridge.ReadableArray;
@@ -104,6 +106,9 @@ public class MainApplication extends Application implements ReactApplication {
                         break;
                 }
             }
+
+            @Override
+            public void performRequest(String path, Consumer<String> onSuccess, Consumer<String> onError) {}
         });
 
         return new ReactNativeHost(this) {

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -91,6 +91,11 @@ android {
     lintOptions {
         abortOnError false
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 repositories {

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
@@ -1,14 +1,16 @@
 package org.wordpress.mobile.ReactNativeGutenbergBridge;
 
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.WritableMap;
 
 import org.wordpress.mobile.WPAndroidGlue.MediaOption;
+import org.wordpress.mobile.WPAndroidGlue.RequestExecutor;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public interface GutenbergBridgeJS2Parent {
+public interface GutenbergBridgeJS2Parent extends RequestExecutor {
     interface RNMedia {
         String getUrl();
         int getId();

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -3,6 +3,7 @@ package org.wordpress.mobile.ReactNativeGutenbergBridge;
 import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -182,6 +183,13 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
         OtherMediaOptionsReceivedCallback otherMediaOptionsReceivedCallback = getNewOtherMediaReceivedCallback(jsCallback);
         MediaType mediaType = getMediaTypeFromFilter(filter);
         mGutenbergBridgeJS2Parent.getOtherMediaPickerOptions(otherMediaOptionsReceivedCallback, mediaType);
+    }
+
+    @ReactMethod
+    public void fetchRequest(String path, Promise promise) {
+        mGutenbergBridgeJS2Parent.performRequest(path,
+                promise::resolve,
+                errorMessage -> promise.reject(new Error(errorMessage)));
     }
 
     private OtherMediaOptionsReceivedCallback getNewOtherMediaReceivedCallback(final Callback jsCallback) {

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/RequestExecutor.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/RequestExecutor.java
@@ -1,0 +1,7 @@
+package org.wordpress.mobile.WPAndroidGlue;
+
+import androidx.core.util.Consumer;
+
+public interface RequestExecutor {
+    void performRequest(String path, Consumer<String> onSuccess, Consumer<String> onError);
+}

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -13,6 +13,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout.LayoutParams;
 
+import androidx.core.util.Consumer;
 import androidx.fragment.app.Fragment;
 
 import com.brentvatne.react.ReactVideoPackage;
@@ -22,6 +23,7 @@ import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactInstanceManagerBuilder;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.ReactRootView;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.LifecycleState;
@@ -76,6 +78,7 @@ public class WPAndroidGlueCode {
     private boolean mShouldUpdateContent;
     private CountDownLatch mGetContentCountDownLatch;
     private WeakReference<View> mLastFocusedView = null;
+    private RequestExecutor mRequestExecutor;
 
     private static final String PROP_NAME_INITIAL_DATA = "initialData";
     private static final String PROP_NAME_INITIAL_TITLE = "initialTitle";
@@ -272,6 +275,11 @@ public class WPAndroidGlueCode {
                 mMediaPickedByUserOnBlock = true;
                 mOnMediaLibraryButtonListener.onOtherMediaButtonClicked(mediaSource, allowMultipleSelection);
             }
+
+            @Override
+            public void performRequest(String pathFromJS, Consumer<String> onSuccess, Consumer<String> onError) {
+                mRequestExecutor.performRequest(pathFromJS, onSuccess, onError);
+            }
         });
 
         return Arrays.asList(
@@ -333,7 +341,8 @@ public class WPAndroidGlueCode {
                                   OnReattachQueryListener onReattachQueryListener,
                                   OnEditorMountListener onEditorMountListener,
                                   OnEditorAutosaveListener onEditorAutosaveListener,
-                                  OnAuthHeaderRequestedListener onAuthHeaderRequestedListener) {
+                                  OnAuthHeaderRequestedListener onAuthHeaderRequestedListener,
+                                  RequestExecutor fetchExecutor) {
         MutableContextWrapper contextWrapper = (MutableContextWrapper) mReactRootView.getContext();
         contextWrapper.setBaseContext(viewGroup.getContext());
 
@@ -341,6 +350,7 @@ public class WPAndroidGlueCode {
         mOnReattachQueryListener = onReattachQueryListener;
         mOnEditorMountListener = onEditorMountListener;
         mOnEditorAutosaveListener = onEditorAutosaveListener;
+        mRequestExecutor = fetchExecutor;
 
         sAddCookiesInterceptor.setOnAuthHeaderRequestedListener(onAuthHeaderRequestedListener);
 

--- a/src/api-fetch-setup.js
+++ b/src/api-fetch-setup.js
@@ -1,8 +1,4 @@
-/**
- * External dependencies
- *
- * @format
- */
+/** @format */
 
 /**
  * External dependencies
@@ -18,6 +14,9 @@ const fetchHandler = ( options ) => {
 	const responsePromise = fetchRequest( options.path );
 
 	const parseResponse = ( response ) => {
+		if ( typeof response === 'string' ) {
+			response = JSON.parse( response );
+		}
 		return response;
 	};
 


### PR DESCRIPTION
Just looking to add the changes required for Android to your branch @etoledom . I realize this won't make a ton of sense without the WPAndroid changes for context (I'll get that up soon), but definitely let me know if you have any thoughts.