### PR TITLE
Add release prechecks

### DIFF
--- a/bin/release_automation.sh
+++ b/bin/release_automation.sh
@@ -39,6 +39,10 @@ fi
 CURRENT_VERSION_NUMBER=$(./node_modules/.bin/json -f package.json version)
 echo "Current Version Number:$CURRENT_VERSION_NUMBER"
 read -p "Enter the new version number: " VERSION_NUMBER
+if [[ -z "$VERSION_NUMBER" ]]; then
+    echo "Version number cannot be empty."
+    exit 1
+fi
 
 # Insure javascript dependencies are up-to-date
 npm ci || { echo "Error: 'npm ci' failed"; echo 1; }

--- a/bin/release_automation.sh
+++ b/bin/release_automation.sh
@@ -29,12 +29,7 @@ CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 if [[ ! "$CURRENT_BRANCH" =~ "^develop$|^main$|^release/.*" ]]; then
     echo "Releases should generally only be based on 'develop', 'main', or an earlier release branch."
     echo "You are currently on the '$CURRENT_BRANCH' branch."
-    read -p "Are you sure you want to create a release branch from the '$CURRENT_BRANCH' branch? (y/n) " -n 1
-    echo ""
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        printf "Aborting release...\n"
-        exit 1
-    fi
+    confirm_to_proceed "Are you sure you want to create a release branch from the '$CURRENT_BRANCH' branch?"
 fi
 
 # Confirm branch is clean
@@ -53,12 +48,7 @@ npm ci || { echo "Error: 'npm ci' failed"; echo 1; }
 number_milestone_prs=$(check_if_version_has_pending_prs_for_milestone "$VERSION_NUMBER")
 if [[ ! -z "$number_milestone_prs" ]] && [[ "0" != "$number_milestone_prs" ]]; then
     echo "There are currently $number_milestone_prs PRs with a milestone matching $VERSION_NUMBER."
-    read -p "Do you want to proceed with cutting the release? (y/n) " -n 1
-    echo ""
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        printf "Exiting release script...\n"
-        exit 1
-    fi
+    confirm_to_proceed "Do you want to proceed with cutting the release?"
 fi
 
 # Create Git branch

--- a/bin/release_prechecks.sh
+++ b/bin/release_prechecks.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Execute script commands from project's root directory
+SCRIPT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "$SCRIPT_PATH/.."
+
+function check_num_milestone_prs() {
+   MILESTONE_NAME="$1"
+   curl -s -H "Accept: application/vnd.github.v3+json" \
+        "https://api.github.com/repos/wordpress-mobile/gutenberg-mobile/milestones" \
+      | npx json -c "this.title === '$MILESTONE_NAME'" -a open_issues
+}
+
+function check_if_version_has_pending_prs_for_milestone() {
+    number_milestone_prs=$(check_num_milestone_prs "$VERSION_NUMBER")
+    # If we got no results and the version ends with ".0"
+    if [[ -z "$number_milestone_prs" ]] && [[ "$VERSION_NUMBER" =~ [0-9]+\.[0-9]+\.0$ ]]; then
+        # Remove the ending ".0" and check again because we usually drop ".0" from our
+        # milestones. For example, the milestone for 1.34.0 was 1.34
+        version_without_dot_zero=$(echo "$VERSION_NUMBER" | rev | cut -c 3- | rev)
+        number_milestone_prs=$(check_num_milestone_prs "$version_without_dot_zero")
+    fi
+    echo "$number_milestone_prs"
+}
+

--- a/bin/release_prechecks.sh
+++ b/bin/release_prechecks.sh
@@ -8,6 +8,7 @@ cd "$SCRIPT_PATH/.."
 # Confirm to Proceed Prompt
 #####
 
+# Accepts a single argument: a yes/no question (ending with a ? most likely) to ask the user
 function confirm_to_proceed() {
     read -p "$1 (y/n) " -n 1
     echo ""

--- a/bin/release_prechecks.sh
+++ b/bin/release_prechecks.sh
@@ -4,6 +4,23 @@
 SCRIPT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$SCRIPT_PATH/.."
 
+#####
+# Confirm to Proceed Prompt
+#####
+
+function confirm_to_proceed() {
+    read -p "$1 (y/n) " -n 1
+    echo ""
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        printf "Aborting release...\n"
+        exit 1
+    fi
+}
+
+#####
+# PR Milestone check
+#####
+
 function check_num_milestone_prs() {
    MILESTONE_NAME="$1"
    curl -s -H "Accept: application/vnd.github.v3+json" \
@@ -23,3 +40,54 @@ function check_if_version_has_pending_prs_for_milestone() {
     echo "$number_milestone_prs"
 }
 
+
+#####
+# Check for Aztec Release Versions
+#####
+
+SEMANTIC_VERSION_REGEX='\d+\.\d+\.\d+'
+
+function check_android_aztec_is_release_version() {
+    react_native_aztec_gradle='gutenberg/packages/react-native-aztec/android/build.gradle'
+    release_version=$(grep aztecVersion "$react_native_aztec_gradle" | grep -oE "$SEMANTIC_VERSION_REGEX")
+    if [[ -z "$release_version" ]]; then
+        echo "A release version for AztecAndroid was not found in $react_native_aztec_gradle"
+    fi
+}
+
+function check_ios_aztec_is_release_version() {
+    result=''
+
+    podspec_file='RNTAztecView.podspec'
+    aztec_version=$(grep WordPress-Aztec-iOS "$podspec_file" | grep -oE "$SEMANTIC_VERSION_REGEX")
+    if [[ -z "$aztec_version" ]]; then
+        result="A release version for WordPress-Aztec-iOS was not found in $podspec_file"
+    fi
+
+    podfile='gutenberg/packages/react-native-editor/ios/Podfile'
+    commented_out_reference_in_podfile=$(grep -E "# *pod 'WordPress-Aztec-iOS'" "$podfile")
+    if [[ -z "$commented_out_reference_in_podfile" ]]; then
+        message="The developer version of WordPress-Aztec-iOS was not commented out in $podfile"
+        if [[ -z "$result" ]]; then
+            result="$message"
+        else
+            result="${result}\n${message}"
+        fi
+
+    fi
+
+    echo "$result"
+}
+
+# If any problems, the problems are each printed on their own line
+function check_android_and_ios_aztec_versions() {
+    android_result=$(check_android_aztec_is_release_version)
+    ios_result=$(check_ios_aztec_is_release_version)
+    if [[ ! -z "$android_result" ]]; then
+        echo "${android_result}\n${ios_result}"
+    else
+        echo "$ios_result"
+    fi
+}
+
+printf "$(check_android_and_ios_aztec_versions)\n"

--- a/docs/Releasing.md
+++ b/docs/Releasing.md
@@ -37,10 +37,6 @@ cut a new release.
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>o Make sure we use a released version of Aztec iOS and Aztec Android: <code>grep WordPress-Aztec-iOS RNTAztecView.podspec</code> and <code>grep aztecVersion gutenberg/packages/react-native-aztec/android/build.gradle</code>(should be part of a <code>./release-check.sh</code> script). Also insure that the line for testing non-official versions of Aztec on iOS is commented out (this command should find a match: <code>grep "^s*#pod 'WordPress-Aztec-iOS'" ios/Podfile</code>)</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
 <p>o Check that the version number in <code>Gutenberg.podspec</code> matches the one in <code>gutenberg/packages/react-native-bridge/Gutenberg.podspec</code>.
 </p>
 <!-- /wp:paragraph -->


### PR DESCRIPTION
Adds checks for milestone PRs and Aztec versions that are not release versions to the release script.

To test:
Verify that the checks work as expected.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered if this change warrants user-facing release notes [more info](docs/Release-notes.md) and have added them to `[RELEASE-NOTES.txt](RELEASE-NOTES.txt)` if necessary.
