### PR TITLE
Bump version number in package.json to 1.27.0

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -21,7 +21,7 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - Gutenberg (1.26.0):
+  - Gutenberg (1.27.0):
     - React (= 0.61.5)
     - React-CoreModules (= 0.61.5)
     - React-RCTImage (= 0.61.5)
@@ -239,7 +239,7 @@ PODS:
     - React
   - RNSVG (9.13.6-gb):
     - React
-  - RNTAztecView (1.26.0):
+  - RNTAztecView (1.27.0):
     - React-Core
     - WordPress-Aztec-iOS (~> 1.18.0)
   - WordPress-Aztec-iOS (1.18.0)
@@ -367,7 +367,7 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 118d0d177724c2d67f08a59136eb29ef5943ec75
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  Gutenberg: 26ae066818c65566ac0d8ce51cfc8a20b66db55c
+  Gutenberg: aa041019bf81d30c7b9c7de0f313a2d55561cc4a
   RCTRequired: b153add4da6e7dbc44aebf93f3cf4fcae392ddf1
   RCTTypeSafety: 9aa1b91d7f9310fc6eadc3cf95126ffe818af320
   React: b6a59ef847b2b40bb6e0180a97d0ca716969ac78
@@ -393,7 +393,7 @@ SPEC CHECKSUMS:
   ReactCommon: 198c7c8d3591f975e5431bec1b0b3b581aa1c5dd
   ReactNativeDarkMode: f61376360c5d983907e5c316e8e1c853a8c2f348
   RNSVG: 68a534a5db06dcbdaebfd5079349191598caef7b
-  RNTAztecView: db66aa89626b70a40c25f7bd06e7d7588fdf85db
+  RNTAztecView: 58f944218c32079d76f2542e5b762b8a4dff263b
   WordPress-Aztec-iOS: fae5d158879dfd6f36c8d0ff0cc111a0b8e36790
   Yoga: f2a7cd4280bfe2cca5a7aed98ba0eb3d1310f18b
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gutenberg-mobile",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "private": true,
   "config": {
     "jsfiles": "./*.js src/*.js src/**/*.js src/**/**/*.js",


### PR DESCRIPTION
### Description

This PR bumps the version number in `package.json` to `1.27.0`. This should have happened with the PR merging from `master` back to `develop`, (https://github.com/wordpress-mobile/gutenberg-mobile/pull/2202), but the merge conflict was resolved incorrectly in [this commit](https://github.com/wordpress-mobile/gutenberg-mobile/commit/38e88c61070318e2804a3e10f6056fba930428e2) (necessary since we do not merge directly from `master` to `develop`, but use an intermediate branch instead).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
