### PR TITLE
[Testing] Link to existing content - RN UI implementation  - (iOS only for now)

### DIFF
--- a/react-native-gutenberg-bridge/index.js
+++ b/react-native-gutenberg-bridge/index.js
@@ -140,4 +140,8 @@ export function addMention() {
 	return RNReactNativeGutenbergBridge.addMention();
 }
 
+export function requestLinks( query, callback ) {
+	return RNReactNativeGutenbergBridge.requestLinks( query, callback );
+}
+
 export default RNReactNativeGutenbergBridge;

--- a/react-native-gutenberg-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/react-native-gutenberg-bridge/ios/GutenbergBridgeDelegate.swift
@@ -168,6 +168,11 @@ public protocol GutenbergBridgeDelegate: class {
     /// Tells the delegate that the editor requested a mention
     /// - Parameter callback: Completion handler to be called with an user mention or an error
     func gutenbergDidRequestMention(callback: @escaping (Swift.Result<String, NSError>) -> Void)
+    
+    /// Tells the delegate that the editor requested posts
+    /// -   Parameter query: The query to search for post titles
+    /// -   Parameter callback: The callback which is invoked with the results of the query
+    func gutenbergDidRequestLinks(query: String, callback: @escaping RCTResponseSenderBlock)
 }
 
 // MARK: - Optional GutenbergBridgeDelegate methods

--- a/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.m
+++ b/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.m
@@ -20,5 +20,6 @@ RCT_EXTERN_METHOD(requestImageFullscreenPreview:(NSString *)currentImageUrlStrin
 RCT_EXTERN_METHOD(requestMediaEditor:(NSString *)mediaUrl callback:(RCTResponseSenderBlock)callback)
 RCT_EXTERN_METHOD(logUserEvent:(NSString *)event properties:(NSDictionary *)properties)
 RCT_EXTERN_METHOD(addMention:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)rejecter)
+RCT_EXTERN_METHOD(requestLinks:(NSString *)query callback:(RCTResponseSenderBlock)callback)
 
 @end

--- a/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/react-native-gutenberg-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -242,6 +242,11 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
             }
         })        
     }
+    
+    @objc
+    func requestLinks(_ query: String, callback: @escaping RCTResponseSenderBlock) {
+        self.delegate?.gutenbergDidRequestLinks(query: query, callback: callback)
+    }
 }
 
 // MARK: - RCTBridgeModule delegate


### PR DESCRIPTION
This PR is for testing link to existing content (related issue: #2194 )

The branch with bundles used in the iOS CI build is here: https://github.com/wordpress-mobile/gutenberg-mobile/tree/feature/link-to-existing-content-rn-with-bundles

To test:
TBD

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
