### PR TITLE
[CI] remove Yarn preios step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,8 +118,8 @@ jobs:
         - dependencies-v3-{{ checksum "ios/Gemfile.lock" }}
         - dependencies-v3-
     - run:
-        name: Yarn preios (if needed)
-        command: test -e ios/build/gutenberg/Build/Products/Release-iphonesimulator/GutenbergDemo.app || yarn preios
+        name: Build (if needed)
+        command: test -e ios/build/gutenberg/Build/Products/Release-iphonesimulator/GutenbergDemo.app || SKIP_BUNDLING=true yarn test:e2e:build-app:ios
     - save_cache:
         name: Save Dependencies Cache
         key: dependencies-v3-{{ checksum "ios/Gemfile.lock" }}-{{ checksum "ios/Podfile.lock" }}-{{
@@ -129,9 +129,6 @@ jobs:
         - ~/Library/Caches/CocoaPods
         - ~/.cocoapods/repos/trunk
         - ios/vendor
-    - run:
-        name: Build (if needed)
-        command: test -e ios/build/gutenberg/Build/Products/Release-iphonesimulator/GutenbergDemo.app || SKIP_BUNDLING=true yarn test:e2e:build-app:ios
     - run:
         name: Bundle iOS
         command: yarn test:e2e:bundle:ios


### PR DESCRIPTION
I realized that we don't need the CI `Yarn preios` step anymore since the `preios` is run in the build step. Recently I updated the `test:e2e:build-app:ios` script to use `yarn ios` under the hood sot the `preios` is also run.

To test:
- Green CI (it affects only CI)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
