### PR TITLE
Release v1.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gutenberg-mobile",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "private": true,
   "config": {
     "jsfiles": "./*.js src/*.js src/**/*.js src/**/**/*.js",

--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = '807062ab67edb46a777883aedc107fc80bb13659'
+        aztecVersion = 'v1.3.37'
     }
 
     repositories {

--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = 'v1.3.36'
+        aztecVersion = '807062ab67edb46a777883aedc107fc80bb13659'
     }
 
     repositories {


### PR DESCRIPTION
This PR points to changes in Aztec. These changes don't touch any existing interfaces and only add new functionality so they shouldn't break anything.
Aztec changes - https://github.com/wordpress-mobile/AztecEditor-Android/pull/887/commits/807062ab67edb46a777883aedc107fc80bb13659

We only want to merge this once the Aztec version is released. 
Did I update the GB version correctly @hypest ?

**Related PRs**
- Add content watcher for all the changes to AztecText - https://github.com/wordpress-mobile/AztecEditor-Android/pull/887
- WPAndroid PR - https://github.com/wordpress-mobile/WordPress-Android/pull/11065

**Test Plan** 
- There is nothing to tests since this is only a new interface not used anywhere in the code yet

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
