### PR TITLE
Use available sim on local device tests

### DIFF
--- a/__device-tests__/helpers/caps.js
+++ b/__device-tests__/helpers/caps.js
@@ -17,7 +17,7 @@ const ios = {
 
 exports.iosLocal = {
 	...ios,
-	platformVersion: '13.4',
+	platformVersion: undefined,	// will be set later based on installed sim runtimes
 	deviceName: 'iPhone 11',
 };
 

--- a/__device-tests__/helpers/utils.js
+++ b/__device-tests__/helpers/utils.js
@@ -102,17 +102,17 @@ const setupDriver = async () => {
 
 			// Set the iOS runtime to one of the available simulator runtimes
 			try {
-			  const allRuntimes = childProcess
-			    .execSync( 'xcrun simctl list runtimes --json' )
-			    .toString()
-			  const iOSRuntimes = JSON.parse(allRuntimes)
-			    .runtimes
-			    .filter( runtime => runtime.name.startsWith('iOS') )
-			  const chosenRuntimeVersion = iOSRuntimes[0].version // assume first in list should be used
-			  desiredCaps.platformVersion = chosenRuntimeVersion
-			  console.log( 'Using iOS simulator runtime version:', chosenRuntimeVersion )
+				const allRuntimes = childProcess.execSync( 'xcrun simctl list runtimes --json' ).toString();
+				const iOSRuntimes = JSON.parse( allRuntimes ).runtimes.filter( ( runtime ) =>
+					runtime.name.startsWith( 'iOS' )
+				);
+				const chosenRuntimeVersion = iOSRuntimes[ 0 ].version; // assume first in list should be used
+				desiredCaps.platformVersion = chosenRuntimeVersion;
+				// eslint-disable-next-line no-console
+				console.log( 'Using iOS simulator runtime version:', chosenRuntimeVersion );
 			} catch ( error ) {
-			  console.error( 'No compatible iOS simulator runtime found' )
+				// eslint-disable-next-line no-console
+				console.error( 'No compatible iOS simulator runtime found' );
 			}
 		}
 	}

--- a/__device-tests__/helpers/utils.js
+++ b/__device-tests__/helpers/utils.js
@@ -99,6 +99,21 @@ const setupDriver = async () => {
 		if ( isLocalEnvironment() ) {
 			desiredCaps = _.clone( iosLocal );
 			desiredCaps.app = path.resolve( localIOSAppPath );
+
+			// Set the iOS runtime to one of the available simulator runtimes
+			try {
+			  const allRuntimes = childProcess
+			    .execSync( 'xcrun simctl list runtimes --json' )
+			    .toString()
+			  const iOSRuntimes = JSON.parse(allRuntimes)
+			    .runtimes
+			    .filter( runtime => runtime.name.startsWith('iOS') )
+			  const chosenRuntimeVersion = iOSRuntimes[0].version // assume first in list should be used
+			  desiredCaps.platformVersion = chosenRuntimeVersion
+			  console.log( 'Using iOS simulator runtime version:', chosenRuntimeVersion )
+			} catch ( error ) {
+			  console.error( 'No compatible iOS simulator runtime found' )
+			}
 		}
 	}
 


### PR DESCRIPTION
I'm propose making running local Appium device tests easier by using the iOS runtime installed on a developer's machine instead of looking for the hard-coded one found in `caps.js` which might not be present:
https://github.com/wordpress-mobile/gutenberg-mobile/blob/06c5f4e16d2d4ea9f50784015fc90054aa29a433/__device-tests__/helpers/caps.js#L20

#### Upside
We now don't have to manually update this value every so often. 

#### Downside
With this change developers will run tests on whichever runtime they have installed which is not necessarily the same as other developers (this isn't always a bad thing). I've also tried to make the runtime used to run the tests more explicit by logging it the build output.

#### To test
1. Checkout the branch locally
2. Ensure a local test passes, e.g.:`yarn test:e2e:ios:local __device-tests__/gutenberg-editor-latest-posts.test.js`


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
