### PR TITLE
Update jetpack

### DIFF
--- a/__device-tests__/gutenberg-editor-contact-info.test.js
+++ b/__device-tests__/gutenberg-editor-contact-info.test.js
@@ -95,91 +95,91 @@ describe.skip( 'Gutenberg Editor Contact Info Block tests', () => {
 		expect( contactInfoBlock ).toBeTruthy();
 	} );
 
-	it( 'should show keyboard when selecting email', async () => {
-		const emailBlock = await editorPage.getBlockAtPosition(
-			'Email Address'
-		);
-		emailBlock.click();
+	// it( 'should show keyboard when selecting email', async () => {
+	// 	const emailBlock = await editorPage.getBlockAtPosition(
+	// 		'Email Address'
+	// 	);
+	// 	emailBlock.click();
 
-		const keyboardShown = await driver.isKeyboardShown();
-		expect( keyboardShown ).toEqual( true );
+	// 	const keyboardShown = await driver.isKeyboardShown();
+	// 	expect( keyboardShown ).toEqual( true );
 
-		await editorPage.dismissKeyboard();
+	// 	await editorPage.dismissKeyboard();
 
-		const contactInfoBlock = await editorPage.getBlockAtPosition(
-			contactInfoBlockName
-		);
-		await clickBeginningOfElement( driver, contactInfoBlock );
-	} );
+	// 	const contactInfoBlock = await editorPage.getBlockAtPosition(
+	// 		contactInfoBlockName
+	// 	);
+	// 	await clickBeginningOfElement( driver, contactInfoBlock );
+	// } );
 
-	it( 'should show keyboard when selecting phone', async () => {
-		const phoneBlock = await editorPage.getBlockAtPosition(
-			'Phone Number',
-			2
-		);
-		phoneBlock.click();
+	// it( 'should show keyboard when selecting phone', async () => {
+	// 	const phoneBlock = await editorPage.getBlockAtPosition(
+	// 		'Phone Number',
+	// 		2
+	// 	);
+	// 	phoneBlock.click();
 
-		const keyboardShown = await driver.isKeyboardShown();
-		expect( keyboardShown ).toEqual( true );
+	// 	const keyboardShown = await driver.isKeyboardShown();
+	// 	expect( keyboardShown ).toEqual( true );
 
-		await editorPage.dismissKeyboard();
+	// 	await editorPage.dismissKeyboard();
 
-		const contactInfoBlock = await editorPage.getBlockAtPosition(
-			contactInfoBlockName
-		);
-		await clickBeginningOfElement( driver, contactInfoBlock );
-	} );
+	// 	const contactInfoBlock = await editorPage.getBlockAtPosition(
+	// 		contactInfoBlockName
+	// 	);
+	// 	await clickBeginningOfElement( driver, contactInfoBlock );
+	// } );
 
-	it( 'should show keyboard when selecting address', async () => {
-		const addressBlock = await editorPage.getBlockAtPosition(
-			'Address',
-			3
-		);
-		addressBlock.click();
+	// it( 'should show keyboard when selecting address', async () => {
+	// 	const addressBlock = await editorPage.getBlockAtPosition(
+	// 		'Address',
+	// 		3
+	// 	);
+	// 	addressBlock.click();
 
-		const keyboardShown = await driver.isKeyboardShown();
-		expect( keyboardShown ).toEqual( true );
+	// 	const keyboardShown = await driver.isKeyboardShown();
+	// 	expect( keyboardShown ).toEqual( true );
 
-		await editorPage.dismissKeyboard();
+	// 	await editorPage.dismissKeyboard();
 
-		const contactInfoBlock = await editorPage.getBlockAtPosition(
-			contactInfoBlockName
-		);
-		await clickBeginningOfElement( driver, contactInfoBlock );
-	} );
+	// 	const contactInfoBlock = await editorPage.getBlockAtPosition(
+	// 		contactInfoBlockName
+	// 	);
+	// 	await clickBeginningOfElement( driver, contactInfoBlock );
+	// } );
 
-	it( 'should have settings toggle on address block', async () => {
-		const addressBlock = await editorPage.getBlockAtPosition(
-			'Address',
-			3
-		);
-		addressBlock.click();
+	// it( 'should have settings toggle on address block', async () => {
+	// 	const addressBlock = await editorPage.getBlockAtPosition(
+	// 		'Address',
+	// 		3
+	// 	);
+	// 	addressBlock.click();
 
-		await toggleSettings( driver, editorPage, addressBlock );
+	// 	await toggleSettings( driver, editorPage, addressBlock );
 
-		const addressSettingsLabel = findElement(
-			driver,
-			editorPage,
-			'Address Settings',
-			'Label'
-		);
-		expect( addressSettingsLabel ).toBeTruthy();
+	// 	const addressSettingsLabel = findElement(
+	// 		driver,
+	// 		editorPage,
+	// 		'Address Settings',
+	// 		'Label'
+	// 	);
+	// 	expect( addressSettingsLabel ).toBeTruthy();
 
-		const addressSettingsLinkToggle = findElement(
-			driver,
-			editorPage,
-			'Link address to Google Maps',
-			'Toggle'
-		);
-		expect( addressSettingsLinkToggle ).toBeTruthy();
+	// 	const addressSettingsLinkToggle = findElement(
+	// 		driver,
+	// 		editorPage,
+	// 		'Link address to Google Maps',
+	// 		'Toggle'
+	// 	);
+	// 	expect( addressSettingsLinkToggle ).toBeTruthy();
 
-		await dismissActionSheet();
-		await editorPage.dismissKeyboard();
-		const contactInfoBlock = await editorPage.getBlockAtPosition(
-			contactInfoBlockName
-		);
-		await clickBeginningOfElement( driver, contactInfoBlock );
-	} );
+	// 	await dismissActionSheet();
+	// 	await editorPage.dismissKeyboard();
+	// 	const contactInfoBlock = await editorPage.getBlockAtPosition(
+	// 		contactInfoBlockName
+	// 	);
+	// 	await clickBeginningOfElement( driver, contactInfoBlock );
+	// } );
 
 	it( 'should only have phone, address, email, separator, heading and spacer options as child blocks', async () => {
 		const unavailableBlocks = [

--- a/__device-tests__/gutenberg-editor-contact-info.test.js
+++ b/__device-tests__/gutenberg-editor-contact-info.test.js
@@ -188,7 +188,6 @@ describe.skip( 'Gutenberg Editor Contact Info Block tests', () => {
 	} );
 
 	afterAll( async () => {
-		jest.resetModules();
 		if ( ! isLocalEnvironment() ) {
 			driver.sauceJobStatus( allPassed );
 		}

--- a/__device-tests__/gutenberg-editor-contact-info.test.js
+++ b/__device-tests__/gutenberg-editor-contact-info.test.js
@@ -14,6 +14,8 @@ import wd from 'wd';
 
 jest.setTimeout( 1000000 );
 
+// Disabling eslint here because these tests need to be disabled until Contact Info block is ungated from __DEV__.
+// eslint-disable-next-line jest/no-disabled-tests
 describe.skip( 'Gutenberg Editor Contact Info Block tests', () => {
 	let driver;
 	let editorPage;
@@ -32,34 +34,36 @@ describe.skip( 'Gutenberg Editor Contact Info Block tests', () => {
 		jasmine.getEnv().addReporter( reporter );
 	}
 
-	async function toggleSettings( driver, editorPage, block ) {
+	async function toggleSettings( drv, ePage, bk ) {
 		const buttonElementName = isAndroid()
 			? '//*'
 			: '//XCUIElementTypeButton';
-		const blockActionsMenuButtonLocator = `${ buttonElementName }[contains(@${ editorPage.accessibilityIdXPathAttrib }, "Open Settings")]`;
+		const blockActionsMenuButtonLocator = `${ buttonElementName }[contains(@${ ePage.accessibilityIdXPathAttrib }, "Open Settings")]`;
 
 		if ( isAndroid() ) {
-			let checkList = await driver.elementsByXPath(
+			let checkList = await drv.elementsByXPath(
 				blockActionsMenuButtonLocator
 			);
 			while ( checkList.length === 0 ) {
-				await swipeUp( driver, block ); // Swipe up to show remove icon at the bottom
-				checkList = await driver.elementsByXPath(
+				await swipeUp( drv, bk ); // Swipe up to show remove icon at the bottom
+				checkList = await drv.elementsByXPath(
 					blockActionsMenuButtonLocator
 				);
 			}
 		}
 
-		const blockActionsMenuButton = await driver.elementByXPath(
+		const blockActionsMenuButton = await drv.elementByXPath(
 			blockActionsMenuButtonLocator
 		);
 		await blockActionsMenuButton.click();
 	}
 
-	async function findElement( driver, editorPage, name, iosType ) {
-		const elementName = isAndroid() ? '//*' : `//XCUIElementType${iosType}`;
-		const blockLocator = `${ elementName }[contains(@${ editorPage.accessibilityIdXPathAttrib }, "${ name }")]`;
-		const elements = await driver.elementsByXPath( blockLocator );
+	async function findElement( drv, ePage, name, iosType ) {
+		const elementName = isAndroid()
+			? '//*'
+			: `//XCUIElementType${ iosType }`;
+		const blockLocator = `${ elementName }[contains(@${ ePage.accessibilityIdXPathAttrib }, "${ name }")]`;
+		const elements = await drv.elementsByXPath( blockLocator );
 		return elements[ 0 ];
 	}
 
@@ -92,7 +96,9 @@ describe.skip( 'Gutenberg Editor Contact Info Block tests', () => {
 	} );
 
 	it( 'should show keyboard when selecting email', async () => {
-		const emailBlock = await editorPage.getBlockAtPosition( 'Email Address' );
+		const emailBlock = await editorPage.getBlockAtPosition(
+			'Email Address'
+		);
 		emailBlock.click();
 
 		const keyboardShown = await driver.isKeyboardShown();
@@ -107,7 +113,10 @@ describe.skip( 'Gutenberg Editor Contact Info Block tests', () => {
 	} );
 
 	it( 'should show keyboard when selecting phone', async () => {
-		const phoneBlock = await editorPage.getBlockAtPosition( 'Phone Number', 2 );
+		const phoneBlock = await editorPage.getBlockAtPosition(
+			'Phone Number',
+			2
+		);
 		phoneBlock.click();
 
 		const keyboardShown = await driver.isKeyboardShown();
@@ -122,7 +131,10 @@ describe.skip( 'Gutenberg Editor Contact Info Block tests', () => {
 	} );
 
 	it( 'should show keyboard when selecting address', async () => {
-		const addressBlock = await editorPage.getBlockAtPosition( 'Address', 3 );
+		const addressBlock = await editorPage.getBlockAtPosition(
+			'Address',
+			3
+		);
 		addressBlock.click();
 
 		const keyboardShown = await driver.isKeyboardShown();
@@ -137,16 +149,29 @@ describe.skip( 'Gutenberg Editor Contact Info Block tests', () => {
 	} );
 
 	it( 'should have settings toggle on address block', async () => {
-		const addressBlock = await editorPage.getBlockAtPosition( 'Address', 3 );
+		const addressBlock = await editorPage.getBlockAtPosition(
+			'Address',
+			3
+		);
 		addressBlock.click();
 
-		await toggleSettings(driver, editorPage, addressBlock);
+		await toggleSettings( driver, editorPage, addressBlock );
 
-		const addressSettingsLabel = findElement(driver, editorPage, 'Address Settings', 'Label');
-		expect(addressSettingsLabel).toBeTruthy();
+		const addressSettingsLabel = findElement(
+			driver,
+			editorPage,
+			'Address Settings',
+			'Label'
+		);
+		expect( addressSettingsLabel ).toBeTruthy();
 
-		const addressSettingsLinkToggle = findElement(driver, editorPage, 'Link address to Google Maps', 'Toggle');
-		expect(addressSettingsLinkToggle).toBeTruthy();
+		const addressSettingsLinkToggle = findElement(
+			driver,
+			editorPage,
+			'Link address to Google Maps',
+			'Toggle'
+		);
+		expect( addressSettingsLinkToggle ).toBeTruthy();
 
 		await dismissActionSheet();
 		await editorPage.dismissKeyboard();
@@ -157,22 +182,57 @@ describe.skip( 'Gutenberg Editor Contact Info Block tests', () => {
 	} );
 
 	it( 'should only have phone, address, email, separator, heading and spacer options as child blocks', async () => {
-		const unavailableBlocks = [ 'Paragraph', 'More', 'Image', 'Video', 'Page Break', 'List', 'Quote', 'Media & Text', 'Preformatted', 'Gallery',
-		'Columns', 'Group', 'Shortcode', 'Buttons', 'Latest Posts', 'Verse', 'Cover', 'Social Icons', 'Pullquote' ];
-		const availableBlocks = [ 'Address', 'Email Address', 'Phone Number', 'Heading', 'Separator', 'Spacer' ];
+		const unavailableBlocks = [
+			'Paragraph',
+			'More',
+			'Image',
+			'Video',
+			'Page Break',
+			'List',
+			'Quote',
+			'Media & Text',
+			'Preformatted',
+			'Gallery',
+			'Columns',
+			'Group',
+			'Shortcode',
+			'Buttons',
+			'Latest Posts',
+			'Verse',
+			'Cover',
+			'Social Icons',
+			'Pullquote',
+		];
+		const availableBlocks = [
+			'Address',
+			'Email Address',
+			'Phone Number',
+			'Heading',
+			'Separator',
+			'Spacer',
+		];
 
-		const emailBlock = await editorPage.getBlockAtPosition( 'Email Address' );
+		const emailBlock = await editorPage.getBlockAtPosition(
+			'Email Address'
+		);
 		emailBlock.click();
 
-		const addBlockIdentifier = isAndroid() ? 'Add block, Double tap to add a block' : 'Add block';
+		const addBlockIdentifier = isAndroid()
+			? 'Add block, Double tap to add a block'
+			: 'Add block';
 		const addButton = await driver.elementByAccessibilityId(
 			addBlockIdentifier
 		);
 		await addButton.click();
 
-		for (const blockName of [ ...unavailableBlocks, ...availableBlocks ]) {
-			const block = await driver.hasElementByAccessibilityId(blockName);
-			expect(block).toBe(availableBlocks.includes(blockName));
+		// Disabling eslint for next line because there seems to be a bug where variable in for...of block isn't seen.
+		// eslint-disable-next-line no-unused-vars
+		for ( const blockName of [
+			...unavailableBlocks,
+			...availableBlocks,
+		] ) {
+			const block = await driver.hasElementByAccessibilityId( blockName );
+			expect( block ).toBe( availableBlocks.includes( blockName ) );
 		}
 
 		await dismissActionSheet();

--- a/__device-tests__/gutenberg-editor-contact-info.test.js
+++ b/__device-tests__/gutenberg-editor-contact-info.test.js
@@ -3,18 +3,22 @@
  */
 import EditorPage from '../gutenberg/packages/react-native-editor/__device-tests__/pages/editor-page';
 import {
-	setupDriver,
+	clickBeginningOfElement,
+	isAndroid,
 	isLocalEnvironment,
+	setupDriver,
 	stopDriver,
+	swipeUp,
 } from '../gutenberg/packages/react-native-editor/__device-tests__/helpers/utils';
+import wd from 'wd';
 
 jest.setTimeout( 1000000 );
 
-describe( 'Gutenberg Editor Contact Info Block tests', () => {
+describe.skip( 'Gutenberg Editor Contact Info Block tests', () => {
 	let driver;
 	let editorPage;
 	let allPassed = true;
-	// const contactInfoBlockName = 'Contact Info';
+	const contactInfoBlockName = 'Contact Info';
 
 	// Use reporter for setting status for saucelabs Job
 	if ( ! isLocalEnvironment() ) {
@@ -28,18 +32,163 @@ describe( 'Gutenberg Editor Contact Info Block tests', () => {
 		jasmine.getEnv().addReporter( reporter );
 	}
 
+	async function toggleSettings( driver, editorPage, block ) {
+		const buttonElementName = isAndroid()
+			? '//*'
+			: '//XCUIElementTypeButton';
+		const blockActionsMenuButtonLocator = `${ buttonElementName }[contains(@${ editorPage.accessibilityIdXPathAttrib }, "Open Settings")]`;
+
+		if ( isAndroid() ) {
+			let checkList = await driver.elementsByXPath(
+				blockActionsMenuButtonLocator
+			);
+			while ( checkList.length === 0 ) {
+				await swipeUp( driver, block ); // Swipe up to show remove icon at the bottom
+				checkList = await driver.elementsByXPath(
+					blockActionsMenuButtonLocator
+				);
+			}
+		}
+
+		const blockActionsMenuButton = await driver.elementByXPath(
+			blockActionsMenuButtonLocator
+		);
+		await blockActionsMenuButton.click();
+	}
+
+	async function findElement( driver, editorPage, name, iosType ) {
+		const elementName = isAndroid() ? '//*' : `//XCUIElementType${iosType}`;
+		const blockLocator = `${ elementName }[contains(@${ editorPage.accessibilityIdXPathAttrib }, "${ name }")]`;
+		const elements = await driver.elementsByXPath( blockLocator );
+		return elements[ 0 ];
+	}
+
+	async function dismissActionSheet() {
+		const action = await new wd.TouchAction( driver );
+		action.press( { x: 100, y: 100 } );
+		action.release();
+		await action.perform();
+	}
+
 	beforeAll( async () => {
 		driver = await setupDriver();
 		editorPage = new EditorPage( driver );
+	} );
+
+	beforeEach( async () => {
+		await editorPage.addNewBlock( contactInfoBlockName );
 	} );
 
 	it( 'should be able to see visual editor', async () => {
 		await expect( editorPage.getBlockList() ).resolves.toBe( true );
 	} );
 
-	//TODO: Add tests
+	it( 'should be able to add contact info block', async () => {
+		const contactInfoBlock = await editorPage.getBlockAtPosition(
+			contactInfoBlockName
+		);
+
+		expect( contactInfoBlock ).toBeTruthy();
+	} );
+
+	it( 'should show keyboard when selecting email', async () => {
+		const emailBlock = await editorPage.getBlockAtPosition( 'Email Address' );
+		emailBlock.click();
+
+		const keyboardShown = await driver.isKeyboardShown();
+		expect( keyboardShown ).toEqual( true );
+
+		await editorPage.dismissKeyboard();
+
+		const contactInfoBlock = await editorPage.getBlockAtPosition(
+			contactInfoBlockName
+		);
+		await clickBeginningOfElement( driver, contactInfoBlock );
+	} );
+
+	it( 'should show keyboard when selecting phone', async () => {
+		const phoneBlock = await editorPage.getBlockAtPosition( 'Phone Number', 2 );
+		phoneBlock.click();
+
+		const keyboardShown = await driver.isKeyboardShown();
+		expect( keyboardShown ).toEqual( true );
+
+		await editorPage.dismissKeyboard();
+
+		const contactInfoBlock = await editorPage.getBlockAtPosition(
+			contactInfoBlockName
+		);
+		await clickBeginningOfElement( driver, contactInfoBlock );
+	} );
+
+	it( 'should show keyboard when selecting address', async () => {
+		const addressBlock = await editorPage.getBlockAtPosition( 'Address', 3 );
+		addressBlock.click();
+
+		const keyboardShown = await driver.isKeyboardShown();
+		expect( keyboardShown ).toEqual( true );
+
+		await editorPage.dismissKeyboard();
+
+		const contactInfoBlock = await editorPage.getBlockAtPosition(
+			contactInfoBlockName
+		);
+		await clickBeginningOfElement( driver, contactInfoBlock );
+	} );
+
+	it( 'should have settings toggle on address block', async () => {
+		const addressBlock = await editorPage.getBlockAtPosition( 'Address', 3 );
+		addressBlock.click();
+
+		await toggleSettings(driver, editorPage, addressBlock);
+
+		const addressSettingsLabel = findElement(driver, editorPage, 'Address Settings', 'Label');
+		expect(addressSettingsLabel).toBeTruthy();
+
+		const addressSettingsLinkToggle = findElement(driver, editorPage, 'Link address to Google Maps', 'Toggle');
+		expect(addressSettingsLinkToggle).toBeTruthy();
+
+		await dismissActionSheet();
+		await editorPage.dismissKeyboard();
+		const contactInfoBlock = await editorPage.getBlockAtPosition(
+			contactInfoBlockName
+		);
+		await clickBeginningOfElement( driver, contactInfoBlock );
+	} );
+
+	it( 'should only have phone, address, email, separator, heading and spacer options as child blocks', async () => {
+		const unavailableBlocks = [ 'Paragraph', 'More', 'Image', 'Video', 'Page Break', 'List', 'Quote', 'Media & Text', 'Preformatted', 'Gallery',
+		'Columns', 'Group', 'Shortcode', 'Buttons', 'Latest Posts', 'Verse', 'Cover', 'Social Icons', 'Pullquote' ];
+		const availableBlocks = [ 'Address', 'Email Address', 'Phone Number', 'Heading', 'Separator', 'Spacer' ];
+
+		const emailBlock = await editorPage.getBlockAtPosition( 'Email Address' );
+		emailBlock.click();
+
+		const addBlockIdentifier = isAndroid() ? 'Add block, Double tap to add a block' : 'Add block';
+		const addButton = await driver.elementByAccessibilityId(
+			addBlockIdentifier
+		);
+		await addButton.click();
+
+		for (const blockName of [ ...unavailableBlocks, ...availableBlocks ]) {
+			const block = await driver.hasElementByAccessibilityId(blockName);
+			expect(block).toBe(availableBlocks.includes(blockName));
+		}
+
+		await dismissActionSheet();
+		await editorPage.dismissKeyboard();
+		const contactInfoBlock = await editorPage.getBlockAtPosition(
+			contactInfoBlockName
+		);
+		await clickBeginningOfElement( driver, contactInfoBlock );
+	} );
+
+	afterEach( async () => {
+		await editorPage.removeBlockAtPosition( contactInfoBlockName );
+	} );
 
 	afterAll( async () => {
+		jest.resetModules();
 		if ( ! isLocalEnvironment() ) {
 			driver.sauceJobStatus( allPassed );
 		}


### PR DESCRIPTION
Fixes #[2166](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2166)
This updates the jetpack submodule hash. See [PR #17123](https://github.com/Automattic/jetpack/pull/17123) for details.

Also adds UI (Appium) tests for Contact Info. Currently skipped due to the `if (__DEV__)` block gating Contact Info. Can remove the skip (`describe.skip` to `describe`) when the gate is removed.

NOTE: There are commented out UI tests. Those tests are commented out for now because they are intermittently failing on Android. On Android, `getLocation` seems to be getting the wrong location coordinates for the block given, causing the top bar to be pressed instead of what should actually be pressed (which is the outside of the inner blocks in Contact Info, causing an inner block to be removed instead of the entire Contact Info block). The other difference causing this issue in Android but not in iOS is that `editorPage.dismissKeyboard()` deselects the child block in iOS but not in Android.