### PR TITLE
Updating Aztec Android ref to Release v1.3.40

### DIFF
--- a/react-native-aztec/android/build.gradle
+++ b/react-native-aztec/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = 'v1.3.39'
+        aztecVersion = 'v1.3.40'
     }
 
     repositories {


### PR DESCRIPTION
### Background
Aztec Android was updated [here](https://github.com/wordpress-mobile/AztecEditor-Android/pull/900) for new AztecToolbar customization options.

This PR is for updating Gutenberg-mobile to be on the latest Aztec Android and in sync with the WordPress Android app Aztec version. 

### Related PR
See WordPress Android update of Aztec Version to v1.3.40 here: https://github.com/wordpress-mobile/WordPress-Android/pull/11594

### Testing
You can use the following branch to test this Aztec update in WPAndroid: [woo/aztec-design-changes-TEST-gb-update](https://github.com/wordpress-mobile/WordPress-Android/tree/woo/aztec-design-changes-TEST-gb-update).

1. [x] Test blocks that use Aztec/RichText Component (Paragraph, List, Verse, etc)
2. [x] Test scrolling up and down on longer articles. 
3. [x] Test within WordPress Android app. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
