### PR TITLE
Have release script open Gutenberg PR

### DIFF
--- a/bin/release_automation.sh
+++ b/bin/release_automation.sh
@@ -136,7 +136,7 @@ BASE_REMOTE=$(get_remote_name 'wordpress-mobile/gutenberg-mobile')
 git push -u "$BASE_REMOTE" HEAD || { echo "Unable to push to remote $BASE_REMOTE"; exit 1; }
 
 # Create Draft GB-Mobile Release PR in GitHub
-GB_MOBILE_PR_URL=$(gh pr create -t "Release $VERSION_NUMBER" -b "$PR_BODY" -B main -l "release-process" -d)
+GB_MOBILE_PR_URL=$(gh pr create --title "Release $VERSION_NUMBER" --body "$PR_BODY" --base main --label "release-process" --draft)
 if [[ $? != 0 ]]; then
     echo "Error: Failed to create Gutenberg-Mobile PR"
     exit 1
@@ -180,4 +180,3 @@ echo "PRs Created"
 echo "==========="
 printf "Gutenberg-Mobile $GB_MOBILE_PR_URL
 Gutenberg $GUTENBERG_PR_URL\n" | column -t
-

--- a/bin/release_automation.sh
+++ b/bin/release_automation.sh
@@ -11,6 +11,7 @@ SCRIPT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$SCRIPT_PATH/.."
 
 source bin/release_prechecks.sh
+source bin/release_utils.sh
 
 # Check that Github CLI is installed
 command -v gh >/dev/null || { echo "Error: The Github CLI must be installed."; exit 1; }
@@ -129,6 +130,11 @@ PR_TEMPLATE=$(cat "$PR_TEMPLATE_PATH")
 # Replace version number in GB-Mobile PR template
 PR_BODY=${PR_TEMPLATE//v1.XX.Y/$VERSION_NUMBER}
 
+# Insure PR is created on proper remote
+# see https://github.com/cli/cli/issues/800
+BASE_REMOTE=$(get_remote_name 'wordpress-mobile/gutenberg-mobile')
+git push -u "$BASE_REMOTE" HEAD || { echo "Unable to push to remote $BASE_REMOTE"; exit 1; }
+
 # Create Draft GB-Mobile Release PR in GitHub
 GB_MOBILE_PR_URL=$(gh pr create -t "Release $VERSION_NUMBER" -b "$PR_BODY" -B main -l "release-process" -d)
 if [[ $? != 0 ]]; then
@@ -156,6 +162,11 @@ For more information about this release and testing instructions, please see the
 GUTENBERG_PR_BODY="$GUTENBERG_PR_BEGINNING
 
 $CHECKLIST_FROM_GUTENBERG_PR_TEMPLATE"
+
+# Insure PR is created on proper remote
+# see https://github.com/cli/cli/issues/800
+GB_BASE_REMOTE=$(get_remote_name 'WordPress/gutenberg')
+git push -u "$GB_BASE_REMOTE" HEAD || { echo "Unable to push to remote: $GB_BASE_REMOTE"; exit 1; }
 
 # Create Draft Gutenberg Release PR in GitHub
 GUTENBERG_PR_URL=$(gh pr create -t "Mobile Release v$VERSION_NUMBER" -b "$GUTENBERG_PR_BODY" -B master -l 'Mobile App Android/iOS' -d)

--- a/bin/release_automation.sh
+++ b/bin/release_automation.sh
@@ -169,7 +169,7 @@ GB_BASE_REMOTE=$(get_remote_name 'WordPress/gutenberg')
 git push -u "$GB_BASE_REMOTE" HEAD || { echo "Unable to push to remote: $GB_BASE_REMOTE"; exit 1; }
 
 # Create Draft Gutenberg Release PR in GitHub
-GUTENBERG_PR_URL=$(gh pr create -t "Mobile Release v$VERSION_NUMBER" -b "$GUTENBERG_PR_BODY" -B master -l 'Mobile App Android/iOS' -d)
+GUTENBERG_PR_URL=$(gh pr create --title "Mobile Release v$VERSION_NUMBER" --body "$GUTENBERG_PR_BODY" --base master --label 'Mobile App Android/iOS' --draft)
 if [[ $? != 0 ]]; then
     echo "Error: Failed to create Gutenberg PR"
     exit 1

--- a/bin/release_utils.sh
+++ b/bin/release_utils.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Accepts the repository owner/name (wordpress-mobile/gutenberg-mobile) and returns
+# the locally matching remote
+function get_remote_name() {
+    REPO="$1"
+    git remote -v | grep "git@github.com:$REPO.git (push)" | grep -oE '^\S*'
+}


### PR DESCRIPTION
This adds opening the gutenberg release PR to the release automation script. In doing that, it automatically includes a link to the gb-mobile PR in the gutenberg PR description. In addition, it prints the list of opened PRs at the end of the script.

Assuming this works well, I think it should be relatively straightforward to add the WPiOS and WPAndroid PRs to this script as well. But I figured we should see how this works first.

To test:
Make sure the release script runs smoothly and opens draft PRs in gb && gb-mobile with appropriately updated branches.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
