### PR TITLE
Removing DEV flag for Image block size options

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 ------
 * New block: Group
 * Add support for upload options in Gallery block
+* Add support for size options in the Image block
 
 1.22.0
 ------


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1329

### Description
We recently finished resolving behavioral issues related to updating images sizes on mobile, and are therefore removing the DEV flag blocking the feature in non-development builds.
See - wordpress-mobile/gutenberg-mobile#1593

### Related PRs:
- Gutenberg: https://github.com/WordPress/gutenberg/pull/20229
- WPiOS (for testing only) - https://github.com/wordpress-mobile/WordPress-iOS/pull/13462
- WPAndroid (for testing only) - https://github.com/wordpress-mobile/WordPress-Android/pull/11305

### Screenshot
![size-changes](https://user-images.githubusercontent.com/1103838/71146730-5e891380-21f4-11ea-9eaf-6d66be5a7a34.gif)

### To test 
(Changes tested in individual PRs from https://github.com/wordpress-mobile/gutenberg-mobile/issues/1593):
(Must be tested in WP Apps, see test PRs above)
1. Add an Image Block and upload an image
2. Click the gear for block settings
3. Tap Image Size row and verify value cycles through available sizes (Thumbnail, Medium, Large, Fullscreen).
4. Verify the Image size changes as you click through the menu.
5. Verify the Image Size is preserved if you update the post, leave, and return.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
