### PR TITLE
Use merged fork commits after the 1706 work

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "react-native-modal": "^6.5.0",
     "react-native-recyclerview-list": "git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#eadaa2f62d2f488d4dc80f9148e52b62047297ab",
     "react-native-safe-area": "^0.5.0",
-    "react-native-svg": "git+https://github.com/wordpress-mobile/react-native-svg.git#a3f32b1af83e0100d10516fe58ba8a0096362b62",
+    "react-native-svg": "git+https://github.com/wordpress-mobile/react-native-svg.git#d466eb06a38e6f553f08666f0ca784d47fd6f724",
     "react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#a0bb36a1ad684c2c1ba591c44f7e4d89502bf2d0",
     "react-redux": "^5.0.7",
     "redux": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
   "dependencies": {
     "@babel/runtime": "^7.3.1",
     "@react-native-community/cli": "^1.5.2",
-    "@react-native-community/slider": "git+https://github.com/wordpress-mobile/react-native-slider.git#1ac7533fad0eb7f091d1ea501010b113efa2e5f8",
+    "@react-native-community/slider": "git+https://github.com/wordpress-mobile/react-native-slider.git#f5d8685ffa389c78a8713162b1e2821067ad214f",
     "classnames": "^2.2.5",
     "dom-react": "^2.2.1",
     "domutils": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "react-native-recyclerview-list": "git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#eadaa2f62d2f488d4dc80f9148e52b62047297ab",
     "react-native-safe-area": "^0.5.0",
     "react-native-svg": "git+https://github.com/wordpress-mobile/react-native-svg.git#d466eb06a38e6f553f08666f0ca784d47fd6f724",
-    "react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#a0bb36a1ad684c2c1ba591c44f7e4d89502bf2d0",
+    "react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#6c75579a95a6ddb3762b6e11ef004c2cd0bed537",
     "react-redux": "^5.0.7",
     "redux": "^3.7.2",
     "redux-multi": "^0.1.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1913,9 +1913,9 @@
     xcode "^2.0.0"
     xmldoc "^0.4.0"
 
-"@react-native-community/slider@git+https://github.com/wordpress-mobile/react-native-slider.git#1ac7533fad0eb7f091d1ea501010b113efa2e5f8":
+"@react-native-community/slider@git+https://github.com/wordpress-mobile/react-native-slider.git#f5d8685ffa389c78a8713162b1e2821067ad214f":
   version "2.0.7"
-  resolved "git+https://github.com/wordpress-mobile/react-native-slider.git#1ac7533fad0eb7f091d1ea501010b113efa2e5f8"
+  resolved "git+https://github.com/wordpress-mobile/react-native-slider.git#f5d8685ffa389c78a8713162b1e2821067ad214f"
 
 "@tannin/compile@^1.0.3":
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11016,9 +11016,9 @@ react-native-sass-transformer@^1.1.1:
   version "9.3.3-gb"
   resolved "git+https://github.com/wordpress-mobile/react-native-svg.git#d466eb06a38e6f553f08666f0ca784d47fd6f724"
 
-"react-native-video@git+https://github.com/wordpress-mobile/react-native-video.git#a0bb36a1ad684c2c1ba591c44f7e4d89502bf2d0":
+"react-native-video@git+https://github.com/wordpress-mobile/react-native-video.git#6c75579a95a6ddb3762b6e11ef004c2cd0bed537":
   version "4.4.1"
-  resolved "git+https://github.com/wordpress-mobile/react-native-video.git#a0bb36a1ad684c2c1ba591c44f7e4d89502bf2d0"
+  resolved "git+https://github.com/wordpress-mobile/react-native-video.git#6c75579a95a6ddb3762b6e11ef004c2cd0bed537"
   dependencies:
     keymirror "^0.1.1"
     prop-types "^15.5.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11012,9 +11012,9 @@ react-native-sass-transformer@^1.1.1:
     css-to-react-native-transform "^1.8.1"
     semver "^5.6.0"
 
-"react-native-svg@git+https://github.com/wordpress-mobile/react-native-svg.git#a3f32b1af83e0100d10516fe58ba8a0096362b62":
+"react-native-svg@git+https://github.com/wordpress-mobile/react-native-svg.git#d466eb06a38e6f553f08666f0ca784d47fd6f724":
   version "9.3.3-gb"
-  resolved "git+https://github.com/wordpress-mobile/react-native-svg.git#a3f32b1af83e0100d10516fe58ba8a0096362b62"
+  resolved "git+https://github.com/wordpress-mobile/react-native-svg.git#d466eb06a38e6f553f08666f0ca784d47fd6f724"
 
 "react-native-video@git+https://github.com/wordpress-mobile/react-native-video.git#a0bb36a1ad684c2c1ba591c44f7e4d89502bf2d0":
   version "4.4.1"


### PR DESCRIPTION
Follow up PR to #1706, to point to the merged PRs of the forked libraries.

To test:

1. Demo app should work as normal, including showing icons and videos
2. Pointing WPAndroid's gutenberg-mobile submodule to this PR should also work for all build modes and variants

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
