### PR TITLE
Issue/1625 implement element closest

### DIFF
--- a/src/jsdom-patches.js
+++ b/src/jsdom-patches.js
@@ -149,6 +149,10 @@ Node.prototype.insertBefore = function( /* Node */ newChild, /* Node*/ refChild 
  */
 Element.prototype.matches = Element.prototype.matchesSelector;
 
+/*
+ * Implementation of Element.prototype.closest that it's missing from the jsdom-jscore fork we're using.
+ * See https://github.com/wordpress-mobile/gutenberg-mobile/issues/1625
+ */
 Element.prototype.closest = function( selector ) {
 	let el = this;
 	while ( el ) {

--- a/src/jsdom-patches.js
+++ b/src/jsdom-patches.js
@@ -161,6 +161,7 @@ Element.prototype.closest = function( selector ) {
 		}
 		el = el.parentElement;
 	}
+	return null;
 };
 
 /**

--- a/src/jsdom-patches.js
+++ b/src/jsdom-patches.js
@@ -149,6 +149,16 @@ Node.prototype.insertBefore = function( /* Node */ newChild, /* Node*/ refChild 
  */
 Element.prototype.matches = Element.prototype.matchesSelector;
 
+Element.prototype.closest = function( selector ) {
+	let el = this;
+	while ( el ) {
+		if ( el.matches( selector ) ) {
+			return el;
+		}
+		el = el.parentElement;
+	}
+};
+
 /**
  * Helper function to check if a node implements the NonDocumentTypeChildNode
  * interface


### PR DESCRIPTION
Fixes #1625

Adds to the local jsdom patches the implementation of `Element.closest()` as seen at https://github.com/jsdom/jsdom/issues/1555#issuecomment-264288212.

Even though jsdom itself has had that function added already, the jsdom-jscore fork we are using is not up-to-date to use it. Updating the fork is far from trivial so, resorting to a local patch instead.

To test:
* Android Appium tests on CI should pass

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
