### PR TITLE
Update react-native-video dependency to remove Apache 2.0 dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "react-native-safe-area": "^0.5.0",
     "react-native-svg": "git+https://github.com/wordpress-mobile/react-native-svg.git#a628e92990a2404e30a0086f168bd2b5b7b4ce96",
     "react-native-url-polyfill": "^1.1.2",
-    "react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#c43bdf6b06d361da399b98b8d2e32b578fa188ac",
+    "react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#5c6697afc5244883615acc84f054a1ed2a0c6ed0",
     "react-redux": "^5.0.7",
     "redux": "^3.7.2",
     "redux-multi": "^0.1.12",

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "react-native-safe-area": "^0.5.0",
     "react-native-svg": "git+https://github.com/wordpress-mobile/react-native-svg.git#a628e92990a2404e30a0086f168bd2b5b7b4ce96",
     "react-native-url-polyfill": "^1.1.2",
-    "react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#5c6697afc5244883615acc84f054a1ed2a0c6ed0",
+    "react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#6cdaddd9c81ebe2da5b28412d389cc105e156948",
     "react-redux": "^5.0.7",
     "redux": "^3.7.2",
     "redux-multi": "^0.1.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12467,9 +12467,9 @@ react-native-url-polyfill@^1.1.2:
     buffer "^5.4.3"
     whatwg-url-without-unicode "8.0.0-1"
 
-"react-native-video@git+https://github.com/wordpress-mobile/react-native-video.git#5c6697afc5244883615acc84f054a1ed2a0c6ed0":
+"react-native-video@git+https://github.com/wordpress-mobile/react-native-video.git#6cdaddd9c81ebe2da5b28412d389cc105e156948":
   version "5.0.1"
-  resolved "git+https://github.com/wordpress-mobile/react-native-video.git#5c6697afc5244883615acc84f054a1ed2a0c6ed0"
+  resolved "git+https://github.com/wordpress-mobile/react-native-video.git#6cdaddd9c81ebe2da5b28412d389cc105e156948"
   dependencies:
     prop-types "^15.5.10"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9632,11 +9632,6 @@ jszip@^3.1.3:
     readable-stream "~2.3.6"
     set-immediate-shim "~1.0.1"
 
-keymirror@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/keymirror/-/keymirror-0.1.1.tgz#918889ea13f8d0a42e7c557250eee713adc95c35"
-  integrity sha1-kYiJ6hP40KQufFVyUO7nE63JXDU=
-
 keypather@^1.10.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/keypather/-/keypather-1.10.2.tgz#e0449632d4b3e516f21cc014ce7c5644fddce614"
@@ -12472,13 +12467,11 @@ react-native-url-polyfill@^1.1.2:
     buffer "^5.4.3"
     whatwg-url-without-unicode "8.0.0-1"
 
-"react-native-video@git+https://github.com/wordpress-mobile/react-native-video.git#c43bdf6b06d361da399b98b8d2e32b578fa188ac":
+"react-native-video@git+https://github.com/wordpress-mobile/react-native-video.git#5c6697afc5244883615acc84f054a1ed2a0c6ed0":
   version "5.0.1"
-  resolved "git+https://github.com/wordpress-mobile/react-native-video.git#c43bdf6b06d361da399b98b8d2e32b578fa188ac"
+  resolved "git+https://github.com/wordpress-mobile/react-native-video.git#5c6697afc5244883615acc84f054a1ed2a0c6ed0"
   dependencies:
-    keymirror "^0.1.1"
     prop-types "^15.5.10"
-    shaka-player "^2.4.4"
 
 react-native@0.61.5:
   version "0.61.5"
@@ -13486,11 +13479,6 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
-
-shaka-player@^2.4.4:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-2.5.3.tgz#f32f47024a6aed3dd66d8098e08b1a16546f3683"
-  integrity sha512-9HwdBXiMNglq2IcjTWCMIwv4s1gucyHEOYWc6YX5NcxyiyQfVP+VG3eADWJXgFv3RF3mma1YPKX83q0PbyxoAQ==
 
 shallowequal@^1.0.2:
   version "1.1.0"


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/19860

react-native-video PR: https://github.com/wordpress-mobile/react-native-video/pull/6

To test:

- Add a Video block check if behaviour stays the same
- Same for Media & Text block with a video
- Same for Cover block with a video

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
