### PR TITLE
Fix crash pasting HTML with wrapped images.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * New block: Latest Posts
 * [Android] Can now scroll post when in landscape orientation with the soft keyboard displayed
 * Fix Quote block's left border not being visible in Dark Mode
+* Fix crash when pasting HTML content with embeded images on paragraphs
 
 1.23.0
 ------


### PR DESCRIPTION
Updating gutenberg ref to fix https://github.com/wordpress-mobile/gutenberg-mobile/issues/1950

More info on the `gutenberg` side PR: https://github.com/WordPress/gutenberg/pull/20499

To test:
- Follow steps on [`gutenberg` side PR](https://github.com/WordPress/gutenberg/pull/20499).

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
