### PR TITLE
Clarify that milestones are not required in release checklist

### DIFF
--- a/docs/Releasing.md
+++ b/docs/Releasing.md
@@ -33,7 +33,7 @@ cut a new release.
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>o Visit all opened PR's in gutenberg-mobile repo that are assigned to milestone X.XX.X and leave proper message with options to merge them or to bump them to the next version.</p>
+<p>o Visit all opened PR's in gutenberg-mobile repo that are assigned to milestone X.XX.X and leave a message with options to (i) merge the PR as soon as possible, (ii) bump the PR to the next milestone, or (iii) remove the milestone from the PR.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->


### PR DESCRIPTION
Updates the PR checklist item for commenting on pending PRs to clarify that the milestone can simply be removed because milestones are not required in this repo. The hope is that this will result in fewer PRs with unnecessary milestones.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
