### PR TITLE
Move DependencyGraph.js so the original file is not left over after `yarn bundle`

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "start:debug": "node --inspect-brk node_modules/.bin/react-native start",
     "start:inside-gb:debug": "node --inspect-brk node_modules/.bin/react-native start:inside-gb",
     "patch-metro-no-file-watch": "cp node_modules/metro/src/node-haste/DependencyGraph.js ./ && cp DependencyGraph.js.patched node_modules/metro/src/node-haste/DependencyGraph.js",
-    "un-patch-metro-no-file-watch": "cp ./DependencyGraph.js node_modules/metro/src/node-haste/DependencyGraph.js",
+    "un-patch-metro-no-file-watch": "mv ./DependencyGraph.js node_modules/metro/src/node-haste/DependencyGraph.js",
     "prebundle": "yarn i18n-cache:force",
     "prebundle:android": "yarn patch-metro-no-file-watch",
     "postbundle:android": "yarn un-patch-metro-no-file-watch",


### PR DESCRIPTION
This PR insures that `DependencyGraph.js` is not left in the root directory after running `yarn bundle`

### Description

Running `yarn bundle` patches metro to not watch files while bundling ([original PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/873)). It does this by copying a patched `DependencyGraph.js` file into the node_modules folder before bundling that disables watching. Then after bundling is finished it copies the original `DependencyGraph.js` file back into `node_modules`, but it (currently) leaves that file at the root of the directory. 

This PR uses `mv` instead of `cp` when restoring that `DependencyGraph.js` back to the `node_modules` folder. As a result, after running `yarn bundle` there is no longer a leftover `DependencyGraph.js` file in the root directory.

### To Test

1. Run `yarn clean:install` 
2. grab a cup of coffee
3. Run `yarn bundle` 
4. Finish the cup of coffee and grab a fresh cup
5. Verify that both:
    1. `yarn bundle` completed successfully; and
    2. There is no `DependencyGraph.js` file in the root folder after the command completes

Once this PR is merged we can remove the references to deleting `DependencyGraph.js` from our Release Checklist.

### PR submission checklist

- [X] I have considered adding unit tests where possible.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
