### PR TITLE
Update README to correct initial setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ git submodule update
 Before running the demo app, you need to download and install the project dependencies. This is done via the following command:
 
 ```
+cd gutenberg
 nvm install --latest-npm
+cd ..
 npm install
 ```
 


### PR DESCRIPTION
This repo doesn't have an `.nvmrc` file on it's own. This means the instruction `nvm install --latest-npm` would install the latest `node` version, which is not what we want. The submodule `gutenberg` repo has an `.nvmrc` which is kept up-to-date and we are making `nvm` use that one by adding these new steps that `cd` into `gutenberg` before installing `node`.