### PR TITLE
Update GB reference.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,6 @@
 ------
 * Prefill caption for image blocks when available on the Media library
 * New block: Buttons. From now you’ll be able to add the individual Button block only inside the Buttons block
-* [iOS]: Video in video blocks can now be played inline on the editor.
 
 1.26.0
 ------


### PR DESCRIPTION
Revert the video player refactor to allow playing iOS videos inline.

Related GB PR: https://github.com/WordPress/gutenberg/pull/21770

To test:
 - Start the demo app
 - Make sure the title is completely visible on the visual mode and HTML mode.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
