### PR TITLE
Update list spaces test to not be canary test

### DIFF
--- a/__device-tests__/gutenberg-editor-lists-canary.test.js
+++ b/__device-tests__/gutenberg-editor-lists-canary.test.js
@@ -7,16 +7,16 @@
  */
 import EditorPage from './pages/editor-page';
 import {
-	backspace,
 	isAndroid,
 	isLocalEnvironment,
 	setupDriver,
 	stopDriver,
 } from './helpers/utils';
+import testData from './helpers/test-data';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000000;
 
-describe( 'Gutenberg Editor tests for List block', () => {
+describe( 'Gutenberg Editor tests for List block @canary', () => {
 	let driver;
 	let editorPage;
 	let allPassed = true;
@@ -42,30 +42,41 @@ describe( 'Gutenberg Editor tests for List block', () => {
 		await expect( editorPage.getBlockList() ).resolves.toBe( true );
 	} );
 
-	// Prevent regression of https://github.com/wordpress-mobile/gutenberg-mobile/issues/871
-	it( 'should handle spaces in a list', async () => {
+	it( 'should be able to add a new List block', async () => {
 		await editorPage.addNewBlock( listBlockName );
-		let listBlockElement = await editorPage.getBlockAtPosition( listBlockName );
+		const listBlockElement = await editorPage.getBlockAtPosition( listBlockName );
 		// Click List block on Android to force EditText focus
 		if ( isAndroid() ) {
 			await listBlockElement.click();
 		}
 
-		// Send the list item text
-		await editorPage.sendTextToListBlock( listBlockElement, '  a' );
+		// Send the first list item text
+		await editorPage.sendTextToListBlock( listBlockElement, testData.listItem1 );
 
 		// send an Enter
 		await editorPage.sendTextToListBlock( listBlockElement, '\n' );
 
-		// send a backspace
-		await editorPage.sendTextToListBlock( listBlockElement, backspace );
+		// Send the second list item text
+		await editorPage.sendTextToListBlock( listBlockElement, testData.listItem2 );
 
 		// switch to html and verify html
-		await editorPage.verifyHtmlContent( `<!-- wp:list -->
-<ul><li>  a</li></ul>
-<!-- /wp:list -->` );
+		await editorPage.verifyHtmlContent( testData.listHtml );
+	} );
 
-		// Remove list block to reset editor to clean state
+	// This test depends on being run immediately after 'should be able to add a new List block'
+	it( 'should update format to ordered list, using toolbar button', async () => {
+		let listBlockElement = await editorPage.getBlockAtPosition( listBlockName );
+
+		// Click List block to force EditText focus
+		await listBlockElement.click();
+
+		// Send a click on the order list format button
+		await editorPage.clickOrderedListToolBarButton();
+
+		// switch to html and verify html
+		await editorPage.verifyHtmlContent( testData.listHtmlOrdered );
+
+		// Remove list block to return editor to empty state
 		listBlockElement = await editorPage.getBlockAtPosition( listBlockName );
 		await listBlockElement.click();
 		await editorPage.removeBlockAtPosition( listBlockName );


### PR DESCRIPTION
We didn't have canary tests yet when I added the test for list spaces, and it's a perfect candidate to _not_ be run with every PR, so this PR addresses that. 

The diff makes it a little hard to see exactly what I have changed. I have updated the "old" `gutenberg-editor-lists.test.js` file to only have the list spaces test. I also created a new `__device-tests__/gutenberg-editor-lists-canary.test.js` that contains the other list tests that should run in the canary job.

To test:
* Verify that the list with spaces test does not run with the PR's canary jobs ([Android](https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/6889/workflows/1f10faff-ac32-4386-ac23-efa0b5ab068a/jobs/36550/steps), [iOS](https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/6889/workflows/ec1268af-90a3-4205-9613-d5bf186bfb72/jobs/36546/steps))
* Verify that the list with spaces test runs with the full test suite ([Android](https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/6889/workflows/1f10faff-ac32-4386-ac23-efa0b5ab068a/jobs/36552), [iOS](https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/6889/workflows/1f10faff-ac32-4386-ac23-efa0b5ab068a/jobs/36551))

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
