### PR TITLE
Update aztec to 1.15.0

### DIFF
--- a/ios/gutenberg.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/gutenberg.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/react-native-aztec/ios/Cartfile
+++ b/react-native-aztec/ios/Cartfile
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "16496c6497651cd3961af063ba3cd25ba8950090"
+github "wordpress-mobile/AztecEditor-iOS" "364ee367c47229e6823f95f3d159df27fe84243b"

--- a/react-native-aztec/ios/Cartfile
+++ b/react-native-aztec/ios/Cartfile
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "364ee367c47229e6823f95f3d159df27fe84243b"
+github "wordpress-mobile/AztecEditor-iOS" "1.15.0"

--- a/react-native-aztec/ios/Cartfile
+++ b/react-native-aztec/ios/Cartfile
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.14.1"
+github "wordpress-mobile/AztecEditor-iOS" "16496c6497651cd3961af063ba3cd25ba8950090"

--- a/react-native-aztec/ios/Cartfile.resolved
+++ b/react-native-aztec/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "16496c6497651cd3961af063ba3cd25ba8950090"
+github "wordpress-mobile/AztecEditor-iOS" "364ee367c47229e6823f95f3d159df27fe84243b"

--- a/react-native-aztec/ios/Cartfile.resolved
+++ b/react-native-aztec/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "364ee367c47229e6823f95f3d159df27fe84243b"
+github "wordpress-mobile/AztecEditor-iOS" "1.15.0"

--- a/react-native-aztec/ios/Cartfile.resolved
+++ b/react-native-aztec/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.14.1"
+github "wordpress-mobile/AztecEditor-iOS" "16496c6497651cd3961af063ba3cd25ba8950090"

--- a/react-native-aztec/ios/RNTAztecView.xcodeproj/project.pbxproj
+++ b/react-native-aztec/ios/RNTAztecView.xcodeproj/project.pbxproj
@@ -12,8 +12,8 @@
 		7ECFA94221C39BBB00FC131B /* BlockModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ECFA94121C39BBB00FC131B /* BlockModel.swift */; };
 		F121467D20ED2F81003DD17B /* RCTAztecViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F121467C20ED2F81003DD17B /* RCTAztecViewManager.m */; };
 		F13BF4A020ECF5450047D3F9 /* RCTAztecViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13BF49F20ECF5450047D3F9 /* RCTAztecViewManager.swift */; };
-		F166A38020EE6DF3008E7C9F /* Aztec.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F166A37B20EE6DD7008E7C9F /* Aztec.framework */; };
 		F1A879D020EE90C000FABD31 /* RCTAztecView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A879CF20EE90C000FABD31 /* RCTAztecView.swift */; };
+		FF0DC1C523CDD21D0060074D /* Aztec.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F166A37B20EE6DD7008E7C9F /* Aztec.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -70,7 +70,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F166A38020EE6DF3008E7C9F /* Aztec.framework in Frameworks */,
+				FF0DC1C523CDD21D0060074D /* Aztec.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -135,6 +135,7 @@ class RCTAztecView: Aztec.TextView {
     }
 
     func commonInit() {
+        Configuration.headersWithBoldTrait = true
         delegate = self
         textContainerInset = .zero
         contentInset = .zero


### PR DESCRIPTION
This PR updates Aztec version to 1.15.0

WP-iOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/13228

Fixes #

To test:

 - Smoke test the demo app to see if all is good
 - Do an extra check on the header block and blockquote block because of changes made in Aztec to that code.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
