### PR TITLE
[Gutenberg] Add AccessibilityLabel and hint to AztecViewManager

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 * [***] Add support for mentions.
 * [***] Users can now individually edit unsupported blocks found in posts or pages.
 * [*] [iOS] Improved editor loading experience with Ghost Effect.
+* [*] Accessibility, update the title VoiceOver label to be more clear when you are editing the post or page title.
 
 1.31.1
 ------

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * [***] Media editing support in Media & Text block.
 * [***] New block: Social Icons
 * [*] Cover block placeholder is updated to allow users start the block with a background color
+* [*] Accessibility, update the title VoiceOver label to be more clear when you are editing the post or page title.
 
 1.32.0
 ------
@@ -10,7 +11,6 @@
 * [***] Add support for mentions.
 * [***] Users can now individually edit unsupported blocks found in posts or pages.
 * [*] [iOS] Improved editor loading experience with Ghost Effect.
-* [*] Accessibility, update the title VoiceOver label to be more clear when you are editing the post or page title.
 
 1.31.1
 ------


### PR DESCRIPTION
Fixes #2364

Related GB PR: https://github.com/WordPress/gutenberg/pull/23057

To test:
1. Download WordPress-iOS. 
2. Make sure that he WordPress-iOS repo is on the same level as this directory. (gutenberg-mobile) 
> - gutenberg-mobile (this repo)
> - WordPress-iOS (https://github.com/wordpress-mobile/WordPress-iOS)

3. Run the following command on the WordPress-iOS repo
```
$ export LOCAL_GUTENBERG=1
bundle exec pod update
``` 
4. Load this PR. 
5. Build the iOS app using xcode and send it open it on your device. 
6. Navigate to the Pages screen. 
7. Enable VoiceOver using Siri. 
8. Navigate to a new post. 

Before:
See https://cloudup.com/cNlMs6Fbu_F

After: You should get this experience 
https://cloudup.com/cjd-RHZpyQM

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
