### PR TITLE
Improve release script

### DIFF
--- a/bin/release_automation.sh
+++ b/bin/release_automation.sh
@@ -223,13 +223,14 @@ For more information about this release and testing instructions, please see the
 
 Release Submission Checklist
 
-- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary."
+- [ ] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary."
 
 # Create Draft WPAndroid Release PR in GitHub
 ohai "Create Draft WPAndroid Release PR in GitHub"
 WP_ANDROID_PR_URL=$(execute "gh" "pr" "create" "--title" "Integrate gutenberg-mobile release $VERSION_NUMBER" "--body" "$WP_ANDROID_PR_BODY" "--base" "develop" "--label" "gutenberg-mobile" "--draft")
 
 ohai "WPAndroid PR Created: $WP_ANDROID_PR_URL"
+echo ""
 
 
 #####
@@ -265,13 +266,14 @@ For more information about this release and testing instructions, please see the
 
 Release Submission Checklist
 
-- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary."
+- [ ] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary."
 
 # Create Draft WPiOS Release PR in GitHub
 ohai "Create Draft WPiOS Release PR in GitHub"
 WP_IOS_PR_URL=$(execute "gh" "pr" "create" "--title" "Integrate gutenberg-mobile release $VERSION_NUMBER" "--body" "$WP_IOS_PR_BODY" "--base" "develop" "--label" "Gutenberg integration" "--draft")
 
 ohai "WPiOS PR Created: $WP_IOS_PR_URL"
+echo ""
 
 echo "Main apps PRs created"
 echo "==========="

--- a/bin/release_automation.sh
+++ b/bin/release_automation.sh
@@ -6,6 +6,8 @@
 # - Release is being created off of a clean branch
 # - Whether there are any open PRs targeting the milestone for the release
 
+set -e
+
 # Execute script commands from project's root directory
 SCRIPT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$SCRIPT_PATH/.."

--- a/bin/release_automation.sh
+++ b/bin/release_automation.sh
@@ -214,7 +214,7 @@ execute "git" "commit" "-m" "Release script: Update strings"
 
 # Insure PR is created on proper remote
 # see https://github.com/cli/cli/issues/800
-WP_ANDROID_BASE_REMOTE=$(get_remote_name 'wordpress-mobile/WordPress-android')
+WP_ANDROID_BASE_REMOTE=$(get_remote_name 'wordpress-mobile/WordPress-Android')
 execute "git" "push" "-u" "$WP_ANDROID_BASE_REMOTE" "HEAD"
 
 WP_ANDROID_PR_BODY="## Description

--- a/bin/release_automation.sh
+++ b/bin/release_automation.sh
@@ -197,6 +197,14 @@ cd "$TEMP_WP_ANDROID_DIRECTORY"
 
 execute "git" "submodule" "update" "--init" "--recursive" "--depth=1" "--recommend-shallow"
 
+ohai "Create after_x.xx.x branch in WordPress-Android"
+execute "git" "switch" "-c" "gutenberg/after_$VERSION_NUMBER" 
+
+# Insure PR is created on proper remote
+# see https://github.com/cli/cli/issues/800
+WP_ANDROID_BASE_REMOTE=$(get_remote_name 'wordpress-mobile/WordPress-Android')
+execute "git" "push" "-u" "$WP_ANDROID_BASE_REMOTE" "HEAD"
+
 ohai "Create release branch in WordPress-Android"
 execute "git" "switch" "-c" "gutenberg/integrate_release_$VERSION_NUMBER" 
 
@@ -221,10 +229,7 @@ else
     ohai "There were no changes from 'python tools/merge_strings_xml.py' to be committed."
 fi
 
-
-# Insure PR is created on proper remote
-# see https://github.com/cli/cli/issues/800
-WP_ANDROID_BASE_REMOTE=$(get_remote_name 'wordpress-mobile/WordPress-Android')
+ohai "Push integration branch"
 execute "git" "push" "-u" "$WP_ANDROID_BASE_REMOTE" "HEAD"
 
 WP_ANDROID_PR_BODY="## Description
@@ -253,6 +258,14 @@ execute "git" "clone" "--depth=1" "git@github.com:wordpress-mobile/WordPress-iOS
 
 cd "$TEMP_WP_IOS_DIRECTORY"
 
+ohai "Create after_x.xx.x branch in WordPress-iOS"
+execute "git" "switch" "-c" "gutenberg/after_$VERSION_NUMBER" 
+
+# Insure PR is created on proper remote
+# see https://github.com/cli/cli/issues/800
+WP_IOS_BASE_REMOTE=$(get_remote_name 'wordpress-mobile/WordPress-iOS')
+execute "git" "push" "-u" "$WP_IOS_BASE_REMOTE" "HEAD"
+
 ohai "Create release branch in WordPress-iOS"
 execute "git" "switch" "-c" "gutenberg/integrate_release_$VERSION_NUMBER" 
 
@@ -265,9 +278,7 @@ execute "rake" "dependencies"
 execute "git" "add" "Podfile" "Podfile.lock"
 execute "git" "commit" "-m" "Release script: Update gutenberg-mobile ref"
 
-# Insure PR is created on proper remote
-# see https://github.com/cli/cli/issues/800
-WP_IOS_BASE_REMOTE=$(get_remote_name 'wordpress-mobile/WordPress-iOS')
+ohai "Push integration branch"
 execute "git" "push" "-u" "$WP_IOS_BASE_REMOTE" "HEAD"
 
 WP_IOS_PR_BODY="## Description

--- a/bin/release_automation.sh
+++ b/bin/release_automation.sh
@@ -202,6 +202,7 @@ ohai "Update gutenberg-mobile ref"
 cd libs/gutenberg-mobile
 execute "git" "fetch" "--recurse-submodules=no" "origin" "$GB_MOBILE_PR_REF"
 execute "git" "checkout" "$GB_MOBILE_PR_REF"
+execute "git" "submodule" "update"
 cd ../..
 
 execute "git" "add" "libs/gutenberg-mobile"

--- a/bin/release_automation.sh
+++ b/bin/release_automation.sh
@@ -146,7 +146,7 @@ BASE_REMOTE=$(get_remote_name 'wordpress-mobile/gutenberg-mobile')
 execute "git" "push" "-u" "$BASE_REMOTE" "HEAD"
 
 # Create Draft GB-Mobile Release PR in GitHub
-GB_MOBILE_PR_URL=$(execute "gh" "pr" "create" "--title" "Release $VERSION_NUMBER" "--body" "$PR_BODY" "--base" "main" "--label" "release-process" "--draft")
+GB_MOBILE_PR_URL=$(execute "gh" "pr" "create" "--title" "Release $VERSION_NUMBER" "--body" "$PR_BODY" "--base" "trunk" "--label" "release-process" "--draft")
 
 #####
 # Gutenberg PR

--- a/bin/release_automation.sh
+++ b/bin/release_automation.sh
@@ -209,8 +209,15 @@ execute "git" "commit" "-m" "Release script: Update gutenberg-mobile ref"
 
 ohai "Update strings"
 execute "python" "tools/merge_strings_xml.py"
-execute "git" "add" "WordPress/src/main/res/values/strings.xml"
-execute "git" "commit" "-m" "Release script: Update strings"
+# If merge_strings_xml.py results in changes, commit them
+if [[ ! -z "$(git status --porcelain)" ]]; then
+    ohai "Commit changes from 'python tools/merge_strings_xml.py'"
+    execute "git" "add" "WordPress/src/main/res/values/strings.xml"
+    execute "git" "commit" "-m" "Release script: Update strings"
+else
+    ohai "There were no changes from 'python tools/merge_strings_xml.py' to be committed."
+fi
+
 
 # Insure PR is created on proper remote
 # see https://github.com/cli/cli/issues/800

--- a/bin/release_automation.sh
+++ b/bin/release_automation.sh
@@ -258,7 +258,7 @@ execute "git" "switch" "-c" "gutenberg/integrate_release_$VERSION_NUMBER"
 
 ohai "Update gutenberg-mobile ref"
 test -f "Podfile" || abort "Error: Could not find Podfile"
-sed -i'.orig' -E "s/gutenberg :commit => '(.*)'/gutenberg :commit => '$GB_MOBILE_PR_REF'/" Podfile || abort "Error: Failed updating gutenberg ref in Podfile"
+sed -i'.orig' -E "s/gutenberg :(commit|tag) => '(.*)'/gutenberg :commit => '$GB_MOBILE_PR_REF'/" Podfile || abort "Error: Failed updating gutenberg ref in Podfile"
 execute "rake" "dependencies"
 
 

--- a/bin/release_automation.sh
+++ b/bin/release_automation.sh
@@ -50,9 +50,11 @@ if [[ -z "$VERSION_NUMBER" ]]; then
 fi
 
 # Ensure javascript dependencies are up-to-date
-ohai "Run 'npm ci' to ensure javascript dependencies are up-to-date"
-execute "npm" "ci"
-
+read -p "Run 'npm ci' to ensure javascript dependencies are up-to-date? (y/n) " -n 1
+echo ""
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    execute "npm" "ci"
+fi
 
 # If there are any open PRs with a milestone matching the release version number, notify the user and ask them if they want to proceed
 number_milestone_prs=$(check_if_version_has_pending_prs_for_milestone "$VERSION_NUMBER")

--- a/docs/Releasing.md
+++ b/docs/Releasing.md
@@ -118,15 +118,15 @@ cut a new release.
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>o Create a new GitHub release pointing to the tag: https://github.com/wordpress-mobile/gutenberg-mobile/releases/new?tag=vX.XX.X&target=main&title=Release%20X.XX.X. Include a list of changes in the release's description</p>
+<p>o Create a new GitHub release pointing to the tag: https://github.com/wordpress-mobile/gutenberg-mobile/releases/new?tag=vX.XX.X&target=trunk&title=Release%20X.XX.X. Include a list of changes in the release's description</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>o In WPiOS update the reference to point to the <em>tag</em>. For iOS do not forget to remove ‘develop’ branch reference near 3rd party pod specs if any.</p>
+<p>o In WPiOS update the reference to point to the <em>tag</em>. For iOS do not forget to remove <code>develop</code> branch reference near 3rd party pod specs if any.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>o In WPAndroid, update the submodule to point to the merge commit on GB-Mobile main.</p>
+<p>o In WPAndroid, update the submodule to point to the merge commit on GB-Mobile <code>trunk</code>.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
@@ -138,7 +138,7 @@ cut a new release.
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>o Open a PR from Gutenberg-Mobile main to bring all the <code>gutenberg/after_X.XX.X</code> changes to <code>develop</code> and point to the Gutenberg side PR (if any changes happened specifically for the release). Merge the PR (or PR domino if Gutenberg changes are there)</p>
+<p>o Open a PR from Gutenberg-Mobile <code>trunk</code> to bring all the <code>release/X.XX.X</code> changes to <code>develop</code> and point to the Gutenberg side PR (if any changes happened specifically for the release). Merge the PR (or PR domino if Gutenberg changes are there)</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->
@@ -146,7 +146,7 @@ cut a new release.
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>o Update the <code>gutenberg/after_X.XX.X</code> branches and open a PR against <code>develop</code>. If the branches are empty we’ll just delete them. The PR can actually get created as soon as something gets merged to the after-ooo branches.&nbsp; Merge the <code>gutenberg/after_X.XX.X</code> PR(s) only AFTER the main apps have cut their release branches.</p>
+<p>o Update the <code>gutenberg/after_X.XX.X</code> branches and open a PR against <code>develop</code>. If the branches are empty we’ll just delete them. The PR can actually get created as soon as something gets merged to the after_X.XX.X branches.&nbsp; Merge the <code>gutenberg/after_X.XX.X</code> PR(s) only AFTER the main apps have cut their release branches.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->

--- a/docs/Releasing.md
+++ b/docs/Releasing.md
@@ -45,30 +45,6 @@ cut a new release.
 <p>o From gutenberg-mobile's <code>develop</code> branch (making sure the gutenberg submodule is updated and clean), run the release script: <code>./bin/release_automation.sh</code>. This will take care of creating the branches in gutenberg-mobile and gutenberg as well as creating the gutenberg-mobile release PR.</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:paragraph -->
-<p>o Create a new branch in the main WP apps (WordPress-iOS, WordPress-Android) based on their <code>develop</code> branches. Name the new branch <code>gutenberg/integrate_release_X.XX.X</code>.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>o Use the commit hash of the head of the release branch in Gutenberg-Mobile as the reference for the main apps.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>o Create a PR in WPAndroid and WPiOS with a description along these lines: "This PR incorporates the X.XX.X release of gutenberg-mobile. For details about the changes included in this PR and testing instructions please see the related gutenberg-mobile PR: [gb-mobile PR link]."</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>o In iOS update the file <code>Podfile</code> to point to the new hash in GB-Mobile and if needed also update the reference to Aztec to the new release. Then run <code>rake dependencies</code>, commit and push.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>o On Android: (1) update the git submodule reference for <code>libs/gutenberg-mobile</code> (<code>cd libs/gutenberg-mobile &amp;&amp; git checkout release/X.XX.X &amp;&amp; git pull origin release/X.XX.X &amp;&amp; cd .. &amp;&amp; git add gutenberg-mobile</code>); and (2) run <code>python tools/merge_strings_xml.py</code> to update the main <code>strings.xml</code> file.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>o Create new branches <code>gutenberg/after_X.XX.X</code> in WPAndroid and WPiOS and keep them up to date with the release branches. These are to be doubles for develop on the main apps for mobile gutenberg dev’s WP app PR’s that didn’t or shouldn’t make it into the X.XX.X editor release.</p>
-<!-- /wp:paragraph -->
-
 <!-- wp:heading {"level":3} -->
 <h3>New Aztec Release</h3>
 <!-- /wp:heading -->

--- a/docs/Releasing.md
+++ b/docs/Releasing.md
@@ -42,7 +42,7 @@ cut a new release.
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>o From gutenberg-mobile's <code>develop</code> branch (making sure the gutenberg submodule is updated and clean), run the release script: <code>./bin/release_automation.sh</code>. This will take care of creating the branches in gutenberg-mobile and gutenberg as well as creating the gutenberg-mobile release PR.</p>
+<p>o From gutenberg-mobile's <code>develop</code> branch (making sure the gutenberg submodule is updated and clean), run the release script: <code>./bin/release_automation.sh</code>. This will take care of creating the branches in gutenberg-mobile and gutenberg, creating the gutenberg-mobile release PR as well as WPAndroid and WPiOS integration PRs.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->


### PR DESCRIPTION
This PR:

- Fixes release script having wrong WPAndroid remote name
- Fixes PR formatting to correctly include `RELEASE-NOTES.txt` text
- Creates `gutenberg/after_x.xx.x` branch in WPiOS and WPAndroid
- Updated release checklist accordingly

To test:
1. Run the script and use an unusually high version number 
1. Check if Gutenberg, GB-Mobile, WPiOS and WPAndroid PRs are created as drafts
1. Check if PRs have correct descriptions and changes
1. Close the draft PRs
1. Check if `gutenberg/after_x.xx.x` branches are created in WPiOS and WPAndroid repos
1. Delete `gutenberg/after_x.xx.x` branches

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
