### PR TITLE
Increase tap-target of primary action on unsupported blocks

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.37.0
+------
+* [**] Increase tap-target of primary action on unsupported blocks.
+
 1.36.0
 ------
 * [**] [Android] New block: Pullquote

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,4 @@
-1.37.0
+1.38.0
 ------
 * [**] Increase tap-target of primary action on unsupported blocks.
 


### PR DESCRIPTION
Fixes : https://github.com/wordpress-mobile/gutenberg-mobile/issues/2567#
To test: Follow instructions from Gutenberg PR: https://github.com/WordPress/gutenberg/pull/25209

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
