### PR TITLE
Unlink python2 before installing watchman

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ jobs:
     steps:
     - run:
         name: Install watchman
-        command: brew install watchman
+        command: brew unlink python@2 && brew install watchman
     - checkout
     - checkout-submodules
     - npm-install


### PR DESCRIPTION
Try to fix watchman install on circle-ci.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](docs/Release-notes.md) and have added them to `[RELEASE-NOTES.txt](RELEASE-NOTES.txt)` if necessary.
