### PR TITLE
Issue/fix spacer max

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -21,7 +21,7 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - Gutenberg (1.23.0):
+  - Gutenberg (1.24.0):
     - React (= 0.61.5)
     - React-CoreModules (= 0.61.5)
     - React-RCTImage (= 0.61.5)
@@ -239,10 +239,10 @@ PODS:
     - React
   - RNSVG (9.13.6-gb):
     - React
-  - RNTAztecView (1.23.0):
+  - RNTAztecView (1.24.0):
     - React-Core
-    - WordPress-Aztec-iOS (= 1.16.0)
-  - WordPress-Aztec-iOS (1.16.0)
+    - WordPress-Aztec-iOS (= 1.17.0)
+  - WordPress-Aztec-iOS (1.17.0)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -367,7 +367,7 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 118d0d177724c2d67f08a59136eb29ef5943ec75
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  Gutenberg: fd94d54ccf8605564288cc6ef0f762da70f18b01
+  Gutenberg: 8cdb2c1e818d3ccdda5b546ad87f3024aaf95c80
   RCTRequired: b153add4da6e7dbc44aebf93f3cf4fcae392ddf1
   RCTTypeSafety: 9aa1b91d7f9310fc6eadc3cf95126ffe818af320
   React: b6a59ef847b2b40bb6e0180a97d0ca716969ac78
@@ -393,8 +393,8 @@ SPEC CHECKSUMS:
   ReactCommon: 198c7c8d3591f975e5431bec1b0b3b581aa1c5dd
   ReactNativeDarkMode: f61376360c5d983907e5c316e8e1c853a8c2f348
   RNSVG: 68a534a5db06dcbdaebfd5079349191598caef7b
-  RNTAztecView: 48948d6a92e3202dca86fbb3c579b0b3065c89fd
-  WordPress-Aztec-iOS: 64a2989d25befb5ce086fac440315f696026ffd5
+  RNTAztecView: 8d9f78ce613bec2de7ab33bd22829ceff28a7c7e
+  WordPress-Aztec-iOS: 2a9fb6c2a23284f53d6d69ada43c50b5fddc7c3b
   Yoga: f2a7cd4280bfe2cca5a7aed98ba0eb3d1310f18b
 
 PODFILE CHECKSUM: 2ca635b0121a10753500623fbaee9edd0fe6ef92


### PR DESCRIPTION
Fix issue where spacers with more than 500 height were being resized automatically to 500 when opening settings

GB PR: https://github.com/WordPress/gutenberg/pull/20984

To test:
 - Open the demo app
 - Add a spacer block
 - Switch to HTML mode
 - Change the height of the spacer to something larger than 500
 - Switch to visual mode
 - Open the setting of the block
 - Check that you can see the larger value and edit the value.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
