### PR TITLE
[Media Edit Icon] Show the media edit icon only if the block is selected

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "gutenberg"]
 	path = gutenberg
-	url = ../../WordPress/gutenberg.git
+	url = ../../leandroalonso/gutenberg.git
 [submodule "react-native-aztec"]
 	path = react-native-aztec-old-submodule
 	url = ../react-native-aztec.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "gutenberg"]
 	path = gutenberg
-	url = ../../leandroalonso/gutenberg.git
+	url = ../../wordpress-mobile/gutenberg.git
 [submodule "react-native-aztec"]
 	path = react-native-aztec-old-submodule
 	url = ../react-native-aztec.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "gutenberg"]
 	path = gutenberg
-	url = ../../wordpress-mobile/gutenberg.git
+	url = ../../WordPress/gutenberg.git
 [submodule "react-native-aztec"]
 	path = react-native-aztec-old-submodule
 	url = ../react-native-aztec.git


### PR DESCRIPTION
Gutenberg PR: https://github.com/WordPress/gutenberg/pull/19961

### To test

* Check that the Media Edit icon matches the style of the Gallery icons
* Check that the icon only appears when the Image block is selected

## Screenshots

<img src="https://user-images.githubusercontent.com/7040243/73445282-19024f00-4339-11ea-9935-8244d29578cf.png" width="400">

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
