### PR TITLE
Brings back gb master to normal

### DIFF
--- a/symlinked-packages/@wordpress/keyboard-shortcuts
+++ b/symlinked-packages/@wordpress/keyboard-shortcuts
@@ -1,1 +1,0 @@
-/Users/markosavic/Documents/Development/Automattic/gutenberg-mobile/gutenberg/packages/keyboard-shortcuts

--- a/symlinked-packages/@wordpress/keyboard-shortcuts
+++ b/symlinked-packages/@wordpress/keyboard-shortcuts
@@ -1,0 +1,1 @@
+../../gutenberg/packages/keyboard-shortcuts/

--- a/symlinked-packages/@wordpress/keyboard-shortcuts
+++ b/symlinked-packages/@wordpress/keyboard-shortcuts
@@ -1,1 +1,1 @@
-../../gutenberg/packages/keyboard-shortcuts/
+../../gutenberg/packages/keyboard-shortcuts/src

--- a/symlinked-packages/@wordpress/keyboard-shortcuts
+++ b/symlinked-packages/@wordpress/keyboard-shortcuts
@@ -1,0 +1,1 @@
+/Users/markosavic/Documents/Development/Automattic/gutenberg-mobile/gutenberg/packages/keyboard-shortcuts


### PR DESCRIPTION
Fixes: Brings back gb master to normal

To test: 
Follow instructions on gb PR: https://github.com/WordPress/gutenberg/pull/19323

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
