### PR TITLE
Fix crash which occurs after deleting image or page break block

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 * [iOS] Support for Pexels image library
 * [Android] Added native fullscreen preview when clicking image from Image Block
 * [iOS] Add support for Preformatted block.
+* [Android] Fix issue when removing image/page break block crashes the app
 
 1.16.1
 ------


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/WordPress-Android/issues/10491

Gutenberg PR: https://github.com/WordPress/gutenberg/pull/18539
WPAndroid PR: https://github.com/wordpress-mobile/WordPress-Android/pull/10805

To test:
Steps to repro - Case A
- Create a new post
- Click on the empty paragraph block
- Add a Page break block
- Click on the "bin" on the Page break block
- Page break block should be deleted as expected

Steps to repro - Case B
- Create a new post
- Add a Page break block
- Click on the "bin" on the Page break block
- This time the block is removed without a crash_
- Add a Page break block
- Click on the "bin" on the Page break block
- Page break block should be deleted as expected


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.