### PR TITLE
Keep no jitpack builds from dirtying submodule

### DIFF
--- a/react-native-gutenberg-bridge/android/build.gradle
+++ b/react-native-gutenberg-bridge/android/build.gradle
@@ -181,6 +181,38 @@ if (buildGutenbergMobileJSBundle) {
     def bundleName = 'index.android.bundle'
     def jsRootDir = '../..'
 
+    // FIXME also check that submodule is properly up to date???
+    task abortIfGutenbergMobileSubmoduleNotClean(type: Exec) {
+        workingDir "../../"
+        commandLine "git", "status", "--porcelain"
+        standardOutput = new ByteArrayOutputStream()
+
+        // Storing this because we cannot access `standardOutput` in the doLast block
+        def output = { standardOutput.toString() }
+        doLast {
+            if (!output().isEmpty()) {
+                def message = "Attempting to build Gutenberg JS Bundle without a clean submodule. \
+Either clean the `libs/gutenberg-mobile` submodule (you probably want to do this) or \
+build Gutenberg from source by setting wp.BUILD_GUTENBERG_FROM_SOURCE to true."
+                throw new GradleException(message)
+            }
+        }
+    }
+
+    task removeGutenbergMobileSubmoduleChanges {
+        doLast {
+            println "Removing any changes in gutenberg-mobile project"
+            exec {
+                workingDir "../../"
+                commandLine "git", "checkout", "."
+            }
+            exec {
+                workingDir "../../"
+                commandLine "git", "clean", "-f"
+            }
+        }
+    }
+
     task bundleUpToDateCheck {
         description("Checks if the inputs to the javascript bundle and the bundle itself are unchanged. \
 If they are changed, the isBundleUpToDate flag is switched to false. That flag is used by other tasks.")
@@ -298,11 +330,13 @@ If they are changed, the isBundleUpToDate flag is switched to false. That flag i
         delete nodeFolder, npmFolder, yarnFolder
     }
 
-    preBuild.dependsOn(cleanupNodeModulesFolder)
+    preBuild.dependsOn(removeGutenbergMobileSubmoduleChanges)
+    removeGutenbergMobileSubmoduleChanges.dependsOn(cleanupNodeModulesFolder)
     cleanupNodeModulesFolder.dependsOn(backupHermesDebugAAR)
     backupHermesDebugAAR.dependsOn(backupHermesReleaseAAR)
     backupHermesReleaseAAR.dependsOn(copyJSBundle)
     copyJSBundle.dependsOn(buildJSBundle)
     buildJSBundle.dependsOn(yarn_install)
     nodeSetup.dependsOn(resetExtractedRNTools)
+    resetExtractedRNTools.dependsOn(abortIfGutenbergMobileSubmoduleNotClean)
 }


### PR DESCRIPTION
WIP 

This is just a quick implementation of an idea I had about a direction we could go to make the no-jitpack builds a bit "cleaner". My intention here is to insure that the submodule directory isn't dirty when the build starts and also clean up the submodule directory after the build is done. I have only minimally tested this code, I'm more just looking for thoughts about the general direction at this point.

Aborting if the submodule is dirty could avoid us generating an invalid bundle file because of unexpected changes in the `libs/gutenberg-mobile` folder. Cleaning the submodule directory after the build avoids distracting users with the artifacts of the build process showing up in git as changes.

My thinking is that if we are able to feel confident that the submodule is clean for the build (with checks like those I've added in this PR), then we could go further and add local caching of the JS bundles, linking them to the relevant gutenberg-mobile submodule hash (this might even be able to replace the majority of the current logic in the `bundleUpToDateCheck` task since we could rely on a submodule hash check to know if we could re-use a particular bundle). That way if you built branch A, then build branch B (which has a different gutenberg-mobile submodule hash), then went back tried to build to branch A, gradle would just check our local cache of js bundles, see that we already had one for this git hash, and use that instead of making a new one. This caching has **not** been implemented yet, it's just an idea at this point.

### To test:

#### Aborts build if submodule dirty

1. Make a change to a file in `libs/gutenberg-mobile` that is under source control
2. Attempt to build WPAndroid with `BUILD_GUTENBERG_FROM_SOURCE` set to false
3. Observe that the build fails with an error message about the gutenberg-mobile submodule not being clean.

#### Cleans submodule directory
1. Build WPAndroid with `BUILD_GUTENBERG_FROM_SOURCE` set to false
2. Verify that the resulting apk runs
3. Verify that the `libs/gutenberg-mobile` submodule is clean

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
