### PR TITLE
Update Aztec-Android for alignment handling

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,8 @@
 * [Android] Floating toolbar, previously located above nested blocks, is now placed at the top of the screen
 * [iOS] Floating toolbar, previously located above nested blocks, is now placed at the bottom of the screen
 * Fix the icons in FloatingToolbar on RTL mode
+* [Android] Add alignment options for heading block
+* Fix quote block so it visually reflects selected alignment
 
 1.26.0
 ------

--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = 'v1.3.41'
+        aztecVersion = 'v1.3.42'
     }
 
     repositories {

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -30,6 +30,7 @@ import com.facebook.react.views.textinput.ContentSizeWatcher;
 import com.facebook.react.views.textinput.ReactTextInputLocalData;
 import com.facebook.react.views.textinput.ScrollWatcher;
 
+import org.wordpress.aztec.AlignmentRendering;
 import org.wordpress.aztec.AztecText;
 import org.wordpress.aztec.AztecTextFormat;
 import org.wordpress.aztec.ITextFormat;
@@ -94,7 +95,7 @@ public class ReactAztecText extends AztecText {
     };
 
     public ReactAztecText(ThemedReactContext reactContext) {
-        super(reactContext);
+        super(reactContext, AlignmentRendering.VIEW_LEVEL);
 
         setGutenbergMode(true);
 


### PR DESCRIPTION
### Description

Enables alignment on Android for non `<p>`-based blocks. In particular,
1. Enables alignment for Heading blocks on Android (was already working on iOS);
2. Applies center alignment for the Pullquote block on Android (was already working on iOS) https://github.com/wordpress-mobile/gutenberg-mobile/issues/1854; and
3. Enables alignment for the Verse block (the option was there before, but it didn't work) https://github.com/wordpress-mobile/gutenberg-mobile/issues/2037;
4. Enables alignment for the quote block on both platforms (alignment button was present, and it would update the HTML, but visually the block did not display the selected alignment) https://github.com/wordpress-mobile/gutenberg-mobile/issues/2161

⚠️ Once the [AztecEditor-Android PR](https://github.com/wordpress-mobile/AztecEditor-Android/pull/899) is merged, the [`aztecVersion` in this PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/2006/files#diff-69ce5125e256f73357d6b4e8312c9fcfR15) must be updated before this is merged.

### Related PRs

https://github.com/wordpress-mobile/AztecEditor-Android/pull/899
https://github.com/WordPress/gutenberg/pull/21803
https://github.com/wordpress-mobile/WordPress-Android/pull/11752

### Testing

These tests should all be performed on both iOS and Android.

#### Heading, Verse, and Quote Blocks
`[Heading, Verse, Quote].forEach { block ->`
  1. Select a ^`block`^
  2. Change the alignment for the block
  3. Observe the text visually updates to reflect the new alignment
  4. Verify that the HTML is updated with the new alignment

`}`

#### Pullquote Block
1. Verify that the text in the Pullquote block has center alignment

#### Regressions
Verify that:
- Alignment still works on Paragraph blocks
- Image and video captions are still centrally aligned

### PR submission checklist

- [X] I have considered adding unit tests where possible.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
