### PR TITLE
[RNMobile] create undo level less frequently

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.35.0
+------
+* Creating undo levels less frequently.
+
 1.34.0
 ------
 * Media editing support in Cover block.


### PR DESCRIPTION
Gutenberg PR: https://github.com/WordPress/gutenberg/pull/24116
In this PR i added selectionStart and selectionEnd to the transientEdits which results less undo levels created.

To test:
Tests from Gutenberg PR

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
