### PR TITLE
Disable align controls for the Heading block in Android

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 * Improve icon on the "Take a Video" media option
 * Removed the dimming effect on unselected blocks
 * Enabled edit button over image block for Android
-* Add alignment toolbar for heading
+* [iOS] Add alignment options for heading block
 * Implemented dropdown toolbar for alignment toolbar in Heading, Paragraph, Image, MediaText blocks
 * Block Editor: When editing link settings, tapping the keyboard return button now closes the settings panel as well as closing the keyboard.
 


### PR DESCRIPTION
GB PR: https://github.com/WordPress/gutenberg/pull/21268

To test:
  - Start the demo in Android
 - Check that on heading block the align toolbar is not visible/available.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
