### PR TITLE
Fix page templates button alignment and strings

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 * [**] Block toolbar can now collapse when the block width is smaller than the toolbar content
 * [**] Creating undo levels less frequently
 * [**] Tooltip for page template selection buttons
+* [*] Fix button alignment in page templates and make strings consistent
 
 1.28.0
 ------


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2287 https://github.com/wordpress-mobile/gutenberg-mobile/issues/2295 https://github.com/wordpress-mobile/gutenberg-mobile/issues/2267

### Related PR:

`gutenberg`: https://github.com/WordPress/gutenberg/pull/22620

## Description
This PR fixes some strings in the mobile pages templates to be consistent, and also uses center alignment for the buttons.

## To test:
In a new page, apply each of the templates and verify that the buttons are center aligned, and that the following strings are consistent "Let's build something together!" (should have an exclamation mark at the end), and "Get in Touch" (consistently title case for each instance).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
