### PR TITLE
Fix Quote border-left not visible in Dark Mode

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "gutenberg"]
 	path = gutenberg
-	url = ../../ceyhun/gutenberg.git
+	url = ../../WordPress/gutenberg.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "gutenberg"]
 	path = gutenberg
-	url = ../../WordPress/gutenberg.git
+	url = ../../ceyhun/gutenberg.git

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 1.24.0
 ------
 * [Android] Can now scroll post when in landscape orientation with the soft keyboard displayed
+* Fix Quote block's left border not being visible in Dark Mode
 
 1.23.0
 ------


### PR DESCRIPTION
Fixes #1673

To test: See Gutenberg PR -> https://github.com/WordPress/gutenberg/pull/20419

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
