### PR TITLE
Fix gutenberg related warnings on xcode project

### DIFF
--- a/ios/gutenberg/GutenbergViewController.swift
+++ b/ios/gutenberg/GutenbergViewController.swift
@@ -71,7 +71,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         print("↳ Content changed: \(changed)")
         print("↳ Title: \(title)")
         print("↳ HTML: \(html)")
-        print("↳ Content Info: \(contentInfo)")
+        print("↳ Content Info: \(String(describing: contentInfo))")
         self.contentInfo = contentInfo
     }
 

--- a/react-native-gutenberg-bridge/ios/Gutenberg.swift
+++ b/react-native-gutenberg-bridge/ios/Gutenberg.swift
@@ -222,7 +222,7 @@ extension Gutenberg {
 }
 
 public extension Gutenberg.MediaSource {
-    public init(id: String, label: String, types: [Gutenberg.MediaType]) {
+    init(id: String, label: String, types: [Gutenberg.MediaType]) {
         self.id = id
         self.label = label
         self.types = Set(types)

--- a/react-native-gutenberg-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/react-native-gutenberg-bridge/ios/GutenbergBridgeDelegate.swift
@@ -80,6 +80,9 @@ extension LogLevel {
         case .warning: self = .warn
         case .error: self = .error
         case .fatal: self = .fatal
+        @unknown default:
+            assertionFailure("Unknown log level: \(rnLogLevel)")
+            self = .trace
         }
     }
 }


### PR DESCRIPTION
This PR fixes a few warnings on the example Xcode project.

To test:
- Open `ios/gutenberg.xcworkspace` with Xcode.
- Build the project.
- Check that there are no warnings under `gutenberg` pod and `gutenberg` project.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
