### PR TITLE
Try running scheduled device tests targeting gutenberg master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,6 +283,4 @@ workflows:
           cron: '1 1,13 * * *'
           filters:
             branches:
-              only:
-                - develop
-                - add/ci-on-gb-master
+              only: develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,10 +25,15 @@ commands:
           name: Checkout Submodules
           command: git submodule update --init --recursive
   add-jest-reporter-dir:
-      steps:
-        - run:
-            name: Create reports directory
-            command: mkdir reports && mkdir reports/test-results
+    steps:
+      - run:
+          name: Create reports directory
+          command: mkdir reports && mkdir reports/test-results
+  checkout-gutenberg-master:
+    steps:
+      - run:
+          name: Checkout gutenberg master
+          command: cd gutenberg && git fetch origin && git checkout origin/master
 
 jobs:
   checks:
@@ -71,6 +76,9 @@ jobs:
       is-canary:
         type: string
         default: ""
+      target-gutenberg-master:
+        type: boolean
+        default: false
     docker:
     - image: circleci/android:api-29-node
     environment:
@@ -79,6 +87,10 @@ jobs:
     steps:
       - checkout
       - checkout-submodules
+      - when:
+          condition: << parameters.target-gutenberg-master >>
+          steps:
+            - checkout-gutenberg-master
       - npm-install
       - add-jest-reporter-dir
       - run:
@@ -134,11 +146,18 @@ jobs:
       is-canary:
         type: string
         default: ""
+      target-gutenberg-master:
+        type: boolean
+        default: false
     macos:
       xcode: "11.2.1"
     steps:
     - checkout
     - checkout-submodules
+    - when:
+        condition: << parameters.target-gutenberg-master >>
+        steps:
+          - checkout-gutenberg-master
     - npm-install
     - add-jest-reporter-dir
     - run:
@@ -251,6 +270,14 @@ workflows:
       - android-device-checks:
           name: Test Android on Device - Scheduled
           post-to-slack: true
+      - ios-device-checks:
+          name: Test iOS on Device targetting gutenberg master - Scheduled
+          post-to-slack: true
+          target-gutenberg-master: true
+      - android-device-checks:
+          name: Test Android on Device targetting gutenberg master - Scheduled
+          post-to-slack: true
+          target-gutenberg-master: true
     triggers:
       - schedule:
           cron: '1 1,13 * * *'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,4 +292,6 @@ workflows:
           cron: '1 2,14 * * *'
           filters:
             branches:
-              only: develop
+              only:
+                - develop
+                - add/ci-on-gb-master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,4 +283,6 @@ workflows:
           cron: '1 1,13 * * *'
           filters:
             branches:
-              only: develop
+              only:
+                - develop
+                - add/ci-on-gb-master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,11 +281,11 @@ workflows:
     jobs:
       - ios-device-checks:
           name: Test iOS on Device targetting gutenberg master - Scheduled
-          post-to-slack: true
+          post-to-slack: false
           target-gutenberg-master: true
       - android-device-checks:
           name: Test Android on Device targetting gutenberg master - Scheduled
-          post-to-slack: true
+          post-to-slack: false
           target-gutenberg-master: true
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,6 +270,15 @@ workflows:
       - android-device-checks:
           name: Test Android on Device - Scheduled
           post-to-slack: true
+    triggers:
+      - schedule:
+          cron: '1 1,13 * * *'
+          filters:
+            branches:
+              only: develop
+
+  ui-tests-targeting-master-full-scheduled:
+    jobs:
       - ios-device-checks:
           name: Test iOS on Device targetting gutenberg master - Scheduled
           post-to-slack: true
@@ -280,7 +289,7 @@ workflows:
           target-gutenberg-master: true
     triggers:
       - schedule:
-          cron: '1 1,13 * * *'
+          cron: '1 2,14 * * *'
           filters:
             branches:
               only: develop


### PR DESCRIPTION
WIP

This PR adds new scheduled device tests to CircleCI. The same exact set of tests is running but it targets gutenberg master instead of the default ref so we can spot regressions as they appear in gutenberg.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
