### PR TITLE
Update Gutenberg to master

### DIFF
--- a/__device-tests__/pages/editor-page.js
+++ b/__device-tests__/pages/editor-page.js
@@ -48,7 +48,7 @@ export default class EditorPage {
 	// and accessibilityId attributes on this object and selects the block
 	// position uses one based numbering
 	async getBlockAtPosition( position: number, blockName: string, options: { autoscroll: boolean } = { autoscroll: false } ) {
-		const blockLocator = `//*[contains(@${ this.accessibilityIdXPathAttrib }, "${ blockName } Block. Row ${ position }.")]`;
+		const blockLocator = `//*[contains(@${ this.accessibilityIdXPathAttrib }, "${ blockName } Block. Row ${ position }")]`;
 		const elements = await this.driver.elementsByXPath( blockLocator );
 		const lastElementFound = elements[ elements.length - 1 ];
 		if ( elements.length === 0 && options.autoscroll ) {
@@ -212,14 +212,11 @@ export default class EditorPage {
 			throw Error( `No Block at position ${ position }` );
 		}
 
-		const parentId = `${ blockName } Block. Row ${ position }.`;
-		const parentLocator = `//*[contains(@${ this.accessibilityIdXPathAttrib }, "${ parentId }")]`;
-		let removeBlockLocator = `${ parentLocator }`;
-		removeBlockLocator += isAndroid() ? '//*' : '//XCUIElementTypeButton';
-		let removeButtonIdentifier = `Remove block at row ${ position }`;
+		const buttonElementName = isAndroid() ? '//*' : '//XCUIElementTypeButton';
+		const removeButtonIdentifier = `Remove block at row ${ position }`;
+		const removeBlockLocator = `${ buttonElementName }[contains(@${ this.accessibilityIdXPathAttrib }, "${ removeButtonIdentifier }")]`;
 
 		if ( isAndroid() ) {
-			removeButtonIdentifier += `, Double tap to remove the block${ this.accessibilityIdSuffix }`;
 			const block = await this.getBlockAtPosition( position, blockName );
 			let checkList = await this.driver.elementsByXPath( removeBlockLocator );
 			while ( checkList.length === 0 ) {
@@ -228,7 +225,6 @@ export default class EditorPage {
 			}
 		}
 
-		removeBlockLocator += `[@${ this.accessibilityIdXPathAttrib }="${ removeButtonIdentifier }"]`;
 		const removeButton = await this.driver.elementByXPath( removeBlockLocator );
 		await removeButton.click();
 	}

--- a/src/jsdom-patches.js
+++ b/src/jsdom-patches.js
@@ -238,3 +238,11 @@ Object.defineProperties( Node.prototype, {
 		},
 	},
 } );
+
+class DOMParser {
+	parseFromString( string ) {
+		return jsdom.html( string );
+	}
+}
+
+global.DOMParser = DOMParser;


### PR DESCRIPTION
https://github.com/WordPress/gutenberg/pull/18132 introduced a new way of doing accessibility labels, and relies on `DOMParser`, which doesn't exist in our jsdom implementation.

This PR adds a simple `DOMParser` implementation based on the API of our `jsdom` version.

To test:

- The app should run without crashing
- CI tests should pass

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
