### PR TITLE
Update Gutenberg ref to use video-alt2 icon

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.25.0
+------
+* Improve icon on the "Take a Video" media option
+
 1.24.0
 ------
 * New block: Latest Posts


### PR DESCRIPTION
Fixes #1697 

Improves the "Take a Video" option in the choose media bottom sheet by using a different icon than the "camera" one used so far

See screenshot and testing instructions at the Gutenberg PR: https://github.com/WordPress/gutenberg/pull/20927

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
