### PR TITLE
Make sure if the textColor is changed the default text color is updated.

### DIFF
--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -446,6 +446,7 @@ class RCTAztecView: Aztec.TextView {
     override var textColor: UIColor? {
         didSet {
             typingAttributes[NSAttributedString.Key.foregroundColor] = self.textColor
+            self.defaultTextColor = self.textColor
         }
     }
 


### PR DESCRIPTION
This change make sure that if the textColor prop is set explicitly we also update the defaultTextColor is used in TextView

To test:
 - Try to change the prop style on RichText uses to something like: `style={ { color: 'red' }}`
 - See if the color is applied.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
