### PR TITLE
Sass Transformer: Also look for partials

### DIFF
--- a/sass-transformer-inside-gb.js
+++ b/sass-transformer-inside-gb.js
@@ -81,7 +81,8 @@ function findVariant( name, extensions, includePaths ) {
 		// try to find the file iterating through the extensions, in order.
 		const foundExtention = extensions.find( ( extension ) => {
 			const fname = includePath + '/' + name + extension;
-			return fs.existsSync( fname );
+			const partialfname = includePath + '/_' + name + extension;
+			return fs.existsSync( fname ) || fs.existsSync( partialfname );
 		} );
 
 		if ( foundExtention ) {

--- a/sass-transformer.js
+++ b/sass-transformer.js
@@ -88,7 +88,7 @@ function findVariant( name, extensions, includePaths ) {
 		// try to find the file iterating through the extensions, in order.
 		const foundExtention = extensions.find( ( extension ) => {
 			const fname = includePath + '/' + name + extension;
-			const partialfname = includePath + "/_" + name + extension;
+			const partialfname = includePath + '/_' + name + extension;
 			return fs.existsSync( fname ) || fs.existsSync( partialfname );
 		} );
 

--- a/sass-transformer.js
+++ b/sass-transformer.js
@@ -88,7 +88,8 @@ function findVariant( name, extensions, includePaths ) {
 		// try to find the file iterating through the extensions, in order.
 		const foundExtention = extensions.find( ( extension ) => {
 			const fname = includePath + '/' + name + extension;
-			return fs.existsSync( fname );
+			const partialfname = includePath + "/_" + name + extension;
+			return fs.existsSync( fname ) || fs.existsSync( partialfname );
 		} );
 
 		if ( foundExtention ) {


### PR DESCRIPTION
Add support for [SASS partials](https://sass-lang.com/guide), as is already present [upstream](https://github.com/kristerkari/react-native-sass-transformer/blob/52884dd59582856fa17e2b2e8ca9efc37d412387/index.js#L41-L42).

This should fix the issue introduced by https://github.com/WordPress/gutenberg/pull/19159, and discussed there.

/cc @hypest 

To test:

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
