### PR TITLE
Updating package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2855,11 +2855,11 @@
       "version": "file:gutenberg/packages/babel-preset-default",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.9.0",
-        "@babel/plugin-transform-react-jsx": "^7.9.4",
-        "@babel/plugin-transform-runtime": "^7.9.0",
-        "@babel/preset-env": "^7.9.0",
-        "@babel/runtime": "^7.9.2",
+        "@babel/core": "^7.11.6",
+        "@babel/plugin-transform-react-jsx": "^7.10.4",
+        "@babel/plugin-transform-runtime": "^7.11.5",
+        "@babel/preset-env": "^7.11.5",
+        "@babel/runtime": "^7.11.2",
         "@wordpress/babel-plugin-import-jsx-pragma": "file:gutenberg/packages/babel-plugin-import-jsx-pragma",
         "@wordpress/browserslist-config": "file:gutenberg/packages/browserslist-config",
         "@wordpress/element": "file:gutenberg/packages/element",
@@ -2883,7 +2883,7 @@
       "version": "file:gutenberg/packages/element",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.9.2",
+        "@babel/runtime": "^7.11.2",
         "@wordpress/escape-html": "file:gutenberg/packages/escape-html",
         "lodash": "^4.17.19",
         "react": "^16.13.1",
@@ -2902,7 +2902,7 @@
       "version": "file:gutenberg/packages/escape-html",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.9.2"
+        "@babel/runtime": "^7.11.2"
       }
     },
     "@wordpress/eslint-plugin": {
@@ -2997,7 +2997,7 @@
       "version": "file:gutenberg/packages/jest-console",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.9.2",
+        "@babel/runtime": "^7.11.2",
         "jest-matcher-utils": "^25.3.0",
         "lodash": "^4.17.19"
       },


### PR DESCRIPTION
This PR updates package-lock.json to be in sync with `gutenberg` dependencies.

@ceyhun - would you mind a review? 🙏 
Thanks!

To test:
- run `npm install`
- Check that there are no diffs

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
