### PR TITLE
Remove react-native-aztec-old-submodule

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,4 +4,3 @@ symlinked-packages
 symlinked-packages-in-parent
 react-native-aztec
 bundle
-react-native-aztec-old-submodule

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "gutenberg"]
 	path = gutenberg
 	url = ../../WordPress/gutenberg.git
-[submodule "react-native-aztec"]
-	path = react-native-aztec-old-submodule
-	url = ../react-native-aztec.git

--- a/jest.config.js
+++ b/jest.config.js
@@ -33,10 +33,7 @@ module.exports = {
 		'/__device-tests__/',
 	],
 	testURL: 'http://localhost/',
-	modulePathIgnorePatterns: [
-		'<rootDir>/gutenberg/gutenberg-mobile',
-		'react-native-aztec-old-submodule',
-	],
+	modulePathIgnorePatterns: [ '<rootDir>/gutenberg/gutenberg-mobile' ],
 	moduleDirectories: [ 'node_modules', 'symlinked-packages' ],
 	moduleNameMapper: {
 		// Mock the CSS modules. See https://facebook.github.io/jest/docs/en/webpack.html#handling-static-assets

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,7 @@
 install:
    - export TMPDIR=`dirname $(mktemp)`
+   - echo "Removing react-native-aztec-old-submodule folder"
+   - rm -rf react-native-aztec-old-submodule
    - echo "Changing into the android folder of the Bridge module"
    - pushd react-native-gutenberg-bridge/android && ./gradlew --stacktrace clean -Pgroup=com.github.wordpress-mobile.gutenberg-mobile -Pversion=$VERSION install && popd
    - pushd react-native-aztec/android && ./gradlew --stacktrace clean -Pgroup=com.github.wordpress-mobile.gutenberg-mobile -Pversion=$VERSION install && popd

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -157,10 +157,6 @@ if (isJitPack) {
     def assetsFolder = 'src/main/assets'
     def aarFolder = 'src/main/assets'
 
-    task removeReactNativeAztecOldSubmodule(type: Delete) {
-        delete '../../react-native-aztec-old-submodule'
-    }
-
     task buildJSBundle(type: YarnTask) {
         args = ['bundle:android']
     }
@@ -214,6 +210,5 @@ if (isJitPack) {
         backupHermesReleaseAAR.dependsOn(copyJSBundle)
         copyJSBundle.dependsOn(buildJSBundle)
         buildJSBundle.dependsOn(yarn_install, ensureAssetsDirectory)
-        ensureAssetsDirectory.dependsOn(removeReactNativeAztecOldSubmodule)
     }
 }

--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -157,6 +157,10 @@ if (isJitPack) {
     def assetsFolder = 'src/main/assets'
     def aarFolder = 'src/main/assets'
 
+    task removeReactNativeAztecOldSubmodule(type: Delete) {
+        delete '../../react-native-aztec-old-submodule'
+    }
+
     task buildJSBundle(type: YarnTask) {
         args = ['bundle:android']
     }
@@ -210,5 +214,6 @@ if (isJitPack) {
         backupHermesReleaseAAR.dependsOn(copyJSBundle)
         copyJSBundle.dependsOn(buildJSBundle)
         buildJSBundle.dependsOn(yarn_install, ensureAssetsDirectory)
+        ensureAssetsDirectory.dependsOn(removeReactNativeAztecOldSubmodule)
     }
 }

--- a/rn-cli.config.js
+++ b/rn-cli.config.js
@@ -6,7 +6,6 @@ const blacklist = require( 'metro-config/src/defaults/blacklist' );
 const blacklistElements = blacklist( [
 	new RegExp( path.basename( __dirname ) + '/gutenberg/node_modules/.*' ),
 	new RegExp( path.basename( __dirname ) + '/gutenberg/gutenberg-mobile/.*' ),
-	new RegExp( path.basename( __dirname ) + '/react-native-aztec-old-submodule/.*' ),
 ] );
 const enm = require( './extra-node-modules.config.js' );
 


### PR DESCRIPTION
`react-native-aztec` was moved into this repo a while ago and it's submodule was removed: https://github.com/wordpress-mobile/gutenberg-mobile/pull/465 
But this submodule was re-introduced again because of JitPack problems: https://github.com/wordpress-mobile/gutenberg-mobile/pull/486
Seems like JitPack is not an issue anymore as the CI is green in this PR so we can remove this submodule now.