### PR TITLE
Update content hash item limit to prevent Watchman crawl failed errors

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,1 +1,3 @@
-{}
+{
+	"content_hash_max_items": 400000
+}


### PR DESCRIPTION
`Related-PR` https://github.com/WordPress/gutenberg/pull/25385

## Fixes:
While running the metro server locally we'll see the error:

```
Loading dependency graph...jest-haste-map: Watchman crawl failed. Retrying once with node crawler.
  Usually this happens when watchman isn't running. Create an empty `.watchmanconfig` file in your project's root folder or initialize a git or hg repository in your project.
  Error: Watchman error: too many pending cache jobs. Make sure watchman is running for this project. See https://facebook.github.io/watchman/docs/troubleshooting.html.
```

This error will occur when our file size has outgrown the default cache size of metro (more info in this [SO answer](https://stackoverflow.com/a/57448116/1350218)) This increases the content hash size limit to prevent the error.

## To test:
1. Run `npm run clean`
1. Run `npm start --reset-cache`

**Expect** The Metro server to start without displaying the cache failure error

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
