### PR TITLE
Undo more changes related to PRE support

### DIFF
--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -32,8 +32,8 @@ import org.wordpress.aztec.plugins.IToolbarButton;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.Set;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.HashMap;
 
 import static android.content.ClipData.*;
 

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -6,14 +6,13 @@ import android.content.Context;
 import android.graphics.Rect;
 import android.os.Handler;
 import android.os.Looper;
+import androidx.annotation.Nullable;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.Spannable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.view.inputmethod.InputMethodManager;
-
-import androidx.annotation.Nullable;
 
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.ReactContext;
@@ -31,12 +30,12 @@ import org.wordpress.aztec.plugins.IAztecPlugin;
 import org.wordpress.aztec.plugins.IToolbarButton;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Set;
+import java.util.HashMap;
+import java.util.HashSet;
 
-import static android.content.ClipData.Item;
+import static android.content.ClipData.*;
 
 public class ReactAztecText extends AztecText {
 

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecTextFormatEnum.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecTextFormatEnum.java
@@ -13,8 +13,7 @@ public enum ReactAztecTextFormatEnum {
     H3("h3", AztecTextFormat.FORMAT_HEADING_3),
     H4("h4", AztecTextFormat.FORMAT_HEADING_4),
     H5("h5", AztecTextFormat.FORMAT_HEADING_5),
-    H6("h6", AztecTextFormat.FORMAT_HEADING_6),
-    PRE("pre", AztecTextFormat.FORMAT_PREFORMAT);
+    H6("h6", AztecTextFormat.FORMAT_HEADING_6);
 
     private final String mTag;
     private final AztecTextFormat mAztecTextFormat;


### PR DESCRIPTION
Undos more Android side changes introduced when we merged https://github.com/wordpress-mobile/gutenberg-mobile/pull/1442 into the v1.17 release branch. Apparently, a crash is happening without this PR:

```
E/SoLoader: couldn't find DSO to load: libreactnativejni.so
...
    --------- beginning of crash
2019-11-14 11:34:24.902 5647-6174/org.wordpress.android.beta E/AndroidRuntime: FATAL EXCEPTION: create_react_context
    Process: org.wordpress.android.beta, PID: 5647
    java.lang.UnsatisfiedLinkError: couldn't find DSO to load: libreactnativejni.so
        at com.facebook.soloader.SoLoader.doLoadLibraryBySoName(SoLoader.java:738)
        at com.facebook.soloader.SoLoader.loadLibraryBySoName(SoLoader.java:591)
        at com.facebook.soloader.SoLoader.loadLibrary(SoLoader.java:529)
        at com.facebook.soloader.SoLoader.loadLibrary(SoLoader.java:484)
        at com.facebook.react.bridge.ReactBridge.staticInit(ReactBridge.java:31)
        at com.facebook.react.bridge.NativeMap.<clinit>(NativeMap.java:19)
        at com.facebook.react.jscexecutor.JSCExecutorFactory.create(JSCExecutorFactory.java:25)
        at com.facebook.react.ReactInstanceManager$5.run(ReactInstanceManager.java:949)
        at java.lang.Thread.run(Thread.java:764)
```

Note: @hypest could see the crash but @daniloercoli couldn't reproduce.

### For code review:
1. See this diff versus the release branch (this PR versus the release hash right before the PRE merge): https://github.com/wordpress-mobile/gutenberg-mobile/compare/a680244662528e87ccc21940c89dedc09bca7385...try/remove-android-side-from-pre
2. There should be no Android side changes since the Preformatted feature only lands for iOS in this release

### To test:

1. Use the WPAndroid side release v1.17 PR to test this and point the gutenberg-mobile submodule to this PR
2. Open a Gutenberg post
3. The editor should open normally

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
