### PR TITLE
Hardcode Android RN version in bridge and aztec

### DIFF
--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -112,7 +112,10 @@ dependencies {
     if (rootProject.ext.buildGutenbergFromSource) {
         implementation "com.facebook.react:react-native:+" // From node_modules.
     } else {
-        def rnVersion = readReactNativeVersion('../package.json', 'peerDependencies')
+
+        // FIXME Temporary fix to get Jitpack builds to green while I work on a solution without hardcoded values.
+        //def rnVersion = readReactNativeVersion('../package.json', 'peerDependencies')
+        def rnVersion = '0.60.0-patched'
         implementation "com.facebook.react:react-native:${rnVersion}" // From Maven repo
     }
 }

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -139,7 +139,9 @@ dependencies {
         implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-video', readHashedVersion('../../package.json', 'react-native-video', 'dependencies')))
         implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-slider', readHashedVersion('../../package.json', '@react-native-community/slider', 'dependencies')))
 
-        def rnVersion = readReactNativeVersion('../package.json', 'peerDependencies')
+        // FIXME Temporary fix to get Jitpack builds to green while I work on a solution without hardcoded values.
+        //def rnVersion = readReactNativeVersion('../package.json', 'peerDependencies')
+        def rnVersion = '0.60.0-patched'
         implementation "com.facebook.react:react-native:${rnVersion}"
     }
 }


### PR DESCRIPTION
Before this fix, building the Android `react-native-gutenberg-bridge` or `react-native-aztec` modules directly (i.e., where they are the `rootProject`) would use an older version of react native. With [a recent change to the project](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1560/files#diff-50887f88a59f4879f48ea11a48b84e14) this resulted in a build error. Jitpack builds those modules directly, so builds on Jitpack were failing.

This is a temporary fix to get the Jitpack builds back to green while I work on a solution that doesn't use hardcoded values. I expect to open a new PR with a cleaner solution later today.

I'm not updating the value in the relevant package.json files in this temporary-fix-PR because it seems that we need version `v0.60.0-patched` in the package.json files, but we need to drop the `v` for the java dependency version.

To test:

* Verify app builds and runs both locally and on Jitpack. I had Jitpack complete a build of this commit (f031379129) before opening this PR: https://jitpack.io/#wordpress-mobile/gutenberg-mobile

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
