### PR TITLE
Fixes Latests Posts Tests by expanding the scroll to button functionality

### DIFF
--- a/__device-tests__/gutenberg-editor-latest-posts.test.js
+++ b/__device-tests__/gutenberg-editor-latest-posts.test.js
@@ -40,15 +40,13 @@ describe( 'Gutenberg Editor Latest Post Block tests', () => {
 		await expect( editorPage.getBlockList() ).resolves.toBe( true );
 	} );
 
-	if ( isAndroid() ) { //limit this test to Android to temporarily avoid the problem here https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/5887/workflows/5664a5c7-2efc-4ca6-be22-eab8c1b79677/jobs/31498
-		it( 'should be able to add a Latests-Posts block', async () => {
-			await editorPage.addNewLatestPostsBlock();
-			const latestPostsBlock = await editorPage.getLatestPostsBlockAtPosition( 1 );
+	it( 'should be able to add a Latests-Posts block', async () => {
+		await editorPage.addNewLatestPostsBlock();
+		const latestPostsBlock = await editorPage.getLatestPostsBlockAtPosition( 1 );
 
-			expect( latestPostsBlock ).toBeTruthy();
-			await editorPage.removeLatestPostsBlockAtPosition( 1 );
-		} );
-	}
+		expect( latestPostsBlock ).toBeTruthy();
+		await editorPage.removeLatestPostsBlockAtPosition( 1 );
+	} );
 
 	afterAll( async () => {
 		if ( ! isLocalEnvironment() ) {

--- a/__device-tests__/gutenberg-editor-latest-posts.test.js
+++ b/__device-tests__/gutenberg-editor-latest-posts.test.js
@@ -10,7 +10,6 @@ import {
 	setupDriver,
 	isLocalEnvironment,
 	stopDriver,
-	isAndroid,
 } from './helpers/utils';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000000;

--- a/__device-tests__/pages/editor-page.js
+++ b/__device-tests__/pages/editor-page.js
@@ -163,19 +163,33 @@ export default class EditorPage {
 
 		// Click on block of choice
 		const blockButton = await this.findBlockButton( blockName );
-		await blockButton.click();
+		if ( isAndroid() ) {
+			await blockButton.click();
+		} else {
+			await this.driver.execute( 'mobile: tap', { element: blockButton, x: 10, y: 10 } );
+		}
 	}
 
 	// Attempts to find the given block button in the block inserter control.
 	async findBlockButton( blockName: string ) {
-		// Checks if the Block Button is available, and if not will scroll to the second half of the available buttons.
-		if ( ! await this.driver.hasElementByAccessibilityId( blockName ) ) {
-			for ( let step = 0; step < 5; step++ ) {
+		if ( isAndroid() ) {
+			// Checks if the Block Button is available, and if not will scroll to the second half of the available buttons.
+			while ( ! await this.driver.hasElementByAccessibilityId( blockName ) ) {
 				await this.driver.pressKeycode( 20 ); // Press the Down arrow to force a scroll.
 			}
+
+			return await this.driver.elementByAccessibilityId( blockName );
 		}
 
-		return await this.driver.elementByAccessibilityId( blockName );
+		const blockButton = await this.driver.elementByAccessibilityId( blockName );
+		const size = await this.driver.getWindowSize();
+		const height = size.height - 5;
+
+		while ( ! await blockButton.isDisplayed() ) {
+			await this.driver.execute( 'mobile: dragFromToForDuration', { fromX: 50, fromY: height, toX: 50, toY: height - 450, duration: 0.5 } );
+		}
+
+		return blockButton;
 	}
 
 	async clickToolBarButton( buttonName: string ) {


### PR DESCRIPTION
Fixes #

## Description
iOS was showing inconsistencies in being able to tap on Block Buttons. Previously the tests were using the `click` command which would send a command to the driver to handle the scroll and the tap. To get the tests to tap consistently the tap needed to be adjusted a few pixels inside the button. 

This also resulted in needed to reimplement the scroll for iOS. (Using a consistent version for iOS and Android wasn't working) 

## To test: 
Run device tests

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
