### PR TITLE
Update Getting Started documentation to shorten git commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ Note that the OS platform used by the maintainers is macOS but the tools and set
 
 * Clone the project and submodules:
 ```
-$ git clone --recurse-submodules https://github.com/wordpress-mobile/gutenberg-mobile.git
+git clone --recurse-submodules https://github.com/wordpress-mobile/gutenberg-mobile.git
 ```
 
 * Or if you already have the project cloned, initialize and update the submodules:
 ```
-$ git submodule init
-$ git submodule update
+git submodule init
+git submodule update
 ```
 
 ## Set up


### PR DESCRIPTION
Make the git commands a little easier to copy by taking out `$` from the start of the lines.

This also matches with the other commands on the page which do not start with `$`.

To test: review README.md.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
