### PR TITLE
[FIX][Android] E2E tests - swipe inserter instead of sending the keycode 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "test": "cross-env NODE_ENV=test jest --verbose --config ./jest.config.js",
     "test:debug": "cross-env NODE_ENV=test node --inspect-brk node_modules/.bin/jest --runInBand --verbose --config jest.config.js",
     "device-tests": "cross-env NODE_ENV=test jest --no-cache --maxWorkers=3 --reporters=default --reporters=jest-junit --verbose --config jest_ui.config.js",
-    "device-tests-canary": "cross-env NODE_ENV=test jest --no-cache --maxWorkers=2 --testNamePattern=@canary --reporters=default --reporters=jest-junit --verbose --config jest_ui.config.js",
+    "device-tests-canary": "cross-env NODE_ENV=test jest --no-cache --maxWorkers=2 --reporters=default --reporters=jest-junit --verbose --config jest_ui.config.js",
     "device-tests:local": "cross-env NODE_ENV=test jest --runInBand --reporters=default --reporters=jest-junit --detectOpenHandles --verbose --config jest_ui.config.js",
     "device-tests:debug": "cross-env NODE_ENV=test node $NODE_DEBUG_OPTION --inspect-brk node_modules/jest/bin/jest --runInBand --reporters=default --reporters=jest-junit --detectOpenHandles --verbose --config jest_ui.config.js",
     "test:e2e:bundle:android": "mkdir -p gutenberg/packages/react-native-editor/android/app/src/main/assets && npm run rn-bundle -- --reset-cache --platform android --dev false --minify false --entry-file index.js --bundle-output gutenberg/packages/react-native-editor/android/app/src/main/assets/index.android.bundle --assets-dest gutenberg/packages/react-native-editor/android/app/src/main/res",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "test": "cross-env NODE_ENV=test jest --verbose --config ./jest.config.js",
     "test:debug": "cross-env NODE_ENV=test node --inspect-brk node_modules/.bin/jest --runInBand --verbose --config jest.config.js",
     "device-tests": "cross-env NODE_ENV=test jest --no-cache --maxWorkers=3 --reporters=default --reporters=jest-junit --verbose --config jest_ui.config.js",
-    "device-tests-canary": "cross-env NODE_ENV=test jest --no-cache --maxWorkers=2 --reporters=default --reporters=jest-junit --verbose --config jest_ui.config.js",
+    "device-tests-canary": "cross-env NODE_ENV=test jest --no-cache --maxWorkers=2 --testNamePattern=@canary --reporters=default --reporters=jest-junit --verbose --config jest_ui.config.js",
     "device-tests:local": "cross-env NODE_ENV=test jest --runInBand --reporters=default --reporters=jest-junit --detectOpenHandles --verbose --config jest_ui.config.js",
     "device-tests:debug": "cross-env NODE_ENV=test node $NODE_DEBUG_OPTION --inspect-brk node_modules/jest/bin/jest --runInBand --reporters=default --reporters=jest-junit --detectOpenHandles --verbose --config jest_ui.config.js",
     "test:e2e:bundle:android": "mkdir -p gutenberg/packages/react-native-editor/android/app/src/main/assets && npm run rn-bundle -- --reset-cache --platform android --dev false --minify false --entry-file index.js --bundle-output gutenberg/packages/react-native-editor/android/app/src/main/assets/index.android.bundle --assets-dest gutenberg/packages/react-native-editor/android/app/src/main/res",


### PR DESCRIPTION
Gutenberg PR https://github.com/WordPress/gutenberg/pull/24338
Fixes Failing CI e2e test. Android e2e tests started failing after removing the scroll view from the inserter menu. I couldn't reproduce it on my side but I could fix that by using swipe gesture instead of sending the keycode 20 (arrow down).
I created the same Simulator as on Sauce Labs, used the same version of Appium and tests were passing on my side. I also tried to send locally keyevent by  `adb shell input keyevent 20` and that also works. However, I used the mechanism from here https://github.com/WordPress/gutenberg/pull/24338/files#diff-34060c7868e5c5d05b0a7f37b80fd440R453 that simulates the swipe gesture and now tests pass.

To test:
- Green e2e tests locally
- Green CI tests here (https://github.com/wordpress-mobile/gutenberg-mobile/pull/2527/commits/71838fafda79da6a5095bf6ac172630045724534) - I removed the canary test pattern for a while just to test

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
