### PR TITLE
[iOS] Fix [Obj] character after dictation

### DIFF
--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -327,9 +327,10 @@ class RCTAztecView: Aztec.TextView {
     }
 
     public override func insertDictationResult(_ dictationResult: [UIDictationPhrase]) {
-        let text = dictationResult.reduce("") { $0 + $1.text }
-        insertText(text)
+        let objectPlaceholder = "\u{FFFC}"
+        let dictationText = dictationResult.reduce("") { $0 + $1.text }
         isInsertingDictationResult = false
+        self.text = self.text?.replacingOccurrences(of: objectPlaceholder, with: dictationText)
     }
 
     // MARK: - Custom Edit Intercepts


### PR DESCRIPTION
This PR fixes an issue where an unwanted character was inserted after dictation.

And also, now dictations on the middle of the string will be positioned correctly (not always at the end).

To test:
- Tap on the Post Title.
- Start dictating with voice.
- When finished, press Enter.
- Check that there is no [UNDEFINED] appended to the post title.
- Check for regressions on #606

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
