### PR TITLE
New template for release PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release_pull_request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_pull_request.md
@@ -1,0 +1,37 @@
+Release for Gutenberg Mobile v1.XX.Y
+
+## Related PRs
+
+- Gutenberg: https://github.com/WordPress/gutenberg/pull/
+- WPAndroid: https://github.com/wordpress-mobile/WordPress-Android/pull/
+- WPiOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/
+
+- Aztec-iOS: N/A
+- Aztec-Android: N/A
+
+## Extra PRs that Landed After the Release Was Cut
+
+- [ ]  PR 1
+- [ ]  PR 2
+
+## Changes
+
+ - Change 1
+ - Change 2
+
+## Test plan
+
+- Use the main WP apps to test the changes above. 
+- Check WPAndroid and WPiOS PRs if there are specific tests to run.
+- Smoke test the main WP apps for [general writing flow](https://github.com/wordpress-mobile/test-cases/tree/master/test-cases/gutenberg/writing-flow).
+
+## Release Submission Checklist
+
+- [ ] Release number was bumped
+- [ ] Aztec dependencies are pointing to a stable release
+  - iOS: 'grep WordPressAztec-iOS RNTAztecView.podspec'
+  - Android: 'grep aztecVersion react-native-aztec/android/build.gradle'
+- [ ] Gutenberg 'Podfile' and 'Podfile.lock' inside './ios/' are updated to the release number
+- [ ] Bundle package of the release is updated 
+- [ ] Check if `RELEASE-NOTES.txt` is updated with all the changes that made it to the release
+

--- a/.github/PULL_REQUEST_TEMPLATE/release_pull_request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_pull_request.md
@@ -6,8 +6,8 @@ Release for Gutenberg Mobile v1.XX.Y
 - WPAndroid: https://github.com/wordpress-mobile/WordPress-Android/pull/
 - WPiOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/
 
-- Aztec-iOS: N/A
-- Aztec-Android: N/A
+- Aztec-iOS: https://github.com/wordpress-mobile/AztecEditor-iOS/pull/
+- Aztec-Android: https://github.com/wordpress-mobile/AztecEditor-Android/pull
 
 ## Extra PRs that Landed After the Release Was Cut
 
@@ -15,6 +15,7 @@ Release for Gutenberg Mobile v1.XX.Y
 - [ ]  PR 2
 
 ## Changes
+<!-- To determine the changes you can check the RELEASE-NOTES.txt file and cross check with the list of commits that are part of the PR -->
 
  - Change 1
  - Change 2


### PR DESCRIPTION
This PR will add a new template for release PRs to make it easier to check all the steps needed and to standardize the release PRs.

This template can then be used by using this link `https://github.com/wordpress-mobile/gutenberg-mobile/compare/master...release/1.25.0?expand=1&template=release_pull_request.md`

Or just use the normal pull request flow in github and then add this to url of the pull request preview page: `?expand=1&template=release_pull_request.md`

Fixes #

To test:

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
