### PR TITLE
Update to latest gutenberg

### DIFF
--- a/__device-tests__/gutenberg-editor-lists.test.js
+++ b/__device-tests__/gutenberg-editor-lists.test.js
@@ -84,8 +84,7 @@ describe( 'Gutenberg Editor tests for List block @canary', () => {
 	} );
 
 	// Prevent regression of https://github.com/wordpress-mobile/gutenberg-mobile/issues/871
-	// Commented out because it started failing. This is being tracked by https://github.com/wordpress-mobile/gutenberg-mobile/issues/2315.
-	it.skip( 'should handle spaces in a list', async () => {
+	it( 'should handle spaces in a list', async () => {
 		await editorPage.addNewBlock( listBlockName );
 		let listBlockElement = await editorPage.getBlockAtPosition( listBlockName );
 		// Click List block on Android to force EditText focus


### PR DESCRIPTION
Also re-enables the list spaces e2e test, which should now pass with the latest gutenberg code merged in.

Before merging this we need to update the gutenberg submodule ref to the gb `master` hash after https://github.com/WordPress/gutenberg/pull/22607 is merged.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
