### PR TITLE
Fix: remove extra line in release note fo FloatingToolbar

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,6 @@
 * Prefill caption for image blocks when available on the Media library
 * New block: Buttons. From now you’ll be able to add the individual Button block only inside the Buttons block
 * [iOS]: Video in video blocks can now be played inline on the editor.
-* [iOS]: Move FloatingToolbar for nested blocks to appears of the bottom of the screen
 * [Android] Floating toolbar, previously located above nested blocks, is now placed at the top of the screen
 * [iOS] Floating toolbar, previously located above nested blocks, is now placed at the bottom of the screen
 * Fix the icons in FloatingToolbar on RTL mode


### PR DESCRIPTION
Remove extra line in `RELEASE-NOTES.txt` after merge FloatingToolbar PR

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
