### PR TITLE
Update release notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 * New block: Group
 * Add support for upload options in Gallery block
 * New block: Button
-* Add support for scroll ability inside block picker
+* Add scroll support inside block picker and block settings
 
 1.22.0
 ------

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,8 @@
 ------
 * New block: Group
 * Add support for upload options in Gallery block
+* New block: Button
+* Add support for scrollable BottomSheet
 
 1.22.0
 ------

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 * New block: Group
 * Add support for upload options in Gallery block
 * New block: Button
-* Add support for scrollable BottomSheet
+* Add support for scroll ability inside block picker
 
 1.22.0
 ------


### PR DESCRIPTION
Fixes missing releasing notes after adding these two functionalities:

1. New block Button -> https://github.com/WordPress/gutenberg/pull/20093
2. Add scroll support inside block picker and block settings -> https://github.com/WordPress/gutenberg/pull/18574


To test:

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
