### PR TITLE
Improve code block style

### DIFF
--- a/src/_native.ios.scss
+++ b/src/_native.ios.scss
@@ -1,7 +1,7 @@
 /** @format */
 
 // Fonts
-$default-monospace-font: courier;
+$default-monospace-font: menlo;
 $default-regular-font: 'Noto Serif';
 $title-block-padding-top: 12;
 $title-block-padding-bottom: 12;


### PR DESCRIPTION
Fixes #368 

This PR improves the style of the code block by:
 - Change the font to Menlo size 14pt
 - Add paddings has indicated in the ticket
 - Adds a border like in the web block

![CodeDarkLight](https://user-images.githubusercontent.com/651601/69737746-d485e780-112c-11ea-887f-5463e7354fab.png)

Gutenberg PR: https://github.com/WordPress/gutenberg/pull/18785

To test:
 - Open the demo app
 - Create a new code block
 - Edit the block and see if all looks good

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
