### PR TITLE
Enforce consistent RN version across javascript and Android projects

### DIFF
--- a/android/shared_config.gradle
+++ b/android/shared_config.gradle
@@ -1,0 +1,11 @@
+import groovy.json.JsonSlurper
+
+/*
+ * This function returns the relevant React Native version for Android as parsed from
+ * the provided package.json file.
+ */
+ext.getRnVersion = { String pathToPackageJson, String section ->
+    def packageSlurper = new JsonSlurper()
+    def packageJson = packageSlurper.parse(file(pathToPackageJson))
+    return packageJson.get(section).get('react-native')
+}

--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -31,9 +31,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'com.github.dcendents.android-maven'
 
-// import the `readReactNativeVersion()` function
-apply from: 'https://gist.githubusercontent.com/hypest/742448b9588b3a0aa580a5e80ae95bdf/raw/8eb62d40ee7a5104d2fcaeff21ce6f29bd93b054/readReactNativeVersion.gradle'
-
 group='com.github.wordpress-mobile.gutenberg-mobile'
 
 // fallback flag value for when lib is compiled individually (e.g. via jitpack)
@@ -112,10 +109,8 @@ dependencies {
     if (rootProject.ext.buildGutenbergFromSource) {
         implementation "com.facebook.react:react-native:+" // From node_modules.
     } else {
-
-        // FIXME Temporary fix to get Jitpack builds to green while I work on a solution without hardcoded values.
-        //def rnVersion = readReactNativeVersion('../package.json', 'peerDependencies')
-        def rnVersion = '0.61.5'
-        implementation "com.facebook.react:react-native:${rnVersion}" // From Maven repo
+        /* import 'getRnVersion' function */
+        apply from: '../../android/shared_config.gradle'
+        implementation "com.facebook.react:react-native:${getRnVersion('../package.json', 'peerDependencies')}"
     }
 }

--- a/react-native-aztec/package.json
+++ b/react-native-aztec/package.json
@@ -13,7 +13,7 @@
   },
   "peerDependencies": {
     "react": "16.6.1",
-    "react-native": "0.57.5"
+    "react-native": "0.61.5"
   },
   "dependencies": {
     "prop-types": "15.6.0"

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -65,9 +65,6 @@ if (isJitPack) {
     }
 }
 
-// import the `readReactNativeVersion()` function
-apply from: 'https://gist.githubusercontent.com/hypest/742448b9588b3a0aa580a5e80ae95bdf/raw/8eb62d40ee7a5104d2fcaeff21ce6f29bd93b054/readReactNativeVersion.gradle'
-
 // import the `readHashedVersion()` function
 apply from: 'https://gist.githubusercontent.com/hypest/ceaf20a8e7d9b8404e4a5ff2e6c36650/raw/e1460a128e4b9863963410d719c7d44c3adefd02/readHashedVersion.gradle'
 
@@ -133,18 +130,17 @@ dependencies {
         implementation project(':react-native-video')
         implementation project(':@react-native-community_slider')
 
-        implementation 'com.facebook.react:react-native:+'
+        implementation 'com.facebook.react:react-native:+' // from node_modules
     } else {
-        hermesPath = "../../bundle/";
+        hermesPath = "../../bundle/"
 
         implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-svg', readHashedVersion('../../package.json', 'react-native-svg', 'dependencies')))
         implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-video', readHashedVersion('../../package.json', 'react-native-video', 'dependencies')))
         implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-slider', readHashedVersion('../../package.json', '@react-native-community/slider', 'dependencies')))
 
-        // FIXME Temporary fix to get Jitpack builds to green while I work on a solution without hardcoded values.
-        //def rnVersion = readReactNativeVersion('../package.json', 'peerDependencies')
-        def rnVersion = '0.61.5'
-        implementation "com.facebook.react:react-native:${rnVersion}"
+        // import 'getRnVersion' function
+        apply from: '../../android/shared_config.gradle'
+        implementation "com.facebook.react:react-native:${getRnVersion('../package.json', 'peerDependencies')}"
     }
 
     debugImplementation files(hermesPath + "hermes-debug.aar")

--- a/src/test/project.test.js
+++ b/src/test/project.test.js
@@ -1,0 +1,24 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import fs from 'fs';
+import _ from 'lodash';
+
+describe( 'RN version from root is same in', () => {
+	const rootRNVersion = parseRNVersionFromPackageJson( '.', 'dependencies' );
+	expect( rootRNVersion ).toBeDefined();
+
+	[ 'react-native-aztec', 'react-native-gutenberg-bridge' ].forEach( ( path ) => {
+		it( path, () => {
+			const otherRNVersion = parseRNVersionFromPackageJson( path, 'peerDependencies' );
+			expect( otherRNVersion ).toEqual( rootRNVersion );
+		} );
+	} );
+} );
+
+function parseRNVersionFromPackageJson( packageJsonPath, section ) {
+	const packageJson = JSON.parse( fs.readFileSync( `${ packageJsonPath }/package.json` ) );
+	return _.get( packageJson, [ section, 'react-native' ] );
+}


### PR DESCRIPTION
This PR enforces that we use the same react native version in our javascript and Android projects.

### Testing
Verify that:
1. demo app builds
2. react-native-gutenberg-bridge android project can be built directly (i.e., `react-native-gutenberg-bridge/android/gradlew assembleDebug`)
3. react-native-aztec android project can be built directly (i.e., `react-native-aztec/android/gradlew assembleDebug`)
4. Jitpack can build with these changes. In other words, WPAndroid can be built with this checked out in `gutenberg-mobile` and `BUILD_GUTENBERG_FROM_SOURCE` set to `false`

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
