### PR TITLE
Remove DEV flag from Media Editor button

### DIFF
--- a/react-native-gutenberg-bridge/index.js
+++ b/react-native-gutenberg-bridge/index.js
@@ -16,7 +16,7 @@ export const mediaSources = {
 	siteMediaLibrary: 'SITE_MEDIA_LIBRARY',
 };
 
-export const showMediaEditorButton = isIOS && __DEV__;
+export const showMediaEditorButton = isIOS;
 
 // Console polyfill from react-native
 


### PR DESCRIPTION
Remove the `__DEV__` flag so the Media Editor button will be available for iOS in production too.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
