### PR TITLE
Enable Spacer block in production

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 1.18.0
 ------
 * [iOS] Added native fullscreen preview when clicking image from Image Block
+* New block: Spacer
 
 1.17.0
 ------


### PR DESCRIPTION
This enables the `Spacer` block in production

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1587

`Gutenberg` PR -> https://github.com/WordPress/gutenberg/pull/18605

To test:

`WordPress iOS` -> https://github.com/wordpress-mobile/WordPress-iOS/pull/12970
`WordPress Android` -> https://github.com/wordpress-mobile/WordPress-Android/pull/10817

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
