### PR TITLE
Tweak Release docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release_pull_request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_pull_request.md
@@ -16,8 +16,8 @@ No extra PRs yet. 🎉
 ## Changes
 <!-- To determine the changes you can check the RELEASE-NOTES.txt and gutenberg/packages/react-native-editor/CHANGELOG.md files and cross check with the list of commits that are part of the PR -->
 
- - Change 1
- - Change 2
+ - Change 1: link-to-pr-describing-change-1
+ - Change 2: link-to-pr-describing-change-2
 
 ## Test plan
 

--- a/docs/Releasing.md
+++ b/docs/Releasing.md
@@ -102,6 +102,10 @@ cut a new release.
 <p>o If there were changes in Gutenberg repo, make sure to cherry-pick the changes that landed in the master branch back to the release branch.</p>
 <!-- /wp:paragraph -->
 
+<!-- wp:paragraph -->
+<p>o Add the new change to the "Extra PRs that Landed After the Release Was Cut" section of the gb-mobile PR description.</p>
+<!-- /wp:paragraph -->
+
 <!-- wp:heading {"level":3} -->
 <h3>Last Day</h3>
 <!-- /wp:heading -->


### PR DESCRIPTION
This PR:
1. Updates the release PR template to include to include a link to the related PR for each change in the release; and
2. Adds a step to the "Specific tasks after a PR has been merged after the freeze" portion of the release checklist for adding any release updates to the "Extra PRs that Landed After the Release Was Cut" section of the gb-mobile release PR.

To test:
Make sure the updates make sense.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered if this change warrants user-facing release notes [more info](docs/Release-notes.md) and have added them to `[RELEASE-NOTES.txt](RELEASE-NOTES.txt)` if necessary.
