### PR TITLE
Issue/update aztec ios to 1.19.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * Add support for changing background and text color in Buttons block
 * Fix the icons and buttons in Gallery, Paragraph, List and MediaText block on RTL mode
 * Remove Subscription Button from the Blog template since it didn't have an initial functionality and it is hard to configure for users.
+* [iOS] Add support for the subscript `<sub>` and superscript `<sup>`HTML elements in text blocks
 
 1.27.0
 ------

--- a/RNTAztecView.podspec
+++ b/RNTAztecView.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.xcconfig         = {'OTHER_LDFLAGS' => '-lxml2',
                         'HEADER_SEARCH_PATHS' => '/usr/include/libxml2'}
   s.dependency         'React-Core'
-  s.dependency         'WordPress-Aztec-iOS', '~> 1.18.0'
+  s.dependency         'WordPress-Aztec-iOS', '~> 1.19.0'
 
 end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -241,8 +241,8 @@ PODS:
     - React
   - RNTAztecView (1.27.0):
     - React-Core
-    - WordPress-Aztec-iOS (~> 1.18.0)
-  - WordPress-Aztec-iOS (1.18.0)
+    - WordPress-Aztec-iOS (~> 1.19.0)
+  - WordPress-Aztec-iOS (1.19.0)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -393,8 +393,8 @@ SPEC CHECKSUMS:
   ReactCommon: 198c7c8d3591f975e5431bec1b0b3b581aa1c5dd
   ReactNativeDarkMode: f61376360c5d983907e5c316e8e1c853a8c2f348
   RNSVG: 68a534a5db06dcbdaebfd5079349191598caef7b
-  RNTAztecView: 58f944218c32079d76f2542e5b762b8a4dff263b
-  WordPress-Aztec-iOS: fae5d158879dfd6f36c8d0ff0cc111a0b8e36790
+  RNTAztecView: dc2364760fad53f52defde7c01be765e77b9ba19
+  WordPress-Aztec-iOS: fb6ea6409a5228292568f665eb22ea0a0aa7ad7e
   Yoga: f2a7cd4280bfe2cca5a7aed98ba0eb3d1310f18b
 
 PODFILE CHECKSUM: 8fc85c086e46c9bb555a0c4ebda2e57ceae0a8d6

--- a/src/initial-html.js
+++ b/src/initial-html.js
@@ -27,7 +27,7 @@ Hello World
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p><b>Hello</b> World!</p>
+<p><strong>Bold</strong> <em>Italic</em> <s>Striked</s> Superscript<sup>(1)</sup> Subscript<sub>(2)</sub></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:nextpage -->


### PR DESCRIPTION
Updates Aztec to version 1.19.0

To test:
 - Smoke test the demo app, especially the text blocks
 - Check the initial content block that has the sup and sub and see if it renders correctly.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
