### PR TITLE
Fix crash dismissing bottom-sheet on iOS after device rotation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.19.0
+------
+* [iOS] Fix crash dismissing bottom-sheet after device rotation.
+
 1.18.0
 ------
 * [iOS] Added native fullscreen preview when clicking image from Image Block


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1522

This PR updates the gutenberg ref to test https://github.com/WordPress/gutenberg/pull/18782

`gutenberg` side PR: https://github.com/WordPress/gutenberg/pull/18782

To test:
- Load the example content.
- Find the Image block with image.
- Press the image settings button.
- Rotate the device.
- Dismiss the settings sheet by pressing outside of it.
- Check that it does not crash. 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
