### PR TITLE
Delete temporary RN tools before building

### DIFF
--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -33,6 +33,11 @@ def buildGutenbergMobileJSBundle =
         ? false : (rootProject.ext.has("buildGutenbergMobileJSBundle")
                 && rootProject.ext.buildGutenbergMobileJSBundle)
 
+def tempFolder = "${System.getenv('TMPDIR')}/jsbundle/${System.getenv('VERSION')}"
+def nodeFolder = file("${tempFolder}/nodejs")
+def npmFolder = file("${tempFolder}/npm")
+def yarnFolder = file("${tempFolder}/yarn")
+
 if (buildGutenbergMobileJSBundle) {
     println 'Building the Gutenberg Mobile JS bundle'
 
@@ -55,16 +60,14 @@ if (buildGutenbergMobileJSBundle) {
         // If false, it will try to use globally installed node.
         download = true
 
-        def tmpdir = "${System.getenv('TMPDIR')}/jsbundle/${System.getenv('VERSION')}"
-
         // Set the work directory for unpacking node
-        workDir = file("${tmpdir}/nodejs")
+        workDir = file(nodeFolder)
 
         // Set the work directory for NPM
-        npmWorkDir = file("${tmpdir}/npm")
+        npmWorkDir = file(npmFolder)
 
         // Set the work directory for Yarn
-        yarnWorkDir = file("${tmpdir}/yarn")
+        yarnWorkDir = file(yarnFolder)
 
         // Set the work directory where node_modules should be located
         nodeModulesDir = file("${project.projectDir}/../../")
@@ -290,10 +293,16 @@ If they are changed, the isBundleUpToDate flag is switched to false. That flag i
         delete '../../node_modules'
     }
 
+    task resetExtractedRNTools(type: Delete) {
+        println "Deleting temporary folders with extracted RN tools"
+        delete nodeFolder, npmFolder, yarnFolder
+    }
+
     preBuild.dependsOn(cleanupNodeModulesFolder)
     cleanupNodeModulesFolder.dependsOn(backupHermesDebugAAR)
     backupHermesDebugAAR.dependsOn(backupHermesReleaseAAR)
     backupHermesReleaseAAR.dependsOn(copyJSBundle)
     copyJSBundle.dependsOn(buildJSBundle)
     buildJSBundle.dependsOn(yarn_install)
+    nodeSetup.dependsOn(resetExtractedRNTools)
 }


### PR DESCRIPTION
Fixes #2302

Under circumstances that we don't quite understand yet, the gradle-node-plugin managed Node/npm/Yarn tools setup ends up in an inconsistent state and break the WPAndroid build. This PR tries to reset the state of the tools by deleting their folders (living in a temporary system directory) and let gradle-node-plugin re-setup them before building.

To test:

1. After a successful WPAndroid build, delete the `libs/gutenberg-mobile/react-native-gutenberg-bridge/android/build/assets/index.android.bundle` JS bundle and also delete the node folder `$TMPDIR/jsbundle/null/nodejs/node-v12.16.1-darwin-x64/lib/node_modules/npm`.
2. Run `./gradlew assembleVanillaDebug`. It should succeed.
3. Install the apk (or use `installVanillaDebug` in Step 2) and run the app. The block editor should work as normal.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
