### PR TITLE
Insure bundle file exists when determining up-to-date status

### DIFF
--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -180,7 +180,7 @@ if (buildGutenbergMobileJSBundle) {
 
     task bundleUpToDateCheck {
         description("Checks if the inputs to the javascript bundle and the bundle itself are unchanged. \
-Only if they are is the isBundleUpToDate flag set to true. That flag is used by other tasks.")
+If they are changed, the isBundleUpToDate flag is switched to false. That flag is used by other tasks.")
 
         def isRelevantFile = { it.name.endsWithAny('.js', '.css') || it.name == 'package.json' }
         def inputFiles = {
@@ -218,24 +218,18 @@ Only if they are is the isBundleUpToDate flag set to true. That flag is used by 
         }
         inputs.files(inputFiles())
 
-        outputs.file("$buildAssetsFolder/$bundleName")
+        // We cannot use the bundle file itself as an output because it does not yet exist when this
+        // task finishes. Nevertheless, we have to declare something as an output because only tasks
+        // with outputs are run incrementally, so we're declaring a file that does not exist as the
+        // output. Since that file never exists, that "output" will always be considered "up-to-date".
+        outputs.file("nonexistentfile")
 
-        // Having this task create this file as an output because changes to
-        // the actual bundle (or even deleting the bundle file) was not triggering
-        // this task to rerun (and flip the isBundleUpToDate flag to false). Now that
-        // this second indicator file is here, which gets deleted if the project is cleaned,
-        // this task knows that it is out of date. Note that if there are changes to the
-        // bundle file though, that alone will not trigger this task to run again, so you'll
-        // need to use --rerun-tasks in that case.
-        def upToDateIndicatorFile = "$buildAssetsFolder/up-to-date-bundle-indicator"
-        outputs.file(upToDateIndicatorFile)
-
-        // set flag to true before task tries to run
-        project.ext.isBundleUpToDate = true
+        // The bundle file can only be up-to-date if a bundle file exists. If this task runs, that
+        // means some of the inputs have changed, and the isBundleUpToDate flag is set back to false
+        // because the bundle should be rebuilt.
+        project.ext.isBundleUpToDate = file("$buildAssetsFolder/$bundleName").exists()
         doLast {
-            // If this task runs, either the inputs or outputs have changed, so the bundle is out of date.
             project.ext.isBundleUpToDate = false
-            file(upToDateIndicatorFile).createNewFile()
         }
     }
 


### PR DESCRIPTION
This improves the incremental build detection following the no-jitpack changes. 

The primary motivation for this change is that the previous implementation would incorrectly find that a bundle was up-to-date if the bundle file was not present but the `upToDateIndicatorFile` was present. This could occur if there was a build failure in the `buildJSBundle` task after the `bundleUpToDateCheck` task had already created the `upToDateIndicatorFile`. It could also occur if someone deleted only the bundle file while making no other changes (see test step 9). In those scenarios, gradle would think that the bundle did not need to be rebuilt (because the `upToDateIndicatorFile` existed) even though there was no bundle file.

With these changes we no longer need the `upToDateIndicatorFile` hack. Instead, we insure that we only set the `isBundleUpToDate` flag to `true` if a bundle file exists. We do not need to check that it is the correct bundle file because the `isBundleUpToDate` flag will be flipped back to false if any of the inputs to the bundle have changed. The only way I can see that this could break would be if the bundle file were manually replaced with a different file without changing any of the bundle file's many inputs (basically all the js and css source). Even this scenario can be recovered from by running the `clean` task though.

I think this change is also an improvement because it no longer registers the bundle as an output to the `upToDateCheck` task. Any bundle file that existed at the end of that task would have been the result of a _previous_ build so registering its from-the-previous-build state as an output before the currently-in-progress build was complete would have been misleading if the current build actually generated a new bundle file. With that said, I think the worst problem that could have caused us would be to sometimes unnecessarily regenerate a bundle when it didn't need to.

To test:

1. Use WPAndroid's `develop` branch with this branch checked out
2. Insure that `wp.BUILD_GUTENBERG_FROM_SOURCE` is missing from `gradle.properties` or set to `false`.
3. Run `./gradlew clean installVanillaDebug`
4. Observe that the build takes minutes to complete and the JS bundle is created (`libs/gutenberg-mobile/react-native-gutenberg-bridge/android/build/assets/index.android.bundle`).
5. Run the resulting apk and insure you can open the block editor _without_ the metro server.
6. Reinstall the app by re-running `./gradlew installVanillaDebug` (note we are _not_ running `clean` anymore)
7. Observe that the build is much faster (10-20 seconds)
8. Run the resulting apk and insure you can open the block editor _without_ the metro server.
9. Manually delete the bundle file `libs/gutenberg-mobile/react-native-gutenberg-bridge/android/build/assets/index.android.bundle`
10. Run a third build: `./gradlew installVanillaDebug`
11. Observe that the build takes minutes to complete and the JS bundle is created (`libs/gutenberg-mobile/react-native-gutenberg-bridge/android/build/assets/index.android.bundle`).
12. Run the resulting apk and insure you can open the block editor _without_ the metro server.
13. Run `./gradlew clean`
14. Verify that the JS bundle was deleted (`libs/gutenberg-mobile/react-native-gutenberg-bridge/android/build/assets/index.android.bundle`)
15. Run a fourth build: `./gradlew installVanillaDebug`
16. Run the resulting apk and insure you can open the block editor _without_ the metro server.


PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
