### PR TITLE
Schedule to request focus instead of asking immediately

### DIFF
--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -7,6 +7,8 @@ import android.os.Build;
 import androidx.annotation.Nullable;
 import androidx.core.graphics.ColorUtils;
 
+import android.os.Handler;
+import android.os.Looper;
 import android.text.Editable;
 import android.text.Layout;
 import android.text.TextUtils;
@@ -488,7 +490,13 @@ public class ReactAztecManager extends BaseViewManager<ReactAztecText, LayoutSha
     public void receiveCommand(final ReactAztecText parent, int commandType, @Nullable ReadableArray args) {
         Assertions.assertNotNull(parent);
         if (commandType == mFocusTextInputCommandCode) {
-            parent.requestFocusFromJS();
+            // schedule a request to focus in the next layout, to fix https://github.com/wordpress-mobile/gutenberg-mobile/issues/1870
+            new Handler(Looper.getMainLooper()).post(new Runnable() {
+                @Override
+                public void run() {
+                    parent.requestFocusFromJS();
+                }
+            });
             return;
         } else if (commandType == mBlurTextInputCommandCode) {
             parent.clearFocusFromJS();


### PR DESCRIPTION
Fixes #1870 

My current theory is that the new View is not yet in the proper position in the layout and requesting focus to it causes a scroll to the top of the ScrollView, since the coordinates of the view are not yet updated in respect to its parent. I can be wrong, haven't fully reached the bottom of this issue.

### To test A:

1. Open the demo app and add an image block at the top (to make the effect more noticeable)
2. Start adding paragraph block. Add more than a few so the view will need to scroll to show the whole content
3. Type "Enter" on the last paragraph block to create a new one
4. There shouldn't be a "whole list" jump to the top and back down again

### To test B:

There's a prior known issue with scrolling to new block added doesn't work so, this PR is not introducing that bug: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1881

### PR submission checklist:

- [x] I have considered adding unit tests where possible. I haven't added any because we don't currently have a way to detect this scrolling jump in automated tests.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
