### PR TITLE
Rename main to trunk in the release script

### DIFF
--- a/bin/release_automation.sh
+++ b/bin/release_automation.sh
@@ -28,10 +28,10 @@ else
     ohai "Confirmed that Aztec Libraries are set to release versions. Proceeding..."
 fi
 
-## Check current branch is develop, main, or release/* branch
+## Check current branch is develop, trunk, or release/* branch
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-if [[ ! "$CURRENT_BRANCH" =~ "^develop$|^main$|^release/.*" ]]; then
-    echo "Releases should generally only be based on 'develop', 'main', or an earlier release branch."
+if [[ ! "$CURRENT_BRANCH" =~ "^develop$|^trunk$|^release/.*" ]]; then
+    echo "Releases should generally only be based on 'develop', 'trunk', or an earlier release branch."
     echo "You are currently on the '$CURRENT_BRANCH' branch."
     confirm_to_proceed "Are you sure you want to create a release branch from the '$CURRENT_BRANCH' branch?"
 fi
@@ -142,7 +142,7 @@ BASE_REMOTE=$(get_remote_name 'wordpress-mobile/gutenberg-mobile')
 execute "git" "push" "-u" "$BASE_REMOTE" "HEAD"
 
 # Create Draft GB-Mobile Release PR in GitHub
-GB_MOBILE_PR_URL=$(execute "gh" "pr" "create" "--title" "Release $VERSION_NUMBER" "--body" "$PR_BODY" "--base" "main" "--label" "release-process" "--draft")
+GB_MOBILE_PR_URL=$(execute "gh" "pr" "create" "--title" "Release $VERSION_NUMBER" "--body" "$PR_BODY" "--base" "trunk" "--label" "release-process" "--draft")
 
 #####
 # Gutenberg PR


### PR DESCRIPTION
We're renaming the `main` branch to `trunk`. I updated the release script and replaced `main` with`trunk`.