### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ For a developer experience closer to the one the project maintainers current hav
 * yarn (`npm install -g yarn`)
 * [AndroidStudio](https://developer.android.com/studio/) to be able to compile the Android version of the app
 * [Xcode](https://developer.apple.com/xcode/) to be able to compile the iOS app
-* [CocoaPods](sudo gem install cocoapods) needed for fetc React and third-party dependencies.
-
+* [CocoaPods](sudo gem install cocoapods) needed to fetch React and third-party dependencies.
 
 Note that the OS platform used by the maintainers is macOS but the tools and setup should be usable in other platforms too.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For a developer experience closer to the one the project maintainers current hav
 * yarn (`npm install -g yarn`)
 * [AndroidStudio](https://developer.android.com/studio/) to be able to compile the Android version of the app
 * [Xcode](https://developer.apple.com/xcode/) to be able to compile the iOS app
-* [Carthage](https://github.com/Carthage/Carthage#installing-carthage) needed for fetching the Aztec dependency.
+* [CocoaPods](sudo gem install cocoapods) needed for fetc React and third-party dependencies.
 
 
 Note that the OS platform used by the maintainers is macOS but the tools and setup should be usable in other platforms too.


### PR DESCRIPTION
We no longer need Carthage because of the update to React 0.61.x.
Now Cocapods is used to fetch Aztec and other React dependencies.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
