### PR TITLE
Feature/revert 1675 dark mode android integration

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,7 +8,6 @@
 * Fix Quote block's left border not being visible in Dark Mode
 * Added Starter Page Templates: when you create a new page, we now show you a few templates to get started more quickly.
 * Fix crash when pasting HTML content with embeded images on paragraphs
-* [Android] Dark Mode
 
 1.23.0
 ------

--- a/android/app/src/main/java/com/gutenberg/MainApplication.java
+++ b/android/app/src/main/java/com/gutenberg/MainApplication.java
@@ -1,7 +1,6 @@
 package com.gutenberg;
 
 import android.app.Application;
-import android.content.res.Configuration;
 import android.os.Bundle;
 import android.util.Log;
 
@@ -127,8 +126,7 @@ public class MainApplication extends Application implements ReactApplication {
 
             @Override
             public void performRequest(String path, Consumer<String> onSuccess, Consumer<Bundle> onError) {}
-
-        }, isDarkMode());
+        });
 
         return new ReactNativeHost(this) {
             @Override
@@ -153,13 +151,6 @@ public class MainApplication extends Application implements ReactApplication {
                 return "index";
             }
         };
-    }
-
-    private boolean isDarkMode() {
-        Configuration configuration = getResources().getConfiguration();
-        int currentNightMode = configuration.uiMode & Configuration.UI_MODE_NIGHT_MASK;
-
-        return currentNightMode == Configuration.UI_MODE_NIGHT_YES;
     }
 
     @Override

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -356,14 +356,6 @@ public class ReactAztecManager extends BaseViewManager<ReactAztecText, LayoutSha
         }
     }
 
-    @ReactProp(name = "linkTextColor", customType = "Color")
-    public void setLinkTextColor(ReactAztecText view, @Nullable Integer color) {
-        view.setLinkFormatter(new LinkFormatter(view,
-                new LinkFormatter.LinkStyle(
-                        color, true)
-        ));
-    }
-
     /* End of the code taken from ReactTextInputManager */
 
     @ReactProp(name = "color", customType = "Color")

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
@@ -1,5 +1,6 @@
 package org.wordpress.mobile.ReactNativeGutenbergBridge;
 
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -23,9 +23,7 @@ import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.
 import org.wordpress.mobile.WPAndroidGlue.MediaOption;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModule {
     private final ReactApplicationContext mReactContext;
@@ -37,7 +35,6 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
     private static final String EVENT_NAME_FOCUS_TITLE = "setFocusOnTitle";
     private static final String EVENT_NAME_MEDIA_UPLOAD = "mediaUpload";
     private static final String EVENT_NAME_MEDIA_APPEND = "mediaAppend";
-    private static final String EVENT_NAME_PREFERRED_COLOR_SCHEME = "preferredColorScheme";
 
     private static final String MAP_KEY_UPDATE_HTML = "html";
     private static final String MAP_KEY_UPDATE_TITLE = "title";
@@ -47,8 +44,6 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
     private static final String MAP_KEY_MEDIA_FILE_UPLOAD_MEDIA_TYPE = "mediaType";
     private static final String MAP_KEY_MEDIA_FILE_UPLOAD_MEDIA_PROGRESS = "progress";
     private static final String MAP_KEY_MEDIA_FILE_UPLOAD_MEDIA_SERVER_ID = "mediaServerId";
-
-    private static final String MAP_KEY_IS_PREFERRED_COLOR_SCHEME_DARK = "isPreferredColorSchemeDark";
 
     private static final int MEDIA_UPLOAD_STATE_UPLOADING = 1;
     private static final int MEDIA_UPLOAD_STATE_SUCCEEDED = 2;
@@ -62,12 +57,10 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
     private static final String MEDIA_SOURCE_DEVICE_CAMERA = "DEVICE_CAMERA";
     private static final String MEDIA_SOURCE_MEDIA_EDITOR = "MEDIA_EDITOR";
 
-    private boolean mIsDarkMode;
 
     public RNReactNativeGutenbergBridgeModule(ReactApplicationContext reactContext,
-            GutenbergBridgeJS2Parent gutenbergBridgeJS2Parent, boolean isDarkMode) {
+            GutenbergBridgeJS2Parent gutenbergBridgeJS2Parent) {
         super(reactContext);
-        mIsDarkMode = isDarkMode;
         mReactContext = reactContext;
         mGutenbergBridgeJS2Parent = gutenbergBridgeJS2Parent;
     }
@@ -75,14 +68,6 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
     @Override
     public String getName() {
         return "RNReactNativeGutenbergBridge";
-    }
-
-
-    @Override
-    public Map<String, Object> getConstants() {
-        final HashMap<String, Object> constants = new HashMap<>();
-        constants.put("isInitialColorSchemeDark", mIsDarkMode);
-        return constants;
     }
 
     private void emitToJS(String eventName, @Nullable WritableMap data) {
@@ -116,12 +101,6 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
         writableMap.putString(MAP_KEY_MEDIA_FILE_UPLOAD_MEDIA_URL, mediaUri);
         writableMap.putInt(MAP_KEY_MEDIA_FILE_UPLOAD_MEDIA_ID, mediaId);
         emitToJS(EVENT_NAME_MEDIA_APPEND, writableMap);
-    }
-
-    public void setPreferredColorScheme(boolean isDarkMode) {
-        WritableMap writableMap = new WritableNativeMap();
-        writableMap.putBoolean(MAP_KEY_IS_PREFERRED_COLOR_SCHEME_DARK, isDarkMode);
-        emitToJS(EVENT_NAME_PREFERRED_COLOR_SCHEME, writableMap);
     }
 
     @ReactMethod

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgePackage.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgePackage.java
@@ -10,26 +10,21 @@ import java.util.Collections;
 import java.util.List;
 
 public class RNReactNativeGutenbergBridgePackage implements ReactPackage {
-    private final GutenbergBridgeJS2Parent mGutenbergBridgeJS2Parent;
-    private final boolean mIsDarkMode;
-
+    private GutenbergBridgeJS2Parent mGutenbergBridgeJS2Parent;
     private RNReactNativeGutenbergBridgeModule mRNReactNativeGutenbergBridgeModule;
 
     public RNReactNativeGutenbergBridgeModule getRNReactNativeGutenbergBridgeModule() {
         return mRNReactNativeGutenbergBridgeModule;
     }
 
-    public RNReactNativeGutenbergBridgePackage(GutenbergBridgeJS2Parent gutenbergBridgeJS2Parent,
-                                               boolean isDarkMode) {
+    public RNReactNativeGutenbergBridgePackage(GutenbergBridgeJS2Parent gutenbergBridgeJS2Parent) {
         mGutenbergBridgeJS2Parent = gutenbergBridgeJS2Parent;
-        mIsDarkMode = isDarkMode;
     }
 
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         mRNReactNativeGutenbergBridgeModule = new RNReactNativeGutenbergBridgeModule(reactContext,
-                mGutenbergBridgeJS2Parent,
-                mIsDarkMode);
+                mGutenbergBridgeJS2Parent);
         return Arrays.<NativeModule>asList(mRNReactNativeGutenbergBridgeModule);
     }
 

--- a/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/react-native-gutenberg-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -100,7 +100,6 @@ public class WPAndroidGlueCode {
 
     private static OkHttpHeaderInterceptor sAddCookiesInterceptor = new OkHttpHeaderInterceptor();
     private static OkHttpClient sOkHttpClient = new OkHttpClient.Builder().addInterceptor(sAddCookiesInterceptor).build();
-    private boolean mIsDarkMode;
 
     public void onCreate(Context context) {
         SoLoader.init(context, /* native exopackage */ false);
@@ -330,7 +329,7 @@ public class WPAndroidGlueCode {
             public void logUserEvent(GutenbergUserEvent event, ReadableMap eventProperties) {
                 mOnLogGutenbergUserEventListener.onGutenbergUserEvent(event, eventProperties.toHashMap());
             }
-        }, mIsDarkMode);
+        });
 
         return Arrays.asList(
                 new MainReactPackage(getMainPackageConfig(getImagePipelineConfig(sOkHttpClient))),
@@ -354,18 +353,15 @@ public class WPAndroidGlueCode {
     @Deprecated
     public void onCreateView(Context initContext, boolean htmlModeEnabled,
                              Application application, boolean isDebug, boolean buildGutenbergFromSource,
-                             boolean isNewPost, String localeString, Bundle translations, int colorBackground, boolean isDarkMode) {
+                             boolean isNewPost, String localeString, Bundle translations) {
         onCreateView(initContext, htmlModeEnabled, application, isDebug, buildGutenbergFromSource, "post", isNewPost
-        , localeString, translations, colorBackground, isDarkMode);
+        , localeString, translations);
     }
 
     public void onCreateView(Context initContext, boolean htmlModeEnabled,
                              Application application, boolean isDebug, boolean buildGutenbergFromSource,
-                             String postType, boolean isNewPost, String localeString, Bundle translations,
-                             int colorBackground, boolean isDarkMode) {
-        mIsDarkMode = isDarkMode;
+                             String postType, boolean isNewPost, String localeString, Bundle translations) {
         mReactRootView = new ReactRootView(new MutableContextWrapper(initContext));
-        mReactRootView.setBackgroundColor(colorBackground);
 
         ReactInstanceManagerBuilder builder =
                 ReactInstanceManager.builder()
@@ -379,8 +375,11 @@ public class WPAndroidGlueCode {
             builder.setBundleAssetName("index.android.bundle");
         }
         mReactInstanceManager = builder.build();
-        mReactInstanceManager.addReactInstanceEventListener(context -> {
-            mReactContext = context;
+        mReactInstanceManager.addReactInstanceEventListener(new ReactInstanceManager.ReactInstanceEventListener() {
+            @Override
+            public void onReactContextInitialized(ReactContext context) {
+                mReactContext = context;
+            }
         });
         Bundle initialProps = mReactRootView.getAppProperties();
         if (initialProps == null) {
@@ -406,9 +405,7 @@ public class WPAndroidGlueCode {
                                   RequestExecutor fetchExecutor,
                                   OnImageFullscreenPreviewListener onImageFullscreenPreviewListener,
                                   OnMediaEditorListener onMediaEditorListener,
-                                  OnLogGutenbergUserEventListener onLogGutenbergUserEventListener,
-                                  boolean isDarkMode) {
-
+                                  OnLogGutenbergUserEventListener onLogGutenbergUserEventListener) {
         MutableContextWrapper contextWrapper = (MutableContextWrapper) mReactRootView.getContext();
         contextWrapper.setBaseContext(viewGroup.getContext());
 
@@ -429,10 +426,6 @@ public class WPAndroidGlueCode {
 
         viewGroup.addView(mReactRootView, 0,
                 new LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
-
-        if (mReactContext != null) {
-            setPreferredColorScheme(isDarkMode);
-        }
 
         refocus();
     }
@@ -504,14 +497,6 @@ public class WPAndroidGlueCode {
     public void appendNewMediaBlock(int mediaId, String mediaUri, String mediaType) {
         mRnReactNativeGutenbergBridgePackage.getRNReactNativeGutenbergBridgeModule()
                                             .appendNewMediaBlock(mediaId, mediaUri, mediaType);
-    }
-
-    public void setPreferredColorScheme(boolean isDarkMode) {
-        if (mIsDarkMode != isDarkMode) {
-            mIsDarkMode = isDarkMode;
-            mRnReactNativeGutenbergBridgePackage.getRNReactNativeGutenbergBridgeModule()
-                                                .setPreferredColorScheme(isDarkMode);
-        }
     }
 
     public void setTitle(String title) {

--- a/react-native-gutenberg-bridge/index.js
+++ b/react-native-gutenberg-bridge/index.js
@@ -10,8 +10,6 @@ const isIOS = Platform.OS === 'ios';
 
 const gutenbergBridgeEvents = new NativeEventEmitter( RNReactNativeGutenbergBridge );
 
-export const { isInitialColorSchemeDark } = RNReactNativeGutenbergBridge;
-
 export const mediaSources = {
 	deviceLibrary: 'DEVICE_MEDIA_LIBRARY',
 	deviceCamera: 'DEVICE_CAMERA',
@@ -70,10 +68,6 @@ export function subscribeMediaUpload( callback ) {
 
 export function subscribeMediaAppend( callback ) {
 	return gutenbergBridgeEvents.addListener( 'mediaAppend', callback );
-}
-
-export function subscribePreferredColorScheme( callback ) {
-	return gutenbergBridgeEvents.addListener( 'preferredColorScheme', callback );
 }
 
 /**


### PR DESCRIPTION
This reverts dark mode integration PR: https://github.com/WordPress/gutenberg/pull/19293
until we don't fix a bug in gb mobile: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2056

GB PR: https://github.com/WordPress/gutenberg/pull/21113

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
