### PR TITLE
Add release notes for Gallery

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 1.19.0
 ------
 * [iOS] Fix crash dismissing bottom-sheet after device rotation.
+* New block: Gallery. You can now create image galleries using WordPress Media library. Upload feature is coming soon.
 
 1.18.0
 ------


### PR DESCRIPTION
Adding release notes for [Gallery block](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1498)

To test: Check the release notes

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
