### PR TITLE
Update release notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,7 +8,8 @@
 * [Android] Fix issue preventing correct placeholder image from displaying during image upload
 * [iOS] Fix diplay of large numbers on ordered lists
 * Fix issue where adding emojis to the post title add strong HTML elements to the title of the post
-* [iOS] Fix issue where alignment of paragraph blocks were not being respected whem splitting the paragraph or reading from the original Post content.
+* [iOS] Fix issue where alignment of paragraph blocks was not always being respected when splitting the paragraph or reading the post's html content.
+* We’ve introduced a new toolbar that floats above the block you’re editing, which makes navigating your blocks easier — especially complex ones.
 
 1.22.0
 ------


### PR DESCRIPTION
Updating release notes for 1.23 release by trying to clarify the ios paragraph alignment note and adding a note to address the fact that the floating block toolbar is now also shown for top-level blocks.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
