### PR TITLE
Update ref to react-native-slider fork to support autolinking

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -191,6 +191,8 @@ PODS:
     - React
   - react-native-safe-area (0.5.1):
     - React
+  - react-native-slider (2.0.7):
+    - React
   - react-native-video (5.0.1):
     - React
     - react-native-video/Video (= 5.0.1)
@@ -261,6 +263,7 @@ DEPENDENCIES:
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - react-native-keyboard-aware-scroll-view (from `../node_modules/react-native-keyboard-aware-scroll-view`)
   - react-native-safe-area (from `../node_modules/react-native-safe-area`)
+  - react-native-slider (from `../node_modules/@react-native-community/slider`)
   - react-native-video (from `../node_modules/react-native-video`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
   - React-RCTAnimation (from `../node_modules/react-native/Libraries/NativeAnimation`)
@@ -318,6 +321,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-keyboard-aware-scroll-view"
   react-native-safe-area:
     :path: "../node_modules/react-native-safe-area"
+  react-native-slider:
+    :path: "../node_modules/@react-native-community/slider"
   react-native-video:
     :path: "../node_modules/react-native-video"
   React-RCTActionSheet:
@@ -368,6 +373,7 @@ SPEC CHECKSUMS:
   React-jsinspector: fa0ecc501688c3c4c34f28834a76302233e29dc0
   react-native-keyboard-aware-scroll-view: 01c4b2303c4ef1c49c4d239c9c5856f0393104df
   react-native-safe-area: e8230b0017d76c00de6b01e2412dcf86b127c6a3
+  react-native-slider: f81b89fa0c1f9a65742d33f889a194ca6653a985
   react-native-video: 331eaf96cb034fedcc27f4f6ada3ac3cf6c0a78a
   React-RCTActionSheet: 600b4d10e3aea0913b5a92256d2719c0cdd26d76
   React-RCTAnimation: 791a87558389c80908ed06cc5dfc5e7920dfa360

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -263,7 +263,7 @@ DEPENDENCIES:
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - react-native-keyboard-aware-scroll-view (from `../node_modules/react-native-keyboard-aware-scroll-view`)
   - react-native-safe-area (from `../node_modules/react-native-safe-area`)
-  - react-native-slider (from `../node_modules/@react-native-community/slider`)
+  - "react-native-slider (from `../node_modules/@react-native-community/slider`)"
   - react-native-video (from `../node_modules/react-native-video`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
   - React-RCTAnimation (from `../node_modules/react-native/Libraries/NativeAnimation`)

--- a/ios/gutenberg.xcodeproj/project.pbxproj
+++ b/ios/gutenberg.xcodeproj/project.pbxproj
@@ -489,6 +489,7 @@
 				"${BUILT_PRODUCTS_DIR}/glog/glog.framework",
 				"${BUILT_PRODUCTS_DIR}/react-native-keyboard-aware-scroll-view/react_native_keyboard_aware_scroll_view.framework",
 				"${BUILT_PRODUCTS_DIR}/react-native-safe-area/react_native_safe_area.framework",
+				"${BUILT_PRODUCTS_DIR}/react-native-slider/react_native_slider.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -521,6 +522,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/glog.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/react_native_keyboard_aware_scroll_view.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/react_native_safe_area.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/react_native_slider.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
   },
   "dependencies": {
     "@react-native-community/cli": "^3.0.4",
-    "@react-native-community/slider": "git+https://github.com/wordpress-mobile/react-native-slider.git#f5d8685ffa389c78a8713162b1e2821067ad214f",
+    "@react-native-community/slider": "git+https://github.com/wordpress-mobile/react-native-slider.git#5ad284d92b8d886e366445bf215be741ed53ddc6",
     "classnames": "^2.2.5",
     "dom-react": "^2.2.1",
     "domutils": "^1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2160,9 +2160,9 @@
     wcwidth "^1.0.1"
     ws "^1.1.0"
 
-"@react-native-community/slider@git+https://github.com/wordpress-mobile/react-native-slider.git#f5d8685ffa389c78a8713162b1e2821067ad214f":
+"@react-native-community/slider@git+https://github.com/wordpress-mobile/react-native-slider.git#5ad284d92b8d886e366445bf215be741ed53ddc6":
   version "2.0.7"
-  resolved "git+https://github.com/wordpress-mobile/react-native-slider.git#f5d8685ffa389c78a8713162b1e2821067ad214f"
+  resolved "git+https://github.com/wordpress-mobile/react-native-slider.git#5ad284d92b8d886e366445bf215be741ed53ddc6"
 
 "@tannin/compile@^1.0.3":
   version "1.0.3"


### PR DESCRIPTION
Fixes app crash on opening settings within `Spacer`, because of missing `RNCSlider` after updating RN.

During the building process you could notice a warning:

```
[!] use_native_modules! skipped the react-native dependency '@react-native-community/slider'. No podspec file was found.
```

I assume that autolinking requires `podspec` file to be on the project root, but in react-native-slider is nested so I had to [move up](https://github.com/wordpress-mobile/react-native-slider/commit/5ad284d92b8d886e366445bf215be741ed53ddc6).


To test:

1. remove old `node_modules`
2. `yarn clean:install`
3. `yarn ios`
4. add a `Spacer` block
5. open settings
6. app mustn't crash!

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
