### PR TITLE
Update react-native-video to version 5.0.2

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -195,10 +195,10 @@ PODS:
     - React
   - react-native-slider (2.0.7):
     - React
-  - react-native-video (5.0.1):
+  - react-native-video (5.0.2):
     - React
-    - react-native-video/Video (= 5.0.1)
-  - react-native-video/Video (5.0.1):
+    - react-native-video/Video (= 5.0.2)
+  - react-native-video/Video (5.0.2):
     - React
   - React-RCTActionSheet (0.61.5):
     - React-Core/RCTActionSheetHeaders (= 0.61.5)
@@ -380,7 +380,7 @@ SPEC CHECKSUMS:
   react-native-keyboard-aware-scroll-view: ffa9152671fec9a571197ed2d02e0fcb90206e60
   react-native-safe-area: e8230b0017d76c00de6b01e2412dcf86b127c6a3
   react-native-slider: f81b89fa0c1f9a65742d33f889a194ca6653a985
-  react-native-video: 331eaf96cb034fedcc27f4f6ada3ac3cf6c0a78a
+  react-native-video: d01ed7ff1e38fa7dcc6c15c94cf505e661b7bfd0
   React-RCTActionSheet: 600b4d10e3aea0913b5a92256d2719c0cdd26d76
   React-RCTAnimation: 791a87558389c80908ed06cc5dfc5e7920dfa360
   React-RCTBlob: d89293cc0236d9cb0933d85e430b0bbe81ad1d72

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "react-native-safe-area": "^0.5.0",
     "react-native-svg": "git+https://github.com/wordpress-mobile/react-native-svg.git#a628e92990a2404e30a0086f168bd2b5b7b4ce96",
     "react-native-url-polyfill": "^1.1.2",
-    "react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#5f9ecd2ee05b7541dbc199274295078d43ba5e3f",
+    "react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#1b964b107863351ed744fc104d7952bbec3e2d4f",
     "react-redux": "^5.0.7",
     "redux": "^3.7.2",
     "redux-multi": "^0.1.12",

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "react-native-safe-area": "^0.5.0",
     "react-native-svg": "git+https://github.com/wordpress-mobile/react-native-svg.git#a628e92990a2404e30a0086f168bd2b5b7b4ce96",
     "react-native-url-polyfill": "^1.1.2",
-    "react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#6cdaddd9c81ebe2da5b28412d389cc105e156948",
+    "react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#5f9ecd2ee05b7541dbc199274295078d43ba5e3f",
     "react-redux": "^5.0.7",
     "redux": "^3.7.2",
     "redux-multi": "^0.1.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12081,9 +12081,9 @@ react-native-url-polyfill@^1.1.2:
     buffer "^5.4.3"
     whatwg-url-without-unicode "8.0.0-1"
 
-"react-native-video@git+https://github.com/wordpress-mobile/react-native-video.git#5f9ecd2ee05b7541dbc199274295078d43ba5e3f":
+"react-native-video@git+https://github.com/wordpress-mobile/react-native-video.git#1b964b107863351ed744fc104d7952bbec3e2d4f":
   version "5.0.2"
-  resolved "git+https://github.com/wordpress-mobile/react-native-video.git#5f9ecd2ee05b7541dbc199274295078d43ba5e3f"
+  resolved "git+https://github.com/wordpress-mobile/react-native-video.git#1b964b107863351ed744fc104d7952bbec3e2d4f"
   dependencies:
     prop-types "^15.5.10"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12081,9 +12081,9 @@ react-native-url-polyfill@^1.1.2:
     buffer "^5.4.3"
     whatwg-url-without-unicode "8.0.0-1"
 
-"react-native-video@git+https://github.com/wordpress-mobile/react-native-video.git#6cdaddd9c81ebe2da5b28412d389cc105e156948":
-  version "5.0.1"
-  resolved "git+https://github.com/wordpress-mobile/react-native-video.git#6cdaddd9c81ebe2da5b28412d389cc105e156948"
+"react-native-video@git+https://github.com/wordpress-mobile/react-native-video.git#5f9ecd2ee05b7541dbc199274295078d43ba5e3f":
+  version "5.0.2"
+  resolved "git+https://github.com/wordpress-mobile/react-native-video.git#5f9ecd2ee05b7541dbc199274295078d43ba5e3f"
   dependencies:
     prop-types "^15.5.10"
 


### PR DESCRIPTION
Updates the react-native-video to version 5.0.2

Related bug: https://github.com/wordpress-mobile/WordPress-iOS/issues/13885

Related PR: https://github.com/wordpress-mobile/react-native-video/pull/8

To test:
 - Start the demo app
 - Smoke test the video block.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
