### PR TITLE
Add Release notes doc

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,4 +5,4 @@ To test:
 PR submission checklist:
 
 - [ ] I have considered adding unit tests where possible.
-- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
+- [ ] I have considered if this change warrants user-facing release notes [more info](docs/Release-notes.md) and have added them to `[RELEASE-NOTES.txt](RELEASE-NOTES.txt)` if necessary.

--- a/docs/Release-notes.md
+++ b/docs/Release-notes.md
@@ -33,4 +33,4 @@ For example:
 Release notes also go through editorial before they are shared with the users. So, while adding release notes, we should 
 try to err on the side of more details so that they changes can be better summarized. 
 
-Release notes are currently translated into different languages before the are seeing by users. 
+Release notes are currently translated into different languages before the are seen by users. 

--- a/docs/Release-notes.md
+++ b/docs/Release-notes.md
@@ -1,0 +1,36 @@
+# Adding release notes
+Release notes are important because they let the users know what has changes since the last time they updates the software. 
+With every new release of Gutenberg Mobile the Gutenberg Mobile release notes also  get rolled in to WordPress-iOS and WordPress-Android apps.
+
+## Importance to users
+In order to keep the release notes as concise as possible we want to make sure that we highlight the most significant changes
+to our users. To do that we include a simple flag system.
+
+
+Please prefix each note that you are adding to `RELEASE-NOTES.txt` with the following. 
+
+    [***] very important → Major new features, significant updates to core flows, or impactful fixes (e.g. a crash that impacts a lot of users) — things our users should be aware of.
+    [**] good to have    → Changes our users will probably notice, but doesn’t impact core flows. Most fixes.
+    [*] low priority     → Minor enhancements and fixes that address annoyances — things our users can miss.
+
+
+For example:
+
+    * [***] New block: Verse
+    * [**] Tooltip for page template selection buttons
+    * [*] Fix button alignment in page templates and make strings consistent
+
+## Noting platform specific changes. 
+
+If you have platform specific changes, iOS or Android only, you can start the release note with `[iOS]` or `[Android]` to 
+indicate tha the change only applies the specific platform. 
+
+For example: 
+
+    * [*] [Android] Disable ripple effect for Slider control
+    
+## Additional info
+Release notes also go through editorial before they are shared with the users. So, while adding release notes, we should 
+try to err on the side of more details so that they changes can be better summarized. 
+
+Release notes are currently translated into different languages before the are seeing by users. 

--- a/docs/Release-notes.md
+++ b/docs/Release-notes.md
@@ -33,4 +33,4 @@ For example:
 Release notes also go through editorial before they are shared with the users. So, while adding release notes, we should 
 try to err on the side of more details so that they changes can be better summarized. 
 
-Release notes are currently translated into different languages before the are seen by users. 
+Release notes are currently translated into different languages before they are seen by users. 

--- a/docs/Release-notes.md
+++ b/docs/Release-notes.md
@@ -1,6 +1,6 @@
 # Adding release notes
-Release notes are important because they let the users know what has changes since the last time they updates the software. 
-With every new release of Gutenberg Mobile the Gutenberg Mobile release notes also  get rolled in to WordPress-iOS and WordPress-Android apps.
+Release notes are important because they let the users know what has changed since the last time they updates the software. 
+With every new release of Gutenberg Mobile the release notes `RELEASE-NOTES.txt` also get rolled in to WordPress-iOS and WordPress-Android release notes.
 
 ## Importance to users
 In order to keep the release notes as concise as possible we want to make sure that we highlight the most significant changes
@@ -31,6 +31,6 @@ For example:
     
 ## Additional info
 Release notes also go through editorial before they are shared with the users. So, while adding release notes, we should 
-try to err on the side of more details so that they changes can be better summarized. 
+try to err on the side of more details so that the changes can be better summarized. 
 
-Release notes are currently translated into different languages before they are seen by users. 
+Also note that the release notes are currently translated into different languages before they are seen by users.


### PR DESCRIPTION
This PR add a release note doc so that we can explain why and how to add a release note to the `RELEASE-NOTE.txt` file. 

Does the new doc make sense what else should we add to it? 
Anything needs to be removed? 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
