### PR TITLE
Set base typographic rhythm

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.31.0
+------
+* [**] More spacious basic typographic rhythm
+
 1.30.0
 ------
 * [**] Adds editor support for theme defined colors and theme defined gradients on cover and button blocks.

--- a/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -338,6 +338,14 @@ public class ReactAztecManager extends BaseViewManager<ReactAztecText, LayoutSha
         }
     }
 
+    @ReactProp(name = ViewProps.LINE_HEIGHT, defaultInt = ViewDefaults.LINE_HEIGHT)
+    public void setLineHeight(ReactAztecText view, int lineHeight) {
+        // setLineHeight is not available on API 21 (the current app minimum) so,
+        // go with setLineSpacing instead, by using this formula:
+        // (font-size) * (line-height multiplier) = (line-height value)
+        view.setLineSpacing(0, 1.0f * lineHeight / PixelUtil.toSPFromPixel(view.getTextSize()));
+    }
+
     /**
      * This code was taken from the method parseNumericFontWeight of the class ReactTextShadowNode
      * TODO: Factor into a common place they can both use


### PR DESCRIPTION
Fixes #550 

Adds support in ReactAztecText (Android only for now) for the `lineHeight` property. At the same time, setting the default fontSize to 16(px) and default lineHeight to 26(px).

Note: Since this PR changes the defaults for the RichText component, blocks that depend on it might change as well. For example the List block, Heading block and others.

Gutenberg PR: https://github.com/WordPress/gutenberg/pull/23079

WPAndroid PR for testing this with a prebuilt APK: https://github.com/wordpress-mobile/WordPress-Android/pull/12156

Keeping this PR as a draft until we decide whether to wait for the iOS side implementation to happen on this PR, or not.

To test:
1. Run the demo app and have a paragraph block with a handful of lines of text
2. Check that the line spacing is around 1.6x

### Screenshots

Before | After
-|-
![Screenshot_1591827487](https://user-images.githubusercontent.com/1032913/84324764-e3406300-ab81-11ea-951a-63f08a0060d1.png)|![Screenshot_1591827786](https://user-images.githubusercontent.com/1032913/84324877-269ad180-ab82-11ea-8adb-e698afe5ef29.png)
![Screenshot_1591828274](https://user-images.githubusercontent.com/1032913/84325429-6615ed80-ab83-11ea-9326-81f4e24949e1.png)|![Screenshot_1591827994](https://user-images.githubusercontent.com/1032913/84325446-6e6e2880-ab83-11ea-999d-df20de8ac4f7.png)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
