### PR TITLE
Update RELEASE NOTES

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.28.0
+------
+* New block: Pullquote
+
 1.27.0
 ------
 * Prefill caption for image blocks when available on the Media library
@@ -10,7 +14,6 @@
 * [Android] Add alignment options for heading block
 * Fix Quote block so it visually reflects selected alignment
 * Fix bug where buttons in page templates were not rendering correctly on web
-* New block: Pullquote
 
 1.26.0
 ------


### PR DESCRIPTION
The PR enabling Pullquote block https://github.com/wordpress-mobile/gutenberg-mobile/pull/2189 was merged after the code freeze of 1.27.0. 

This PR updates the release notes to reflect the correct version in which will be included.