### PR TITLE
[iOS] Remove xcworkspace.

### DIFF
--- a/ios/gutenberg.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/gutenberg.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>


### PR DESCRIPTION
xcworkspace dir makes UITests to fail.

To test:
- All tests should pass.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
