### PR TITLE
Send selection change event when typing

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * [iOS] Show an "Edit" button overlay on selected image blocks
 * [Android] Fix blank post when sharing media from another app
 * Add support for image size options in the gallery block
+* Fix issue that sometimes prevented merging paragraph blocks
 
 1.21.0
 ------

--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = 'v1.3.37'
+        aztecVersion = '2e5536de838129e94fb31df17fdf0fc89a1543de'
     }
 
     repositories {

--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = '2e5536de838129e94fb31df17fdf0fc89a1543de'
+        aztecVersion = 'v1.3.38'
     }
 
     repositories {

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -544,6 +544,8 @@ public class ReactAztecManager extends BaseViewManager<ReactAztecText, LayoutSha
         private EventDispatcher mEventDispatcher;
         private ReactAztecText mEditText;
         private String mPreviousText;
+        private int mPreviousSelectionStart;
+        private int mPreviousSelectionEnd;
 
         public AztecTextWatcher(final ReactContext reactContext, final ReactAztecText aztecText) {
             mEventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
@@ -555,6 +557,8 @@ public class ReactAztecManager extends BaseViewManager<ReactAztecText, LayoutSha
         public void beforeTextChanged(CharSequence s, int start, int count, int after) {
             // Incoming charSequence gets mutated before onTextChanged() is invoked
             mPreviousText = s.toString();
+            mPreviousSelectionStart = mEditText.getSelectionStart();
+            mPreviousSelectionEnd = mEditText.getSelectionEnd();
         }
 
         @Override
@@ -576,14 +580,14 @@ public class ReactAztecManager extends BaseViewManager<ReactAztecText, LayoutSha
             // if the "Enter" handling is underway, don't sent text change events. The ReactAztecEnterEvent will have
             // the text (minus the Enter char itself).
             if (!mEditText.isEnterPressedUnderway()) {
-                int currentEventCount = mEditText.incrementAndGetEventCounter();
+                final String content = mEditText.toHtml(mEditText.getText(), false);
                 // The event that contains the event counter and updates it must be sent first.
                 // TODO: t7936714 merge these events
                 mEventDispatcher.dispatchEvent(
                         new ReactTextChangedEvent(
                                 mEditText.getId(),
-                                mEditText.toHtml(mEditText.getText(), false),
-                                currentEventCount));
+                                content,
+                                mEditText.incrementAndGetEventCounter()));
 
                 mEventDispatcher.dispatchEvent(
                         new ReactTextInputEvent(
@@ -592,6 +596,20 @@ public class ReactAztecManager extends BaseViewManager<ReactAztecText, LayoutSha
                                 oldText,
                                 start,
                                 start + before));
+
+
+                final int selectionStart = mEditText.getSelectionStart();
+                final int selectionEnd = mEditText.getSelectionEnd();
+                if (selectionStart != mPreviousSelectionStart
+                        || selectionEnd != mPreviousSelectionEnd) {
+                    mEventDispatcher.dispatchEvent(
+                            new ReactAztecSelectionChangeEvent(
+                                    mEditText.getId(),
+                                    content,
+                                    selectionStart,
+                                    selectionEnd,
+                                    mEditText.incrementAndGetEventCounter()));
+                }
             }
 
 


### PR DESCRIPTION
Fixes #1865 

Experimental fix by dispatching a `ReactAztecSelectionChangeEvent` when text is changed in (Android) Aztec's manager.

This fix needs some extensive testing since the extra selection changed event could have side effects in other features.

Thing is, selection changed events should be sent out anyway [by this code](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java#L138) but it looks like the listener is suspended because of [this code on the Aztec side](https://github.com/wordpress-mobile/AztecEditor-Android/blob/d2baefd3512e3c2e19a6b5a183befb4c8f108949/aztec/src/main/kotlin/org/wordpress/aztec/watchers/ZeroIndexContentWatcher.kt#L30-L32).

@khaykov , I know it's been a while now since that code was written but, do you remember who/when should re-enable the selection change listener after the `ZeroIndexContentWatcher` has disabled it?

**Edit: latest fix on this PR is on the Aztec side. PR here: https://github.com/wordpress-mobile/AztecEditor-Android/pull/892**

## To test:

1. Add a pararaph block and add some text to it
2. Click in the middle of the text and hit enter to move the right half of the text to a new block
3. Hit backspace and watch the new block merge back correctly with the previous block
4. Hit enter from the middle of the text again to create a new block
5. This time delete one or more characters from the beginning of the new text block
6. Continue to hit the backspace key => blocks should get merged

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
