### PR TITLE
Revert back to using extracted editing UI in landscape mode on Android

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,5 @@
 1.24.0
 ------
-* [Android] Can now scroll post when in landscape orientation with the soft keyboard displayed
 * Fix Quote block's left border not being visible in Dark Mode
 
 1.23.0

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -18,7 +18,6 @@ import android.text.InputType;
 import android.text.Spannable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
-import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.TextView;
 
@@ -139,7 +138,6 @@ public class ReactAztecText extends AztecText {
                 ReactAztecText.this.propagateSelectionChanges(selStart, selEnd);
             }
         });
-        this.setImeOptions(getImeOptions() | EditorInfo.IME_FLAG_NO_EXTRACT_UI);
         this.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_CAP_SENTENCES | InputType.TYPE_TEXT_FLAG_MULTI_LINE);
     }
 


### PR DESCRIPTION

This reverts #1842 because not extracting the editing ui in landscape mode left too small of a window in WPAndroid on account of the top toolbar. See [this comment](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1842#issuecomment-596628153) for more details.

To test:
1. Open post with paragraph block
2. Switch the phone to landscape mode
3. Select a paragraph block so the keyboard displays
4. Observe that the extracted editing UI is presented (i.e. there is a "Done" button and you can no longer see your post.  You can only see the keyboard and a view with the text from the paragraph block.

Before Revert | After Revert
--- | ---
 ![Screen Shot 2020-01-30 at 11 39 35 AM](https://user-images.githubusercontent.com/4656348/73470008-3ba26100-4355-11ea-9e9c-198883428187.png) | ![Screen Shot 2020-01-30 at 11 42 06 AM](https://user-images.githubusercontent.com/4656348/73470246-8fad4580-4355-11ea-9a6e-253dee85f1bb.png) 


PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
