### PR TITLE
Update RELEASE-NOTES after merging Buttons

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.27.0
+------
+* New block: Buttons. From now you’ll be able to add individual Button block only inside the Buttons block
+
 1.26.0
 ------
 * [iOS] Disable ripple effect in all BottomSheet's controls.

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 1.27.0
 ------
-* New block: Buttons. From now you’ll be able to add individual Button block only inside the Buttons block
+* New block: Buttons. From now you’ll be able to add the individual Button block only inside the Buttons block
 
 1.26.0
 ------


### PR DESCRIPTION
That PR is adding a missing note about adding Buttons block after merging that feature.

To test:

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
