### PR TITLE
Bottom sheet navigation

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -52,6 +52,8 @@ module.exports = {
 	moduleNameMapper: {
 		// Mock the CSS modules. See https://facebook.github.io/jest/docs/en/webpack.html#handling-static-assets
 		'\\.(scss)$': '<rootDir>/' + configPath + '/__mocks__/styleMock.js',
+		'\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
+			'<rootDir>/' + configPath + '/__mocks__/fileMock.js',
 		...transpiledPackages,
 	},
 	haste: {

--- a/third-party-podspecs/RNCMaskedView.podspec.json
+++ b/third-party-podspecs/RNCMaskedView.podspec.json
@@ -1,0 +1,19 @@
+{
+  "name": "RNCMaskedView",
+  "version": "0.1.10",
+  "summary": "React Native MaskedView component",
+  "authors": "Mike Nedosekin <crespo8800@gmail.com>",
+  "homepage": "https://github.com/react-native-community/react-native-masked-view#readme",
+  "license": "MIT",
+  "platforms": {
+    "ios": "9.0"
+  },
+  "source": {
+    "git": "https://github.com/react-native-community/react-native-masked-view.git"
+  },
+  "source_files": "ios/**/*.{h,m}",
+  "dependencies": {
+    "React": [
+    ]
+  }
+}

--- a/third-party-podspecs/RNGestureHandler.podspec.json
+++ b/third-party-podspecs/RNGestureHandler.podspec.json
@@ -1,0 +1,23 @@
+{
+  "name": "RNGestureHandler",
+  "version": "1.6.1",
+  "summary": "Experimental implementation of a new declarative API for gesture handling in react-native",
+  "authors": {
+    "email": "krzys.magiera@gmail.com",
+    "name": "Krzysztof Magiera"
+  },
+  "homepage": "https://github.com/software-mansion/react-native-gesture-handler",
+  "license": "MIT",
+  "platforms": {
+    "ios": "9.0"
+  },
+  "source": {
+    "git": "https://github.com/software-mansion/react-native-gesture-handler.git",
+    "tag": "1.6.1"
+  },
+  "source_files": "ios/**/*.{h,m}",
+  "dependencies": {
+    "React": [
+    ]
+  }
+}

--- a/third-party-podspecs/RNReanimated.podspec.json
+++ b/third-party-podspecs/RNReanimated.podspec.json
@@ -1,0 +1,24 @@
+{
+  "name": "RNReanimated",
+  "version": "1.9.0",
+  "summary": "More powerful alternative to Animated library for React Native.",
+  "authors": {
+    "email": "krzys.magiera@gmail.com",
+    "name": "Krzysztof Magiera"
+  },
+  "homepage": "https://github.com/software-mansion/react-native-reanimated",
+  "license": "MIT",
+  "platforms": {
+    "ios": "9.0"
+  },
+  "source": {
+    "git": "https://github.com/software-mansion/react-native-reanimated.git",
+    "tag": "1.9.0"
+  },
+  "source_files": "ios/**/*.{h,m}",
+  "dependencies": {
+    "React": [
+    ]
+  },
+  "requires_arc": true
+}

--- a/third-party-podspecs/RNScreens.podspec.json
+++ b/third-party-podspecs/RNScreens.podspec.json
@@ -1,0 +1,24 @@
+{
+  "name": "RNScreens",
+  "version": "2.8.0",
+  "summary": "Native navigation primitives for your React Native app.",
+  "authors": {
+    "email": "krzys.magiera@gmail.com",
+    "name": "Krzysztof Magiera"
+  },
+  "homepage": "https://github.com/kmagiera/react-native-screens",
+  "license": "MIT",
+  "platforms": {
+    "ios": "9.0"
+  },
+  "source": {
+    "git": "https://github.com/kmagiera/react-native-screens.git",
+    "tag": "2.8.0"
+  },
+  "source_files": "ios/**/*.{h,m}",
+  "dependencies": {
+    "React": [
+    ]
+  },
+  "requires_arc": true
+}

--- a/third-party-podspecs/react-native-safe-area-context.podspec.json
+++ b/third-party-podspecs/react-native-safe-area-context.podspec.json
@@ -1,0 +1,20 @@
+{
+  "name": "react-native-safe-area-context",
+  "version": "3.0.2",
+  "summary": "A flexible way to handle safe area, also works on Android and web.",
+  "authors": "Janic Duplessis <janicduplessis@gmail.com>",
+  "homepage": "https://github.com/th3rdwave/react-native-safe-area-context#readme",
+  "license": "MIT",
+  "platforms": {
+    "ios": "9.0"
+  },
+  "source": {
+    "git": "https://github.com/th3rdwave/react-native-safe-area-context.git",
+    "tag": "v3.0.2"
+  },
+  "source_files": "ios/**/*.{h,m}",
+  "dependencies": {
+    "React": [
+    ]
+  }
+}


### PR DESCRIPTION
Gutenberg PR: https://github.com/WordPress/gutenberg/pull/23782

In this PR I added a `react-navigation` to use in bottom-sheet. The `react-navigation` requires a few native modules to be linked so I had to add `podspecs` files for each of them for iOS and fork each of them and add jitpack setup for Android.

This also brings a possibility to
- use `react-native-reanimated` instead of `Animated` from `react-native`
- use `react-navigation` somewhere else in the application. (i.e on the top level and add the HTML mode as a separate screen)

To test:

- Check settings of each block
- Open Button Block settings
- Click on Text Color / Backgrounds color
- The navigation inside bottom sheet should be possible
- Play a bit with colors and check if the button reflecting these changes
- Try the hardware back button on Android - the back button should back to the previous screen or hide the bottom-sheet if it's the main settings screen

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
