### PR TITLE
Turn the git submodules to shallow by default

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "gutenberg"]
 	path = gutenberg
 	url = ../../WordPress/gutenberg.git
+	shallow = true
 [submodule "jetpack"]
 	path = jetpack
 	url = ../../Automattic/jetpack.git
+	shallow = true


### PR DESCRIPTION
Fixes #2182 

WPAndroid side PR: TBD

Our current theory is that the submodules are large enough and JitPack is not cloning then shallowly so, this PR marks the submodules as shallow by default in an attempt to minimize the size of their casual cloning.

The typical way we pull the submodules is by issuing `git submodule update --init --recursive`. The same command can still be used and it will pull a shallow copy of the submodules.

If you need to pull the whole history instead, the initial pull after a fresh clone can be: `git submodule update --no-recommend-shallow --init --recursive`

### To test A
0. Prepare for a fresh clone of the repo by going into a folder that doesn't have the repo clone yet
1. Issue `git clone --single-branch --branch try/shallow-submodules git@github.com:wordpress-mobile/gutenberg-mobile.git` to pull the repo. Wait until that finishes.
2. `cd gutenberg-mobile` to go into the clone
3. Issue `git submodule update --init --recursive` and wait until it finishes
4. `cd gutenberg` to go into the Gutenberg submodule
5. Issue `git rev-parse --is-shallow-repository` to verify it's a shallow clone. It should return `true`.
6. Issue `git fetch --unshallow` to pull the whole submodule history, to verify that it can be done.
7. Do steps 5 and 6 for the other submodule (`jetpack`) too, to verify that that one is shallow too and it can be unshallowed.

### To test B
0. Prepare for a fresh clone of the repo by going into a folder that doesn't have the repo clone yet
1. Issue `git clone --single-branch --branch try/shallow-submodules git@github.com:wordpress-mobile/gutenberg-mobile.git` to pull the repo. Wait until that finishes.
2. `cd gutenberg-mobile` to go into the clone
3. Issue `git submodule update --init --recursive --no-recommend-shallow` and wait until it finishes
4. `cd gutenberg` to go into the Gutenberg submodule
5. Issue `git rev-parse --is-shallow-repository` to verify it's a not shallow clone. It should return `false`.
6. Do the same for the other submodule (`jetpack`) too, to verify that that one is not shallow too.

PR submission checklist:

- [x] I have considered adding unit tests where possible. No unit testing applicable.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
