### PR TITLE
Issue/1592 fix alignment hiding image placeholder

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.20.0
+------
+* Fix bug where image placeholders would sometimes not be shown
+
 1.19.0
 ------
 * Add support for changing Settings in List Block.


### PR DESCRIPTION
Fixes #1592 

This fixes a bug that was introduced with the addition of paragraph alignment options. In particular, the placeholder icon would not display for an aligned image block if the image could not be downloaded.

[Related gutenberg PR](https://github.com/WordPress/gutenberg/pull/18793)

To test:

* Create a draft post on web with aligned images
* Open an empty post in the app (to load the js from the metro bundler)
* Go to the list of draft posts in the app so that the newly created draft is loaded
* Turn on airplane mode
* Open the draft post
* Observe that all of the image blocks have visible placeholder images

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
