### PR TITLE
Update Aztec to version 1.19.2

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -39,7 +39,7 @@ target 'gutenberg' do
   pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
   pod 'RNTAztecView', :path => '../RNTAztecView.podspec'
   #Use for testing non official versions of Aztec
-  #pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git', :commit => '29dff741f4b19435d75f21179e27766337de8e9d'
+  pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git', :commit => '23e40905d673673d12b61976f1212f6d97cb47cd'
   pod 'Gutenberg', :path => '../Gutenberg.podspec'
 
   target 'gutenbergTests' do

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -242,7 +242,7 @@ PODS:
   - RNTAztecView (1.28.1):
     - React-Core
     - WordPress-Aztec-iOS (~> 1.19.1)
-  - WordPress-Aztec-iOS (1.19.1)
+  - WordPress-Aztec-iOS (1.19.2)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -282,12 +282,12 @@ DEPENDENCIES:
   - ReactNativeDarkMode (from `../node_modules/react-native-dark-mode`)
   - RNSVG (from `../node_modules/react-native-svg`)
   - RNTAztecView (from `../RNTAztecView.podspec`)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git`, commit `23e40905d673673d12b61976f1212f6d97cb47cd`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
   trunk:
     - boost-for-react-native
-    - WordPress-Aztec-iOS
 
 EXTERNAL SOURCES:
   BVLinearGradient:
@@ -356,8 +356,16 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-svg"
   RNTAztecView:
     :path: "../RNTAztecView.podspec"
+  WordPress-Aztec-iOS:
+    :commit: 23e40905d673673d12b61976f1212f6d97cb47cd
+    :git: https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
+
+CHECKOUT OPTIONS:
+  WordPress-Aztec-iOS:
+    :commit: 23e40905d673673d12b61976f1212f6d97cb47cd
+    :git: https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
@@ -394,9 +402,9 @@ SPEC CHECKSUMS:
   ReactNativeDarkMode: f61376360c5d983907e5c316e8e1c853a8c2f348
   RNSVG: 68a534a5db06dcbdaebfd5079349191598caef7b
   RNTAztecView: 5cdf80ba01a7f92a456e17b6f8ba0529b1941baa
-  WordPress-Aztec-iOS: 25a9cbe204a22dd6d540d66d90b8a889421e0b42
+  WordPress-Aztec-iOS: d01bf0c5e150ae6a046f06ba63b7cc2762061c0b
   Yoga: f2a7cd4280bfe2cca5a7aed98ba0eb3d1310f18b
 
-PODFILE CHECKSUM: 8fc85c086e46c9bb555a0c4ebda2e57ceae0a8d6
+PODFILE CHECKSUM: a0e14ed675a052ac29f1a39f4dce50f2436eaec0
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
Fixes #1218 

This update of Aztec fixes another instance of the underlines going the full width of a line.

To test:
 - Create a list block
 - Write some test in an item
 - Add a link to the full text on the line
 - Check that the underline does not expand to the full line.
 - Tap Enter
 - Check that the underline does not expand to the full line.
 - Test the same using the Paragraph block and the Quote block

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
