### PR TITLE
Fix release notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,3 @@
-1.27.1
-------
-* Remove Subscription Button from the Blog template since it didn't have an initial functionality and it is hard to configure for users.
 1.28.0
 ------
 * New block: Pullquote
@@ -9,6 +6,10 @@
 * Remove Subscription Button from the Blog template since it didn't have an initial functionality and it is hard to configure for users.
 * [iOS] Add support for the subscript `<sub>` and superscript `<sup>`HTML elements in text blocks
 * [**] Update page templates to use recently added blocks
+
+1.27.1
+------
+* Remove Subscription Button from the Blog template since it didn't have an initial functionality and it is hard to configure for users.
 
 1.27.0
 ------

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,10 +1,10 @@
 1.28.0
 ------
-* New block: Pullquote
-* Add support for changing background and text color in Buttons block
-* Fix the icons and buttons in Gallery, Paragraph, List and MediaText block on RTL mode
-* Remove Subscription Button from the Blog template since it didn't have an initial functionality and it is hard to configure for users.
-* [iOS] Add support for the subscript `<sub>` and superscript `<sup>`HTML elements in text blocks
+* [***] New block: Pullquote
+* [**] Add support for changing background and text color in Buttons block
+* [*] Fix the icons and buttons in Gallery, Paragraph, List and MediaText block on RTL mode
+* [**] Remove Subscription Button from the Blog template since it didn't have an initial functionality and it is hard to configure for users.
+* [**] [iOS] Add support for the subscript `<sub>` and superscript `<sup>`HTML elements in text blocks
 * [**] Update page templates to use recently added blocks
 
 1.27.1


### PR DESCRIPTION
Merging the 1.27.1 release back into develop [got the release notes out of order](https://github.com/wordpress-mobile/gutenberg-mobile/pull/2246/files#diff-a3d054590c32de57d87be233927e755dR1-R4). This PR fixes that and also adds priority indicators to all the 1.28.0 release notes.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
