### PR TITLE
[UI tests] Run only canary tests on a PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
             curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" -X POST -H "Content-Type: application/octet-stream" https://saucelabs.com/rest/v1/storage/automattic/Gutenberg-$SAUCE_FILENAME.apk?overwrite=true --data-binary @./android/app/build/outputs/apk/debug/app-debug.apk
       - run:
           name: Run Device Tests
-          command: yarn device-tests
+          command: yarn device-tests-canary
           environment:
             JEST_JUNIT_OUTPUT: "reports/test-results/android-test-results.xml"
       - store_test_results:
@@ -143,7 +143,7 @@ jobs:
     - run:
         name: Run Device Tests
         command: |
-          yarn device-tests
+          yarn device-tests-canary
         environment:
           JEST_JUNIT_OUTPUT: "reports/test-results/ios-test-results.xml"
     - store_test_results:
@@ -172,6 +172,6 @@ workflows:
           platform: android
           check-tests: true
       - ios-device-checks:
-          name: Test iOS on Device
+          name: Test iOS on Device - Canaries
       - android-device-checks:
-          name: Test Android on Device
+          name: Test Android on Device - Canaries

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,6 +172,6 @@ workflows:
           platform: android
           check-tests: true
       - ios-device-checks:
-          name: Test iOS on Device
+          name: Test iOS on Device - Canaries
       - android-device-checks:
-          name: Test Android on Device
+          name: Test Android on Device - Canaries

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,6 +172,6 @@ workflows:
           platform: android
           check-tests: true
       - ios-device-checks:
-          name: Test iOS on Device - Canaries
+          name: Test iOS on Device
       - android-device-checks:
-          name: Test Android on Device - Canaries
+          name: Test Android on Device

--- a/__device-tests__/gutenberg-editor-heading.test.js
+++ b/__device-tests__/gutenberg-editor-heading.test.js
@@ -16,7 +16,7 @@ import testData from './helpers/test-data';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000000;
 
-describe( 'Gutenberg Editor tests', () => {
+describe( 'Gutenberg Editor tests @canary', () => {
 	let driver;
 	let editorPage;
 	let allPassed = true;

--- a/__device-tests__/gutenberg-editor-image.test.js
+++ b/__device-tests__/gutenberg-editor-image.test.js
@@ -18,7 +18,7 @@ import testData from './helpers/test-data';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000000;
 
-describe( 'Gutenberg Editor Image Block tests', () => {
+describe( 'Gutenberg Editor Image Block tests @canary', () => {
 	let driver;
 	let editorPage;
 	let allPassed = true;

--- a/__device-tests__/gutenberg-editor-lists.test.js
+++ b/__device-tests__/gutenberg-editor-lists.test.js
@@ -16,7 +16,7 @@ import testData from './helpers/test-data';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000000;
 
-describe( 'Gutenberg Editor tests for List block', () => {
+describe( 'Gutenberg Editor tests for List block @canary', () => {
 	let driver;
 	let editorPage;
 	let allPassed = true;

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "test:inside-gb": "cross-env NODE_ENV=test jest --verbose --config jest_gb.config.js",
     "test:debug": "cross-env NODE_ENV=test node --inspect-brk node_modules/.bin/jest --runInBand --verbose --config jest.config.js",
     "device-tests": "cross-env NODE_ENV=test jest --no-cache --maxWorkers=3 --reporters=default --reporters=jest-junit --verbose --config jest_ui.config.js",
+    "device-tests-canary": "cross-env NODE_ENV=test jest --no-cache --maxWorkers=2 --testNamePattern=@canary --reporters=default --reporters=jest-junit --verbose --config jest_ui.config.js",
     "device-tests:local": "cross-env NODE_ENV=test jest --runInBand --reporters=default --reporters=jest-junit --detectOpenHandles --verbose --config jest_ui.config.js",
     "device-tests:debug": "cross-env NODE_ENV=test node $NODE_DEBUG_OPTION --inspect-brk node_modules/jest/bin/jest --runInBand --reporters=default --reporters=jest-junit --detectOpenHandles --verbose --config jest_ui.config.js",
     "test:e2e": "yarn test:e2e:android && yarn test:e2e:ios",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "test:inside-gb": "cross-env NODE_ENV=test jest --verbose --config jest_gb.config.js",
     "test:debug": "cross-env NODE_ENV=test node --inspect-brk node_modules/.bin/jest --runInBand --verbose --config jest.config.js",
     "device-tests": "cross-env NODE_ENV=test jest --no-cache --maxWorkers=3 --reporters=default --reporters=jest-junit --verbose --config jest_ui.config.js",
-    "device-tests-canary": "cross-env NODE_ENV=test jest --no-cache --maxWorkers=2 --testNamePattern=@canary --reporters=default --reporters=jest-junit --verbose --config jest_ui.config.js",
+    "device-tests-canary": "cross-env NODE_ENV=test jest --forceExit --detectOpenHandles --no-cache --maxWorkers=2 --testNamePattern=@canary --reporters=default --reporters=jest-junit --verbose --config jest_ui.config.js",
     "device-tests:local": "cross-env NODE_ENV=test jest --runInBand --reporters=default --reporters=jest-junit --detectOpenHandles --verbose --config jest_ui.config.js",
     "device-tests:debug": "cross-env NODE_ENV=test node $NODE_DEBUG_OPTION --inspect-brk node_modules/jest/bin/jest --runInBand --reporters=default --reporters=jest-junit --detectOpenHandles --verbose --config jest_ui.config.js",
     "test:e2e": "yarn test:e2e:android && yarn test:e2e:ios",


### PR DESCRIPTION
Run a subset of tests instead of a full suite against every PR. This is an experiment and the purpose of it is to reduce waiting time for CircleCI jobs and avoid running full suite against every commit. More info - p9ugOq-106-p2

Things to consider before we go with it:
- What tests/functionalities we want to cover with canary tests?
- Number of [workers](https://github.com/wordpress-mobile/gutenberg-mobile/pull/2099/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R105)? With a smaller number of tests the jobs will wait less time when we have _high traffic_. But, should we reduce number of workers? Right now it's [three](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/package.json#L104). 

To test:
Look at the tests in CircleCI jobs. Are they green? 
What about execution time? Are they faster than before? 

Note:
This option should not go to `develop` before we add the option to run the full suite against PR.  

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
