### PR TITLE
Remove Dev only restriction on Pullquote on Android

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.35.6
+------
+* [**] [Android] New block: Pullquote
+
 1.35.0
 ------
 * [***] Fixed empty text fields on RTL layout. Now they are selectable and placeholders are visible.

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,4 @@
-1.35.6
+1.36.0
 ------
 * [**] [Android] New block: Pullquote
 


### PR DESCRIPTION
See related Gutenberg PR: https://github.com/WordPress/gutenberg/pull/24921

This PR should only be merged after a fix for missing pullquote placeholder is merged here: 
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/2307
- https://github.com/WordPress/gutenberg/pull/22561

To test:
Ensure you can see pullquote build in Production build on Android, and it has a placeholder on Android when empty.
PR submission checklist:

You can test production build to verify Pullquote is there using this WPAndroid test PR: https://github.com/wordpress-mobile/WordPress-Android/pull/12843

- [X] I have considered adding unit tests where possible.
- [X] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
