### PR TITLE
Add selectionStart and selectionEnd to the transientEdits

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * [*] Fix merging of text blocks when text had active formatting (bold, italic, strike, link)
 * [***] Trash icon that is used to remove blocks is moved to the new menu reachable via ellipsis button in the block toolbar
 * [**] Block toolbar can now collapse when the block width is smaller than the toolbar content
+* [**] Creating undo levels less frequently
 
 1.28.0
 ------


### PR DESCRIPTION
Gutenberg PR: https://github.com/WordPress/gutenberg/pull/22492
In this PR i added `selectionStart` and `selectionEnd` to the `transientEdits` which results less undo levels created.

To test:
Tests from Gutenberg PR

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
