### PR TITLE
Update the VS code search settings to that seaching is easier

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,8 +7,7 @@
     // Use 'prettier-eslint' instead of 'prettier'. Other settings will only be fallbacks in case they could not be inferred from eslint rules.
     "prettier.eslintIntegration": true,
     "search.exclude": {
-        "**/bundle/android": true,
-        "**/bundle/ios": true,
+        "**/bundle/": true,
         "**/gutenber/packages/**/build": true,
         "**/gutenber/packages/**/build-modules": true,
         "**/gutenber/packages/**/build-types": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,10 @@
     // Use 'prettier-eslint' instead of 'prettier'. Other settings will only be fallbacks in case they could not be inferred from eslint rules.
     "prettier.eslintIntegration": true,
     "search.exclude": {
-        "**/bundle/": true,
+        "**/bundle/android/App.js": true,
+        "**/bundle/android/App.js.map": true,
+        "**/bundle/ios/App.js": true,
+        "**/bundle/ios/App.js.map": true,
         "**/gutenber/packages/**/build": true,
         "**/gutenber/packages/**/build-modules": true,
         "**/gutenber/packages/**/build-types": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,9 +11,6 @@
         "**/bundle/android/App.js.map": true,
         "**/bundle/ios/App.js": true,
         "**/bundle/ios/App.js.map": true,
-        "**/gutenberg/packages/**/build": true,
-        "**/gutenberg/packages/**/build-modules": true,
-        "**/gutenberg/packages/**/build-types": true,
         "**/i18n-cache/data": true,
         "**/symlinked-packages": true
     },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,4 +6,13 @@
 
     // Use 'prettier-eslint' instead of 'prettier'. Other settings will only be fallbacks in case they could not be inferred from eslint rules.
     "prettier.eslintIntegration": true,
+    "search.exclude": {
+        "**/bundle/android": true,
+        "**/bundle/ios": true,
+        "**/gutenber/packages/**/build": true,
+        "**/gutenber/packages/**/build-modules": true,
+        "**/gutenber/packages/**/build-types": true,
+        "**/i18n-cache/data": true,
+        "**/symlinked-packages": true
+    },
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,9 +11,9 @@
         "**/bundle/android/App.js.map": true,
         "**/bundle/ios/App.js": true,
         "**/bundle/ios/App.js.map": true,
-        "**/gutenber/packages/**/build": true,
-        "**/gutenber/packages/**/build-modules": true,
-        "**/gutenber/packages/**/build-types": true,
+        "**/gutenberg/packages/**/build": true,
+        "**/gutenberg/packages/**/build-modules": true,
+        "**/gutenberg/packages/**/build-types": true,
         "**/i18n-cache/data": true,
         "**/symlinked-packages": true
     },


### PR DESCRIPTION
Currently in VS code when you search for a specific string you get back results that include build files, and symlinked files so the string in question can appear in multiple places. 

This PR tries to fix that in the VS code editor since by removing specific folders from search.

To test:
- Pull in this PR, perform a search in VS code do you get back files as expected? 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
