### PR TITLE
Scroll down to reveal the Trash buttons

### DIFF
--- a/__device-tests__/gutenberg-editor-block-insertion.test.js
+++ b/__device-tests__/gutenberg-editor-block-insertion.test.js
@@ -12,6 +12,7 @@ import {
 	stopDriver,
 	isAndroid,
 	swipeDown,
+	swipeUp,
 	clickMiddleOfElement,
 } from './helpers/utils';
 import testData from './helpers/test-data';
@@ -68,14 +69,15 @@ describe( 'Gutenberg Editor tests for Block insertion', () => {
 
 		// Workaround for now since deleting the first element causes a crash on CI for Android
 		if ( isAndroid() ) {
-			paragraphBlockElement = await editorPage.getParagraphBlockAtPosition( 3, { autoscroll: true } );
-			await paragraphBlockElement.click();
-			await editorPage.removeParagraphBlockAtPosition( 3 );
-			for ( let i = 3; i > 0; i-- ) {
+			for ( let i = 4; i > 0; i-- ) {
 				// wait for accessibility ids to update
 				await driver.sleep( 1000 );
 				paragraphBlockElement = await editorPage.getParagraphBlockAtPosition( i, { autoscroll: true } );
 				await paragraphBlockElement.click();
+
+				await driver.sleep( 500 ); // wait for the click to finish reliably
+				await swipeUp( driver ); // swipe up to bring the Trash icon into view
+
 				await editorPage.removeParagraphBlockAtPosition( i );
 			}
 		} else {

--- a/__device-tests__/gutenberg-editor-paragraph.test.js
+++ b/__device-tests__/gutenberg-editor-paragraph.test.js
@@ -13,6 +13,7 @@ import {
 	clickBeginningOfElement,
 	stopDriver,
 	isAndroid,
+	swipeUp,
 } from './helpers/utils';
 import testData from './helpers/test-data';
 
@@ -115,6 +116,7 @@ describe( 'Gutenberg Editor tests for Paragraph Block', () => {
 		await editorPage.sendTextToParagraphBlockAtPosition( 1, testData.longText );
 
 		for ( let i = 3; i > 0; i-- ) {
+			await swipeUp( driver ); // swipe up to bring the Trash icon into view
 			await editorPage.removeParagraphBlockAtPosition( i );
 		}
 	} );

--- a/__device-tests__/gutenberg-editor-rotation.test.js
+++ b/__device-tests__/gutenberg-editor-rotation.test.js
@@ -51,6 +51,9 @@ describe( 'Gutenberg Editor tests', () => {
 
 		await editorPage.sendTextToParagraphBlock( paragraphBlockElement, testData.mediumText );
 
+		// wait for text sending to settle before rotating
+		await driver.sleep( 1000 );
+
 		await toggleOrientation( driver );
 		// On Android the keyboard hides the add block button, let's hide it after rotation
 		if ( isAndroid() ) {
@@ -69,6 +72,10 @@ describe( 'Gutenberg Editor tests', () => {
 			paragraphBlockElement = await editorPage.getParagraphBlockAtPosition( 2 );
 		}
 		await editorPage.sendTextToParagraphBlock( paragraphBlockElement, testData.mediumText );
+
+		// wait for text sending to settle before rotating
+		await driver.sleep( 1000 );
+
 		await toggleOrientation( driver );
 
 		await editorPage.verifyHtmlContent( testData.deviceRotationHtml );

--- a/__device-tests__/gutenberg-editor-rotation.test.js
+++ b/__device-tests__/gutenberg-editor-rotation.test.js
@@ -52,7 +52,7 @@ describe( 'Gutenberg Editor tests', () => {
 		await editorPage.sendTextToParagraphBlock( paragraphBlockElement, testData.mediumText );
 
 		// wait for text sending to settle before rotating
-		await driver.sleep( 1000 );
+		await driver.sleep( 5000 );
 
 		await toggleOrientation( driver );
 		// On Android the keyboard hides the add block button, let's hide it after rotation
@@ -74,7 +74,7 @@ describe( 'Gutenberg Editor tests', () => {
 		await editorPage.sendTextToParagraphBlock( paragraphBlockElement, testData.mediumText );
 
 		// wait for text sending to settle before rotating
-		await driver.sleep( 1000 );
+		await driver.sleep( 5000 );
 
 		await toggleOrientation( driver );
 

--- a/__device-tests__/gutenberg-editor-rotation.test.js
+++ b/__device-tests__/gutenberg-editor-rotation.test.js
@@ -49,7 +49,7 @@ describe( 'Gutenberg Editor tests', () => {
 			await paragraphBlockElement.click();
 		}
 
-		await editorPage.sendTextToParagraphBlock( paragraphBlockElement, testData.mediumText );
+		await editorPage.sendTextToParagraphBlock( paragraphBlockElement, testData.shortText );
 
 		// wait for text sending to settle before rotating
 		await driver.sleep( 5000 );
@@ -71,7 +71,7 @@ describe( 'Gutenberg Editor tests', () => {
 			await driver.hideDeviceKeyboard();
 			paragraphBlockElement = await editorPage.getParagraphBlockAtPosition( 2 );
 		}
-		await editorPage.sendTextToParagraphBlock( paragraphBlockElement, testData.mediumText );
+		await editorPage.sendTextToParagraphBlock( paragraphBlockElement, testData.shortText );
 
 		// wait for text sending to settle before rotating
 		await driver.sleep( 5000 );

--- a/__device-tests__/helpers/utils.js
+++ b/__device-tests__/helpers/utils.js
@@ -170,7 +170,7 @@ const typeString = async ( driver: wd.PromiseChainWebdriver, element: wd.Promise
 		const paragraphs = str.split( '\n' );
 
 		for ( let i = 0; i < paragraphs.length; i++ ) {
-			const paragraph = paragraphs[ i ];
+			const paragraph = paragraphs[ i ].replace( /[ ]/g, '%s' );
 			if ( paragraph in strToKeycode ) {
 				await driver.pressKeycode( strToKeycode[ paragraph ] );
 			} else {

--- a/__device-tests__/helpers/utils.js
+++ b/__device-tests__/helpers/utils.js
@@ -175,7 +175,7 @@ const typeString = async ( driver: wd.PromiseChainWebdriver, element: wd.Promise
 				await driver.pressKeycode( strToKeycode[ paragraph ] );
 			} else {
 				// Execute with adb shell input <text> since normal type auto clears field on Android
-				await driver.execute( 'mobile: shell', { command: 'input', args: [ 'keyboard', 'text', paragraph ] } );
+				await driver.execute( 'mobile: shell', { command: 'input', args: [ 'text', paragraph ] } );
 			}
 			if ( i !== paragraphs.length - 1 ) {
 				await driver.pressKeycode( strToKeycode[ '\n' ] );

--- a/__device-tests__/helpers/utils.js
+++ b/__device-tests__/helpers/utils.js
@@ -170,7 +170,7 @@ const typeString = async ( driver: wd.PromiseChainWebdriver, element: wd.Promise
 		const paragraphs = str.split( '\n' );
 
 		for ( let i = 0; i < paragraphs.length; i++ ) {
-			const paragraph = paragraphs[ i ].replace( /[ ]/g, '%s' );
+			const paragraph = paragraphs[ i ];
 			if ( paragraph in strToKeycode ) {
 				await driver.pressKeycode( strToKeycode[ paragraph ] );
 			} else {

--- a/__device-tests__/helpers/utils.js
+++ b/__device-tests__/helpers/utils.js
@@ -175,7 +175,7 @@ const typeString = async ( driver: wd.PromiseChainWebdriver, element: wd.Promise
 				await driver.pressKeycode( strToKeycode[ paragraph ] );
 			} else {
 				// Execute with adb shell input <text> since normal type auto clears field on Android
-				await driver.execute( 'mobile: shell', { command: 'input', args: [ 'text', paragraph ] } );
+				await driver.execute( 'mobile: shell', { command: 'input', args: [ 'keyboard', 'text', paragraph ] } );
 			}
 			if ( i !== paragraphs.length - 1 ) {
 				await driver.pressKeycode( strToKeycode[ '\n' ] );


### PR DESCRIPTION
Tries to fix some of the flakiness of the e2e tests by scrolling the content to reveal the Trash button.

Another detail is with the `should be able to insert block into post` test, removed the special treatment (removal) of one of blocks on Android since now with the scroll-to-reveal-trash-icon the dedicated removal is not needed.

Tested locally and the Appium tests are green on my Pixel 2 XL, Android 9.

To test:

1. CI should be green

2. Locally running `yarn test:e2e:android:local` and `yarn  test:e2e:ios:local` should be green

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
