### PR TITLE
Fix/add gallery colors

### DIFF
--- a/src/_colors.scss
+++ b/src/_colors.scss
@@ -131,12 +131,16 @@ $toolbar-button-disabled: $gray-lighten-30;
 $background-dark-elevated: #2e2e2e;
 $background-dark-secondary: #1e2327;
 $blue-30: #5198d9;
-$gray-70: #3c434a;
 
-$gray-50: #646970;
-$gray-20: #a7aaad;
-$gray-10: #c3c4c7;
-$gray-90: #1d2327;
+// color-studio
+$gray-0: #f6f7f7;
 $gray-5: #dcdcde;
+$gray-10: #c3c4c7;
+$gray-20: #a7aaad;
+$gray-30: #8e9196;
+$gray-40: #787c82;
+$gray-50: #646970;
+$gray-70: #3c434a;
+$gray-90: #1d2327;
 $gray-95: #1d2327;
 $gray-100: #101517;


### PR DESCRIPTION
This PR adds gallery colors to unblock metro build, and disables gallery block temporarily (will re-enable in the main gallery PR).

Related gutenberg PR: https://github.com/WordPress/gutenberg/pull/18910

To test:

The demo app should build without error, and metro build should not fail.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
