### PR TITLE
Libs forks need to use node_modules when building locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
   "dependencies": {
     "@babel/runtime": "^7.3.1",
     "@react-native-community/cli": "^1.5.2",
-    "@react-native-community/slider": "git+https://github.com/wordpress-mobile/react-native-slider.git#e20f268e61327321a5bbd66afc5238388d65f2a4",
+    "@react-native-community/slider": "git+https://github.com/wordpress-mobile/react-native-slider.git#1ac7533fad0eb7f091d1ea501010b113efa2e5f8",
     "classnames": "^2.2.5",
     "dom-react": "^2.2.1",
     "domutils": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "react-native-recyclerview-list": "git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#eadaa2f62d2f488d4dc80f9148e52b62047297ab",
     "react-native-safe-area": "^0.5.0",
     "react-native-svg": "git+https://github.com/wordpress-mobile/react-native-svg.git#a3f32b1af83e0100d10516fe58ba8a0096362b62",
-    "react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#3a0e2fa6fc6bf1fe1a54adb2dbf94545b28c2bc4",
+    "react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#a0bb36a1ad684c2c1ba591c44f7e4d89502bf2d0",
     "react-redux": "^5.0.7",
     "redux": "^3.7.2",
     "redux-multi": "^0.1.12",

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "react-native-modal": "^6.5.0",
     "react-native-recyclerview-list": "git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#eadaa2f62d2f488d4dc80f9148e52b62047297ab",
     "react-native-safe-area": "^0.5.0",
-    "react-native-svg": "git+https://github.com/wordpress-mobile/react-native-svg.git#f16e9adae71c6cf3158f2356cf95fff5c2075e0f",
+    "react-native-svg": "git+https://github.com/wordpress-mobile/react-native-svg.git#a3f32b1af83e0100d10516fe58ba8a0096362b62",
     "react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#3a0e2fa6fc6bf1fe1a54adb2dbf94545b28c2bc4",
     "react-redux": "^5.0.7",
     "redux": "^3.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1913,9 +1913,9 @@
     xcode "^2.0.0"
     xmldoc "^0.4.0"
 
-"@react-native-community/slider@git+https://github.com/wordpress-mobile/react-native-slider.git#e20f268e61327321a5bbd66afc5238388d65f2a4":
+"@react-native-community/slider@git+https://github.com/wordpress-mobile/react-native-slider.git#1ac7533fad0eb7f091d1ea501010b113efa2e5f8":
   version "2.0.7"
-  resolved "git+https://github.com/wordpress-mobile/react-native-slider.git#e20f268e61327321a5bbd66afc5238388d65f2a4"
+  resolved "git+https://github.com/wordpress-mobile/react-native-slider.git#1ac7533fad0eb7f091d1ea501010b113efa2e5f8"
 
 "@tannin/compile@^1.0.3":
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11012,9 +11012,9 @@ react-native-sass-transformer@^1.1.1:
     css-to-react-native-transform "^1.8.1"
     semver "^5.6.0"
 
-"react-native-svg@git+https://github.com/wordpress-mobile/react-native-svg.git#f16e9adae71c6cf3158f2356cf95fff5c2075e0f":
+"react-native-svg@git+https://github.com/wordpress-mobile/react-native-svg.git#a3f32b1af83e0100d10516fe58ba8a0096362b62":
   version "9.3.3-gb"
-  resolved "git+https://github.com/wordpress-mobile/react-native-svg.git#f16e9adae71c6cf3158f2356cf95fff5c2075e0f"
+  resolved "git+https://github.com/wordpress-mobile/react-native-svg.git#a3f32b1af83e0100d10516fe58ba8a0096362b62"
 
 "react-native-video@git+https://github.com/wordpress-mobile/react-native-video.git#3a0e2fa6fc6bf1fe1a54adb2dbf94545b28c2bc4":
   version "4.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11016,9 +11016,9 @@ react-native-sass-transformer@^1.1.1:
   version "9.3.3-gb"
   resolved "git+https://github.com/wordpress-mobile/react-native-svg.git#a3f32b1af83e0100d10516fe58ba8a0096362b62"
 
-"react-native-video@git+https://github.com/wordpress-mobile/react-native-video.git#3a0e2fa6fc6bf1fe1a54adb2dbf94545b28c2bc4":
+"react-native-video@git+https://github.com/wordpress-mobile/react-native-video.git#a0bb36a1ad684c2c1ba591c44f7e4d89502bf2d0":
   version "4.4.1"
-  resolved "git+https://github.com/wordpress-mobile/react-native-video.git#3a0e2fa6fc6bf1fe1a54adb2dbf94545b28c2bc4"
+  resolved "git+https://github.com/wordpress-mobile/react-native-video.git#a0bb36a1ad684c2c1ba591c44f7e4d89502bf2d0"
   dependencies:
     keymirror "^0.1.1"
     prop-types "^15.5.10"


### PR DESCRIPTION
Fixes #1703, #1705 

On Android, some of the npm libraries we're forking are using the Maven mirror of React Native both when building them as standalone libs (on JitPack) and when built locally as normal npm deps. That wouldn't be a problem per se but, the RN version referenced in the local builds is the "latest' ([see this for example](https://github.com/wordpress-mobile/react-native-svg/blob/f155fbdd309f5e28bdbb326b819c5bf5af6f4cc9/android/build.gradle#L49)) so, when a newer version becomes available in the maven mirror it gets picked up.

We recently made available in the maven mirror some RN versions that are unfortunately incompatible with the versions expected by the forks, leading to crashes.

The versions used in local builds need to come from the local node_modules folder, and this PR brings in updates to the forks to do just that.

Related PRs:
`react-native-svg`:  https://github.com/wordpress-mobile/react-native-svg/pull/8
`react-native-video`:  https://github.com/wordpress-mobile/react-native-video/pull/2
`react-native-slider`: https://github.com/wordpress-mobile/react-native-slider/pull/1

To test:

1. Demo app should work as normal, including showing icons and videos

2. Pointing WPAndroid's gutenberg-mobile submodule to this PR should also work for all build modes and variants

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
