### PR TITLE
Add @wordpress/warning package symlink

### DIFF
--- a/symlinked-packages/@wordpress/warning
+++ b/symlinked-packages/@wordpress/warning
@@ -1,0 +1,1 @@
+../../gutenberg/packages/warning/src/


### PR DESCRIPTION
Fixes an issue with missing symlink to `@wordpress/warning` package which is currently used in native file after [replacing](https://github.com/WordPress/gutenberg/commit/a3a2f7b007d349582e877e2524e0dee971fc051c) `console.warn` within `gutenberg`

To test:

* CI should be green ✅ 
* CI should be green [there](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1769) as well ✅ 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
