### PR TITLE
Add tests for Latest-Posts Bock

### DIFF
--- a/__device-tests__/gutenberg-editor-latest-posts.test.js
+++ b/__device-tests__/gutenberg-editor-latest-posts.test.js
@@ -1,0 +1,56 @@
+/**
+ * @format
+ * */
+
+/**
+ * Internal dependencies
+ */
+import EditorPage from './pages/editor-page';
+import {
+	setupDriver,
+	isLocalEnvironment,
+	stopDriver,
+} from './helpers/utils';
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000000;
+
+describe( 'Gutenberg Editor Latest Post Block tests', () => {
+	let driver;
+	let editorPage;
+	let allPassed = true;
+
+	// Use reporter for setting status for saucelabs Job
+	if ( ! isLocalEnvironment() ) {
+		const reporter = {
+			specDone: async ( result ) => {
+				allPassed = allPassed && result.status !== 'failed';
+			},
+		};
+
+		jasmine.getEnv().addReporter( reporter );
+	}
+
+	beforeAll( async () => {
+		driver = await setupDriver();
+		editorPage = new EditorPage( driver );
+	} );
+
+	it( 'should be able to see visual editor', async () => {
+		await expect( editorPage.getBlockList() ).resolves.toBe( true );
+	} );
+
+	it( 'should be able to add a Latests-Posts block', async () => {
+		await editorPage.addNewLatestPostsBlock();
+		const latestPostsBlock = await editorPage.getLatestPostsBlockAtPosition( 1 );
+
+		expect( latestPostsBlock ).toBeTruthy();
+		await editorPage.removeLatestPostsBlockAtPosition( 1 );
+	} );
+
+	afterAll( async () => {
+		if ( ! isLocalEnvironment() ) {
+			driver.sauceJobStatus( allPassed );
+		}
+		await stopDriver( driver );
+	} );
+} );

--- a/__device-tests__/pages/editor-page.js
+++ b/__device-tests__/pages/editor-page.js
@@ -21,6 +21,7 @@ export default class EditorPage {
 	headingBlockName = 'Heading';
 	imageBlockName = 'Image';
 	galleryBlockName = 'Gallery';
+	latestPostsBlockName = 'Latest Posts';
 	unorderedListButtonName = 'Convert to unordered list';
 	orderedListButtonName = 'Convert to ordered list';
 
@@ -431,5 +432,21 @@ export default class EditorPage {
 		const textViewElement = await this.getTextViewForHeadingBlock( block, false );
 		const text = await textViewElement.text();
 		return text.toString();
+	}
+
+	// ============================
+	// Latest-Posts Block functions
+	// ============================
+
+	async addNewLatestPostsBlock() {
+		await this.addNewBlock( this.latestPostsBlockName );
+	}
+
+	async getLatestPostsBlockAtPosition( position: number ) {
+		return this.getBlockAtPosition( position, this.latestPostsBlockName );
+	}
+
+	async removeLatestPostsBlockAtPosition( position: number ) {
+		return await this.removeBlockAtPosition( position, this.latestPostsBlockName );
 	}
 }

--- a/__device-tests__/pages/editor-page.js
+++ b/__device-tests__/pages/editor-page.js
@@ -162,8 +162,25 @@ export default class EditorPage {
 		await addButton.click();
 
 		// Click on block of choice
-		const blockButton = await this.driver.elementByAccessibilityId( blockName );
+		const blockButton = await this.findBlockButton( blockName );
 		await blockButton.click();
+	}
+
+	// Attempts to find the given block button in the block inserter control.
+	async findBlockButton( blockName: string ) {
+		// If running on iOS returns the result of the look up as no scrolling is necessary for offscreen items.
+		if ( ! isAndroid() ) {
+			return await this.driver.elementByAccessibilityId( blockName );
+		}
+
+		// Checks if the Block Button is available, and if not will scroll to the second half of the available buttons.
+		if ( ! await this.driver.hasElementByAccessibilityId( blockName ) ) {
+			for ( let step = 0; step < 5; step++ ) {
+				await this.driver.pressKeycode( 20 ); // Press the Down arrow to force a scroll.
+			}
+		}
+
+		return await this.driver.elementByAccessibilityId( blockName );
 	}
 
 	async clickToolBarButton( buttonName: string ) {

--- a/src/initial-html.js
+++ b/src/initial-html.js
@@ -226,4 +226,6 @@ else:
 <p class="has-text-color has-text-align-center has-large-font-size has-very-light-gray-color">Cool cover</p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->
+
+<!-- wp:latest-posts {"displayPostContent":true,"displayPostDate":true} /-->
 `;

--- a/src/test/api-fetch-setup.test.js
+++ b/src/test/api-fetch-setup.test.js
@@ -11,6 +11,7 @@ const supportedPaths = [
 	'wp/v2/media/54/',
 	'wp/v2/media/',
 	'wp/v2/media?context=edit&_locale=user',
+	'wp/v2/categories/',
 ];
 
 const unsupportedPaths = [


### PR DESCRIPTION
Adds a device test for latest posts and adds the block to the initial html in order to help catch regressions

To test:
The CI run of the device tests should be enough to validate

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
