### PR TITLE
Avoid fullscreen text entry UI in landscape mode

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.24.0
+------
+* [Android] Can now scroll post when in landscape orientation with the soft keyboard displayed
+
 1.23.0
 ------
 * New block: Group

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -18,6 +18,7 @@ import android.text.InputType;
 import android.text.Spannable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
+import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.TextView;
 
@@ -138,6 +139,7 @@ public class ReactAztecText extends AztecText {
                 ReactAztecText.this.propagateSelectionChanges(selStart, selEnd);
             }
         });
+        this.setImeOptions(getImeOptions() | EditorInfo.IME_FLAG_NO_EXTRACT_UI);
         this.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_CAP_SENTENCES | InputType.TYPE_TEXT_FLAG_MULTI_LINE);
     }
 


### PR DESCRIPTION
Fixes #1829 

## Summary

On Android when we are editing a paragraph block in landscape mode and you press the done button, an "Enter" keypress is registered. Therfore, the block is split at the point of the cursor. @iamthomasbishop indicated that the "Done" button should just close the keyboard, but that he would prefer not have the "full screen" editing type view when in landscape mode. Conveniently enough, the preferred solution is actually easier to implement. 😄 I would like to get @iamthomasbishop 's sign-off on this first though to make sure he's ok with how the view is mostly taken up by the keyboard.

### But What Does It Look Like?!?!?

I'm glad you asked! 

Before | After
--- | ---
![Screen Shot 2020-01-30 at 11 42 06 AM](https://user-images.githubusercontent.com/4656348/73470246-8fad4580-4355-11ea-9a6e-253dee85f1bb.png) | ![Screen Shot 2020-01-30 at 11 39 35 AM](https://user-images.githubusercontent.com/4656348/73470008-3ba26100-4355-11ea-9e9c-198883428187.png)
![android_landscape_no_extract mp4](https://user-images.githubusercontent.com/4656348/73470424-df8c0c80-4355-11ea-88e1-929642ecb32f.gif) | ![android_landscape_no_extract mp4](https://user-images.githubusercontent.com/4656348/73764264-a7634000-4740-11ea-91b5-27ad5634717b.gif)


## To Test

1. Open post with paragraph block
2. Select paragraph block so that keyboard displays
3. Switch the phone to landscape mode
4. Observe that the phone looks like the "After" picture ^above^ (i.e., there isn't a "Done" button).

## PR Submission Checklist

- [X] I have considered adding unit tests where possible.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
