### PR TITLE
Issue/1916 fix align issues

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 * [Android] Fix issue preventing correct placeholder image from displaying during image upload
 * [iOS] Fix diplay of large numbers on ordered lists
 * Fix issue where adding emojis to the post title add strong HTML elements to the title of the post
+* [iOS] Fix issue where alignment of paragraph blocks were not being respected whem splitting the paragraph or reading from the original Post content.
 
 1.22.0
 ------

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -37,10 +37,14 @@ class RCTAztecView: Aztec.TextView {
     }
 
     override var textAlignment: NSTextAlignment {
-        didSet {
-            super.textAlignment = textAlignment
-            defaultParagraphStyle.alignment = textAlignment
-            placeholderLabel.textAlignment = textAlignment
+        set {
+            super.textAlignment = newValue
+            defaultParagraphStyle.alignment = newValue
+            placeholderLabel.textAlignment = newValue
+        }
+
+        get {
+            return super.textAlignment
         }
     }
 


### PR DESCRIPTION
Fixes #1916 

This PR fixes the set alignment property on RCTAzteView to avoid conflict condition with the alignment property on the base TextView Class.

To test:
 - Open the demo app
 - Add a paragraph block
 - Write some text
 - Set the alignment to Right or Center
 - Check if the alignment is set
 - Tap Enter
 - Check that the alignment stays set on the previous block
 - Switch to HTML
 - Check that the HTML has the alignment attributes
 - Go back to visual and check if the alignment is applied
 - Now tap Enter in the middle of the text of the block
 - Check that both block keep the alignment.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
