### PR TITLE
Issue/469 code block scroll to caret

### DIFF
--- a/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -29,6 +29,20 @@ class RCTAztecView: Aztec.TextView {
         }
     }
 
+    @objc var enableAutoCorrection: Bool = true {
+        didSet {
+            if enableAutoCorrection {
+                autocorrectionType = .default
+                autocapitalizationType = .sentences
+                spellCheckingType = .default
+            } else {
+                autocorrectionType = .no
+                autocapitalizationType = .none
+                spellCheckingType = .no
+            }
+        }
+    }
+
     override var textAlignment: NSTextAlignment {
         set {
             super.textAlignment = newValue

--- a/react-native-aztec/ios/RNTAztecView/RCTAztecViewManager.m
+++ b/react-native-aztec/ios/RNTAztecView/RCTAztecViewManager.m
@@ -28,6 +28,7 @@ RCT_EXPORT_VIEW_PROPERTY(fontSize, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(fontWeight, NSString)
 
 RCT_EXPORT_VIEW_PROPERTY(disableEditingMenu, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(enableAutoCorrection, BOOL)
 RCT_REMAP_VIEW_PROPERTY(textAlign, textAlignment, NSTextAlignment)
 RCT_REMAP_VIEW_PROPERTY(selectionColor, tintColor, UIColor)
 


### PR DESCRIPTION
Fixes #469 

Replace PlainText on the Code block edit for RichText to allow autoscroll to caret to work.

GB PR: https://github.com/WordPress/gutenberg/pull/21077

To test:
 - Start the demo app
 - Add a code block
 - Play around with it to check if the following works:
 - Write code on it with multiple lines
 - Switch to HTML and Visual and check if all is correct.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
