### PR TITLE
Remove duplicate gallery image size release note

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,7 +10,6 @@
 
 1.22.0
 ------
-* Add support for changing images size in Gallery block
 * Make inserter to show options on long-press to add before/after
 * Retry displaying image when connectivity restores
 * [iOS] Show an "Edit" button overlay on selected image blocks


### PR DESCRIPTION
Remove duplicate release note for enabling changing images in gallery blocks from 1.22.0 as discussed in [this comment](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1924#discussion_r380403874).

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
