### PR TITLE
Feat: hide hide "⤴️" button on floating toolbar

### DIFF
--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -327,9 +327,10 @@ class RCTAztecView: Aztec.TextView {
     }
 
     public override func insertDictationResult(_ dictationResult: [UIDictationPhrase]) {
-        let text = dictationResult.reduce("") { $0 + $1.text }
-        insertText(text)
+        let objectPlaceholder = "\u{FFFC}"
+        let dictationText = dictationResult.reduce("") { $0 + $1.text }
         isInsertingDictationResult = false
+        self.text = self.text?.replacingOccurrences(of: objectPlaceholder, with: dictationText)
     }
 
     // MARK: - Custom Edit Intercepts


### PR DESCRIPTION
Fixes #1967  

Please also refer to:
[Related gutenberg PR](https://github.com/WordPress/gutenberg/pull/20572)
[Related gutenberg-mobile issue](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1967)

It presents:
Hides the ⤴️ button on the FloatingToolbar for top-level blocks when selected.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
