### PR TITLE
Force the react-native-video fork to build against same RN version as gutenberg-mobile from maven repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "react-native-recyclerview-list": "git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#eadaa2f62d2f488d4dc80f9148e52b62047297ab",
     "react-native-safe-area": "^0.5.0",
     "react-native-svg": "git+https://github.com/wordpress-mobile/react-native-svg.git#d466eb06a38e6f553f08666f0ca784d47fd6f724",
-    "react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#93abb3984bec3999a70043c9ab588b0b80345ba2",
+    "react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#ad64098edc4ce1cd0ad783cb1843df634d997fdb",
     "react-redux": "^5.0.7",
     "redux": "^3.7.2",
     "redux-multi": "^0.1.12",

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "react-native-recyclerview-list": "git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#eadaa2f62d2f488d4dc80f9148e52b62047297ab",
     "react-native-safe-area": "^0.5.0",
     "react-native-svg": "git+https://github.com/wordpress-mobile/react-native-svg.git#d466eb06a38e6f553f08666f0ca784d47fd6f724",
-    "react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#6c75579a95a6ddb3762b6e11ef004c2cd0bed537",
+    "react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#3a0e2fa6fc6bf1fe1a54adb2dbf94545b28c2bc4",
     "react-redux": "^5.0.7",
     "redux": "^3.7.2",
     "redux-multi": "^0.1.12",

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "react-native-recyclerview-list": "git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#eadaa2f62d2f488d4dc80f9148e52b62047297ab",
     "react-native-safe-area": "^0.5.0",
     "react-native-svg": "git+https://github.com/wordpress-mobile/react-native-svg.git#d466eb06a38e6f553f08666f0ca784d47fd6f724",
-    "react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#3a0e2fa6fc6bf1fe1a54adb2dbf94545b28c2bc4",
+    "react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#6c75579a95a6ddb3762b6e11ef004c2cd0bed537",
     "react-redux": "^5.0.7",
     "redux": "^3.7.2",
     "redux-multi": "^0.1.12",

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "react-native-recyclerview-list": "git+https://github.com/wordpress-mobile/react-native-recyclerview-list.git#eadaa2f62d2f488d4dc80f9148e52b62047297ab",
     "react-native-safe-area": "^0.5.0",
     "react-native-svg": "git+https://github.com/wordpress-mobile/react-native-svg.git#d466eb06a38e6f553f08666f0ca784d47fd6f724",
-    "react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#6c75579a95a6ddb3762b6e11ef004c2cd0bed537",
+    "react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#93abb3984bec3999a70043c9ab588b0b80345ba2",
     "react-redux": "^5.0.7",
     "redux": "^3.7.2",
     "redux-multi": "^0.1.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11016,9 +11016,9 @@ react-native-sass-transformer@^1.1.1:
   version "9.3.3-gb"
   resolved "git+https://github.com/wordpress-mobile/react-native-svg.git#d466eb06a38e6f553f08666f0ca784d47fd6f724"
 
-"react-native-video@git+https://github.com/wordpress-mobile/react-native-video.git#93abb3984bec3999a70043c9ab588b0b80345ba2":
+"react-native-video@git+https://github.com/wordpress-mobile/react-native-video.git#ad64098edc4ce1cd0ad783cb1843df634d997fdb":
   version "4.4.1"
-  resolved "git+https://github.com/wordpress-mobile/react-native-video.git#93abb3984bec3999a70043c9ab588b0b80345ba2"
+  resolved "git+https://github.com/wordpress-mobile/react-native-video.git#ad64098edc4ce1cd0ad783cb1843df634d997fdb"
   dependencies:
     keymirror "^0.1.1"
     prop-types "^15.5.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11016,9 +11016,9 @@ react-native-sass-transformer@^1.1.1:
   version "9.3.3-gb"
   resolved "git+https://github.com/wordpress-mobile/react-native-svg.git#d466eb06a38e6f553f08666f0ca784d47fd6f724"
 
-"react-native-video@git+https://github.com/wordpress-mobile/react-native-video.git#3a0e2fa6fc6bf1fe1a54adb2dbf94545b28c2bc4":
+"react-native-video@git+https://github.com/wordpress-mobile/react-native-video.git#6c75579a95a6ddb3762b6e11ef004c2cd0bed537":
   version "4.4.1"
-  resolved "git+https://github.com/wordpress-mobile/react-native-video.git#3a0e2fa6fc6bf1fe1a54adb2dbf94545b28c2bc4"
+  resolved "git+https://github.com/wordpress-mobile/react-native-video.git#6c75579a95a6ddb3762b6e11ef004c2cd0bed537"
   dependencies:
     keymirror "^0.1.1"
     prop-types "^15.5.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11016,9 +11016,9 @@ react-native-sass-transformer@^1.1.1:
   version "9.3.3-gb"
   resolved "git+https://github.com/wordpress-mobile/react-native-svg.git#d466eb06a38e6f553f08666f0ca784d47fd6f724"
 
-"react-native-video@git+https://github.com/wordpress-mobile/react-native-video.git#6c75579a95a6ddb3762b6e11ef004c2cd0bed537":
+"react-native-video@git+https://github.com/wordpress-mobile/react-native-video.git#3a0e2fa6fc6bf1fe1a54adb2dbf94545b28c2bc4":
   version "4.4.1"
-  resolved "git+https://github.com/wordpress-mobile/react-native-video.git#6c75579a95a6ddb3762b6e11ef004c2cd0bed537"
+  resolved "git+https://github.com/wordpress-mobile/react-native-video.git#3a0e2fa6fc6bf1fe1a54adb2dbf94545b28c2bc4"
   dependencies:
     keymirror "^0.1.1"
     prop-types "^15.5.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11016,9 +11016,9 @@ react-native-sass-transformer@^1.1.1:
   version "9.3.3-gb"
   resolved "git+https://github.com/wordpress-mobile/react-native-svg.git#d466eb06a38e6f553f08666f0ca784d47fd6f724"
 
-"react-native-video@git+https://github.com/wordpress-mobile/react-native-video.git#6c75579a95a6ddb3762b6e11ef004c2cd0bed537":
+"react-native-video@git+https://github.com/wordpress-mobile/react-native-video.git#93abb3984bec3999a70043c9ab588b0b80345ba2":
   version "4.4.1"
-  resolved "git+https://github.com/wordpress-mobile/react-native-video.git#6c75579a95a6ddb3762b6e11ef004c2cd0bed537"
+  resolved "git+https://github.com/wordpress-mobile/react-native-video.git#93abb3984bec3999a70043c9ab588b0b80345ba2"
   dependencies:
     keymirror "^0.1.1"
     prop-types "^15.5.10"


### PR DESCRIPTION
This reverts commit 4085aebab5483002e4512e199cf18c95f9cf022a.

Fixes #1761 

It's not clear yet why the issue is happening but, reverting in order to patch and unblock the v1.20 editor release.

Edit: With 39f9f34aab75ba11945bd465cb4bcd81cb06fa8d, I'm pointing to a react-native-video version ([here's the branch](https://github.com/wordpress-mobile/react-native-video/commits/try/fix-video-overflow-issue-in-gb-mobile-take-3)) that builds using a specific RN version (same as gutenberg-mobile at the moment of writing) and only fetching it from our remote RN maven mirror on Bintray.

To test:

1. On an Android 7 or 8 (possibly 9 too) device, run WPAndroid against this PR
2. Have a post with a vertical video in a vide block. Example content:
```
<!-- wp:paragraph -->
<p>hello world!</p>
<!-- /wp:paragraph -->
<!-- wp:video {"autoplay":false,"id":248,"loop":false,"muted":false,"playsInline":false,"src":"https://tuggytestgmb1.wpcomstaging.com/wp-content/uploads/2020/01/VID_20200109_173921.mp4"} -->
<figure class="wp-block-video"><video controls src="https://tuggytestgmb1.wpcomstaging.com/wp-content/uploads/2020/01/VID_20200109_173921.mp4"></video></figure>
<!-- /wp:video -->
```
3. Open the post
4. Tap on the video block and then its caption
5. the video preview should be visible and no overflow should be happening

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
