### PR TITLE
[FIX] Rich Text loop when autocompleting text on iOS

### DIFF
--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -669,6 +669,7 @@ extension RCTAztecView: UITextViewDelegate {
     }
 
     func textViewDidEndEditing(_ textView: UITextView) {
-        onBlur?([:])
+        let text = packForRN(cleanHTML(), withName: "text")
+        onBlur?(text)
     }
 }

--- a/react-native-aztec/src/AztecView.js
+++ b/react-native-aztec/src/AztecView.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactNative, {requireNativeComponent, TextViewPropTypes, UIManager, ColorPropType, TouchableWithoutFeedback, Platform} from 'react-native';
+import TextInputState from 'react-native/lib/TextInputState';
 
 const AztecManager = UIManager.getViewManagerConfig('RCTAztecView');
 
@@ -34,6 +35,14 @@ class AztecView extends React.Component {
     ...TextViewPropTypes, // include the default view properties
   }
 
+  componentDidMount() {
+    TextInputState.registerInput(ReactNative.findNodeHandle(this))
+  }
+
+  componentWillUnmount() {
+    TextInputState.unregisterInput(ReactNative.findNodeHandle(this))
+  }
+
   dispatch(command, params) {
     params = params || [];
     UIManager.dispatchViewManagerCommand(
@@ -57,6 +66,10 @@ class AztecView extends React.Component {
   }
 
   _onEnter = (event) => {
+    if (!this.isFocused()) {	
+      return;	
+    }
+
     if (!this.props.onEnter) {
       return;
     }
@@ -87,18 +100,16 @@ class AztecView extends React.Component {
   }
 
   _onFocus = (event) => {
-    this.focused = true;
     const { onFocus } = this.props;
-
     if (onFocus) {
       onFocus(event);
     }
   }
   
   _onBlur = (event) => {
-    this.focused = false;
     this.selectionEndCaretY = null;
     const { onBlur } = this.props;
+    TextInputState.blurTextInput(ReactNative.findNodeHandle(this));
 
     if (onBlur) {
       onBlur(event);
@@ -106,13 +117,13 @@ class AztecView extends React.Component {
   }
 
   _onSelectionChange = (event) => {
-    if (this.focused && this.props.onSelectionChange) {
+    if (this.props.onSelectionChange) {
       const { selectionStart, selectionEnd, text } = event.nativeEvent;
       const { onSelectionChange } = this.props;
       onSelectionChange( selectionStart, selectionEnd, text, event );
     }
 
-    if (this.focused && this.props.onCaretVerticalPositionChange && 
+    if (this.props.onCaretVerticalPositionChange && 
       this.selectionEndCaretY != event.nativeEvent.selectionEndCaretY) {
         const caretY = event.nativeEvent.selectionEndCaretY;
         this.props.onCaretVerticalPositionChange( event.target, caretY, this.selectionEndCaretY );
@@ -121,31 +132,23 @@ class AztecView extends React.Component {
   }
 
   blur = () => {
-    if (this.focused) {
-      if (Platform.OS === "ios") {
-        UIManager.blur(ReactNative.findNodeHandle(this))
-      } else {
-        this.dispatch(UIManager.getViewManagerConfig('AndroidTextInput').Commands.blurTextInput)
-      }
-    }
-    this.focused = false;
+    TextInputState.blurTextInput(ReactNative.findNodeHandle(this));
   }
 
   focus = () => {
-    if (!this.focused) {
-      if (Platform.OS === "ios") {
-        UIManager.focus(ReactNative.findNodeHandle(this))
-      } else {
-        this.dispatch(UIManager.getViewManagerConfig('AndroidTextInput').Commands.focusTextInput)
-      }
-    }
-    this.focused = true;
+    TextInputState.focusTextInput(ReactNative.findNodeHandle(this));
   }
 
-  isFocused = () => this.focused
+  isFocused = () => {
+    const focusedField = TextInputState.currentlyFocusedField();	
+    return focusedField && ( focusedField === ReactNative.findNodeHandle(this) );
+  }
 
   _onPress = (event) => {
-		this._onFocus(event); // Check if there are listeners set on the focus event
+    if( !this.isFocused() ) {
+      this.focus();
+      this._onFocus(event); // Check if there are listeners set on the focus event
+    }
   }
 
   _onAztecFocus = (event) => {

--- a/react-native-aztec/src/AztecView.js
+++ b/react-native-aztec/src/AztecView.js
@@ -7,7 +7,6 @@ const AztecManager = UIManager.getViewManagerConfig('RCTAztecView');
 
 class AztecView extends React.Component {
   selectionEndCaretY: number;
-  focused: Boolean = false;
 
   static propTypes = {
     activeFormats: PropTypes.array,

--- a/react-native-aztec/src/AztecView.js
+++ b/react-native-aztec/src/AztecView.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactNative, {requireNativeComponent, TextViewPropTypes, UIManager, ColorPropType, TouchableWithoutFeedback, Platform} from 'react-native';
-import TextInputState from 'react-native/lib/TextInputState';
 
 const AztecManager = UIManager.getViewManagerConfig('RCTAztecView');
 
@@ -107,14 +106,14 @@ class AztecView extends React.Component {
   }
 
   _onSelectionChange = (event) => {
-    if ( this.focused && this.props.onSelectionChange ) {
+    if (this.focused && this.props.onSelectionChange) {
       const { selectionStart, selectionEnd, text } = event.nativeEvent;
       const { onSelectionChange } = this.props;
       onSelectionChange( selectionStart, selectionEnd, text, event );
     }
 
-    if ( this.focused && this.props.onCaretVerticalPositionChange && 
-      this.selectionEndCaretY != event.nativeEvent.selectionEndCaretY ) {
+    if (this.focused && this.props.onCaretVerticalPositionChange && 
+      this.selectionEndCaretY != event.nativeEvent.selectionEndCaretY) {
         const caretY = event.nativeEvent.selectionEndCaretY;
         this.props.onCaretVerticalPositionChange( event.target, caretY, this.selectionEndCaretY );
         this.selectionEndCaretY = caretY;
@@ -122,30 +121,28 @@ class AztecView extends React.Component {
   }
 
   blur = () => {
-    if ( this.focused ) {
+    if (this.focused) {
       if (Platform.OS === "ios") {
         UIManager.blur(ReactNative.findNodeHandle(this))
       } else {
-        this.dispatch(UIManager.getViewManagerConfig('AndroidTextInput').Commands.focusTextInput)
+        this.dispatch(UIManager.getViewManagerConfig('AndroidTextInput').Commands.blurTextInput)
       }
     }
     this.focused = false;
   }
 
   focus = () => {
-    if ( !this.focused ) {
+    if (!this.focused) {
       if (Platform.OS === "ios") {
         UIManager.focus(ReactNative.findNodeHandle(this))
       } else {
-        this.dispatch(UIManager.getViewManagerConfig('AndroidTextInput').Commands.blurTextInput)
+        this.dispatch(UIManager.getViewManagerConfig('AndroidTextInput').Commands.focusTextInput)
       }
     }
     this.focused = true;
   }
 
-  isFocused = () => {
-    return this.focused
-  }
+  isFocused = () => this.focused
 
   _onPress = (event) => {
 		this._onFocus(event); // Check if there are listeners set on the focus event

--- a/react-native-aztec/src/AztecView.js
+++ b/react-native-aztec/src/AztecView.js
@@ -34,14 +34,6 @@ class AztecView extends React.Component {
     ...TextViewPropTypes, // include the default view properties
   }
 
-  componentDidMount() {
-    TextInputState.registerInput(ReactNative.findNodeHandle(this))
-  }
-
-  componentWillUnmount() {
-    TextInputState.unregisterInput(ReactNative.findNodeHandle(this))
-  }
-
   dispatch(command, params) {
     params = params || [];
     UIManager.dispatchViewManagerCommand(

--- a/react-native-aztec/src/AztecView.js
+++ b/react-native-aztec/src/AztecView.js
@@ -66,8 +66,8 @@ class AztecView extends React.Component {
   }
 
   _onEnter = (event) => {
-    if (!this.isFocused()) {	
-      return;	
+    if (!this.isFocused()) {
+      return;
     }
 
     if (!this.props.onEnter) {
@@ -100,31 +100,35 @@ class AztecView extends React.Component {
   }
 
   _onFocus = (event) => {
-    const { onFocus } = this.props;
-    if (onFocus) {
-      onFocus(event);
+    if (!this.props.onFocus) {
+      return;
     }
+
+    const { onFocus } = this.props;
+    onFocus(event);
   }
   
   _onBlur = (event) => {
     this.selectionEndCaretY = null;
-    const { onBlur } = this.props;
     TextInputState.blurTextInput(ReactNative.findNodeHandle(this));
 
-    if (onBlur) {
-      onBlur(event);
+    if (!this.props.onBlur) {
+      return;
     }
+
+    const { onBlur } = this.props;
+    onBlur(event);
   }
 
   _onSelectionChange = (event) => {
-    if (this.props.onSelectionChange) {
+    if ( this.props.onSelectionChange ) {
       const { selectionStart, selectionEnd, text } = event.nativeEvent;
       const { onSelectionChange } = this.props;
       onSelectionChange( selectionStart, selectionEnd, text, event );
     }
 
-    if (this.props.onCaretVerticalPositionChange && 
-      this.selectionEndCaretY != event.nativeEvent.selectionEndCaretY) {
+    if ( this.props.onCaretVerticalPositionChange && 
+      this.selectionEndCaretY != event.nativeEvent.selectionEndCaretY ) {
         const caretY = event.nativeEvent.selectionEndCaretY;
         this.props.onCaretVerticalPositionChange( event.target, caretY, this.selectionEndCaretY );
         this.selectionEndCaretY = caretY;
@@ -140,15 +144,15 @@ class AztecView extends React.Component {
   }
 
   isFocused = () => {
-    const focusedField = TextInputState.currentlyFocusedField();	
+    const focusedField = TextInputState.currentlyFocusedField();
     return focusedField && ( focusedField === ReactNative.findNodeHandle(this) );
   }
 
   _onPress = (event) => {
-    if( !this.isFocused() ) {
-      this.focus();
-      this._onFocus(event); // Check if there are listeners set on the focus event
-    }
+	if ( ! this.isFocused() ) {
+		this.focus(); // Call to move the focus in RN way (TextInputState)
+		this._onFocus(event); // Check if there are listeners set on the focus event
+	}
   }
 
   _onAztecFocus = (event) => {


### PR DESCRIPTION
Fixes #
Gutenberg PR: https://github.com/WordPress/gutenberg/pull/19240
Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1696

In this PR I created a local variable for focus state instead of using `TextInputState`, thanks to that we do not call `focus()` in `onFocus` which was a bit weird. I also pass the latest native value to `onBlur` event to update JS value if that is not correct.

PR submission checklist:
- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
