### PR TITLE
Update version change in package-lock.json and commit version changes separately

### DIFF
--- a/bin/release_automation.sh
+++ b/bin/release_automation.sh
@@ -21,8 +21,7 @@ if [[ ! "$CURRENT_BRANCH" =~ "^develop$|^main$|^release/.*" ]]; then
 fi
 
 # Confirm branch is clean
-[ -z "$(git status --porcelain)" ] || { git status; printf "\nUncommitted changes found. Aborting release script...\n"; exit 1; }
-
+[[ -z "$(git status --porcelain)" ]] || { git status; printf "\nUncommitted changes found. Aborting release script...\n"; exit 1; }
 
 # Ask for new version number
 CURRENT_VERSION_NUMBER=$(./node_modules/.bin/json -f package.json version)
@@ -42,28 +41,41 @@ cd gutenberg
 git switch -c "$GB_RELEASE_BRANCH" || { echo "Error: could not create '$GB_RELEASE_BRANCH' branch."; exit 1; }
 cd ..
 
-# Set version number in package.json
-npx json -I -f package.json -e "this.version='$VERSION_NUMBER'" || { echo "Error: could not update version in package.json"; exit 1; }
+# Set version numbers
+for file in 'package.json' 'package-lock.json' 'gutenberg/packages/react-native-editor/package.json'; do
+    npx json -I -f "$file" -e "this.version='$VERSION_NUMBER'" || { echo "Error: could not update version in ${file}"; exit 1; }
+done
 
-# Set version number in react-native-editor package.json
-npx json -I -f gutenberg/packages/react-native-editor/package.json -e "this.version='$VERSION_NUMBER'" || { echo "Error: could not update version in react-native-editor package.json"; exit 1; }
-
-# Make sure podfile is updated
-npm run core preios
-
-# Commit react-native-editor package changes
+# Commit react-native-editor version update
 cd gutenberg
-git commit -a -m "Update react-native-editor version to: $VERSION_NUMBER" || { echo "Error: failed to commit changes"; exit 1; }
+git add 'packages/react-native-editor/package.json'
+git commit -m "Release script: Update react-native-editor version to $VERSION_NUMBER" || { echo "Error: failed to commit changes"; exit 1; }
 cd ..
 
-# Commit package version update changes
-git commit -a -m "Update gb mobile version to: $VERSION_NUMBER" || { echo "Error: failed to commit changes"; exit 1; }
+# Commit gutenberg-mobile version updates
+git add 'package.json' 'package-lock.json'
+git commit -m "Release script: Update gb mobile version to $VERSION_NUMBER" || { echo "Error: failed to commit changes"; exit 1; }
+
+
+# Make sure podfile is updated
+PRE_IOS_COMMAND="npm run core preios"
+eval "$PRE_IOS_COMMAND"
+
+# If preios results in changes, commit them
+cd gutenberg
+if [[ ! -z "$(git status --porcelain)" ]]; then
+  git commit -a -m "Release script: Update with changes from '$PRE_IOS_COMMAND'" || { echo "Error: failed to commit changes from '$PRE_IOS_COMMAND'"; exit 1; }
+else
+  echo "There were no changes from '$PRE_IOS_COMMAND' to be committed."
+fi
+cd ..
+
 
 # Update the bundles
 npm run bundle || { printf "\nError: 'npm bundle' failed.\nIf there is an error stating something like \"Command 'bundle' unrecognized.\" above, perhaps try running 'rm -rf node_modules gutenberg/node_modules && npm install'.\n"; exit 1; }
 
 # Commit bundle changes
-git commit -a -m "Update bundle for: $VERSION_NUMBER" || { echo "Error: failed to commit changes"; exit 1; }
+git commit -a -m "Release script: Update bundle for: $VERSION_NUMBER" || { echo "Error: failed to commit changes"; exit 1; }
 
 # Verify before publishing a PR
 read -p "This script will now create a PR on Github. Would you like to proceed? (y/n) " -n 1


### PR DESCRIPTION
This updates the release script to also update the version in package-lock.json. It also commites the version changes separately from any preios changes.

I don't love the fact that I am manually editing the `package-lock.json` file here, but that seemed better than running `npm install` and either (a) blindly committing any resulting changes or (b) aborting the script anytime there were changes to anything other than the version number. Certainly open to other thoughts/ideas though.

To test:
Smoke test the release script and make sure the resulting commits make sense.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered if this change warrants user-facing release notes [more info](docs/Release-notes.md) and have added them to `[RELEASE-NOTES.txt](RELEASE-NOTES.txt)` if necessary.
