### PR TITLE
Fix links in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,4 +5,4 @@ To test:
 PR submission checklist:
 
 - [ ] I have considered adding unit tests where possible.
-- [ ] I have considered if this change warrants user-facing release notes [more info](docs/Release-notes.md) and have added them to `[RELEASE-NOTES.txt](RELEASE-NOTES.txt)` if necessary.
+- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.


### PR DESCRIPTION
This fixes two issues with the PR template:
1. The links used relative paths from the root of the repository, which seems to be causing github to look for a matching branch (and failing to find one). For example: [Release Notes doc](docs/Release-notes.md).
2. The RELEASE_NOTES link was formatted as code with backticks, which caused it to not actually show a link but instead to show the raw text: `[RELEASE_NOTES.txt](RELEASE_NOTES.txt)`.

You can see examples of the PR template before these changes in the checklist below, which is unchanged from the template, and what it should look like after these changes in https://github.com/wordpress-mobile/gutenberg-mobile/pull/2517.

To test:

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered if this change warrants user-facing release notes [more info](docs/Release-notes.md) and have added them to `[RELEASE-NOTES.txt](RELEASE-NOTES.txt)` if necessary.
