### PR TITLE
Glue code to get content info metrics

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 1.31.0
 ------
-* [*] [iOS] Show content structure (word, paragraph, block, characters counts).
+* [*] Show content information (block, word and characters counts).
 
 1.30.0
 ------


### PR DESCRIPTION
Expands #2380 to include the Android side of the call to get content information.

To test:
Use the WPAndroid PR to test: https://github.com/wordpress-mobile/WordPress-Android/pull/12191
 
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
