### PR TITLE
Fix - Media Text: media acts like video even if I upload jpg

### DIFF
--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/Media.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/Media.java
@@ -29,12 +29,12 @@ public class Media implements RNMedia {
     public static Media createRNMediaUsingMimeType(final int id, final String url, @NonNull final String mimeType) {
         String type;
 
-        if (mimeType.startsWith(MediaType.IMAGE.name().toLowerCase(Locale.ENGLISH))) {
-            type =  MediaType.IMAGE.name().toLowerCase(Locale.ENGLISH);
-        } else if (mimeType.startsWith(MediaType.VIDEO.name().toLowerCase(Locale.ENGLISH))) {
-            type =  MediaType.VIDEO.name().toLowerCase(Locale.ENGLISH);
+        if (mimeType.startsWith(MediaType.IMAGE.name().toLowerCase(Locale.ROOT))) {
+            type =  MediaType.IMAGE.name().toLowerCase(Locale.ROOT);
+        } else if (mimeType.startsWith(MediaType.VIDEO.name().toLowerCase(Locale.ROOT))) {
+            type =  MediaType.VIDEO.name().toLowerCase(Locale.ROOT);
         } else {
-            type = MediaType.OTHER.name().toLowerCase(Locale.ENGLISH);
+            type = MediaType.OTHER.name().toLowerCase(Locale.ROOT);
         }
 
         return new Media(id, url, type);

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/Media.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/Media.java
@@ -7,6 +7,8 @@ import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
 
+import java.util.Locale;
+
 public class Media implements RNMedia {
     private int mId;
     private String mUrl;
@@ -27,12 +29,12 @@ public class Media implements RNMedia {
     public static Media createRNMediaUsingMimeType(final int id, final String url, @NonNull final String mimeType) {
         String type;
 
-        if (mimeType.startsWith(MediaType.IMAGE.name().toLowerCase())) {
-            type =  MediaType.IMAGE.name().toLowerCase();
-        } else if (mimeType.startsWith(MediaType.VIDEO.name().toLowerCase())) {
-            type =  MediaType.VIDEO.name().toLowerCase();
+        if (mimeType.startsWith(MediaType.IMAGE.name().toLowerCase(Locale.ENGLISH))) {
+            type =  MediaType.IMAGE.name().toLowerCase(Locale.ENGLISH);
+        } else if (mimeType.startsWith(MediaType.VIDEO.name().toLowerCase(Locale.ENGLISH))) {
+            type =  MediaType.VIDEO.name().toLowerCase(Locale.ENGLISH);
         } else {
-            type = MediaType.OTHER.name().toLowerCase();
+            type = MediaType.OTHER.name().toLowerCase(Locale.ENGLISH);
         }
 
         return new Media(id, url, type);


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1753

Root cause analysis can be found [here](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1753#issuecomment-571550043).

To test:

Tested with the steps:

Set locale to Turkish

- [x] Upload image with media-text
- [x] Upload video with media-text
- [x] Upload image with image block
- [x] Upload video with video block

Set locale to English

- [x] Upload image with media-text
- [x] Upload video with media-text
- [x] Upload image with image block
- [x] Upload video with video block

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
