### PR TITLE
Update Aztec to fix CI error with xcode 10

### DIFF
--- a/react-native-aztec/ios/Cartfile
+++ b/react-native-aztec/ios/Cartfile
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.12.0"
+github "wordpress-mobile/AztecEditor-iOS" "1d0c77d01a12e4062296943e12a19f85ff1f23dd"

--- a/react-native-aztec/ios/Cartfile.resolved
+++ b/react-native-aztec/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.12.0"
+github "wordpress-mobile/AztecEditor-iOS" "1d0c77d01a12e4062296943e12a19f85ff1f23dd"


### PR DESCRIPTION
Related Aztec PR: https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1247

To test:
- Check that e2e iOS tests on Device are ✅ 
- Test dark-mode colours on iOS are correct
