### PR TITLE
Fix "ENOMEM: not enough memory, write" error on CI with Android E2E tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,37 +233,37 @@ jobs:
 workflows:
   gutenberg-mobile:
     jobs:
-      - checks:
-          name: Check Correctness
-          check-correctness: true
-      - checks:
-          name: Test iOS
-          platform: ios
-          check-tests: true
-      - checks:
-          name: Test Android
-          platform: android
-          check-tests: true
-      - ios-device-checks:
-          name: Test iOS on Device - Canaries
-          is-canary: "-canary"
+      # - checks:
+      #     name: Check Correctness
+      #     check-correctness: true
+      # - checks:
+      #     name: Test iOS
+      #     platform: ios
+      #     check-tests: true
+      # - checks:
+      #     name: Test Android
+      #     platform: android
+      #     check-tests: true
+      # - ios-device-checks:
+      #     name: Test iOS on Device - Canaries
+      #     is-canary: "-canary"
       - android-device-checks:
           name: Test Android on Device - Canaries
           is-canary: "-canary"
-      - Optional UI Tests:
-          type: approval
-          filters:
-            branches:
-              ignore:
-                - develop
-      - ios-device-checks:
-          name: Test iOS on Device - Full
-          requires: [ "Optional UI Tests" ]
-      - android-device-checks:
-          name: Test Android on Device - Full
-          requires: [ "Optional UI Tests" ]
-      - android-native-unit-tests:
-          name: Android Native Unit Tests
+      # - Optional UI Tests:
+      #     type: approval
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - develop
+      # - ios-device-checks:
+      #     name: Test iOS on Device - Full
+      #     requires: [ "Optional UI Tests" ]
+      # - android-device-checks:
+      #     name: Test Android on Device - Full
+      #     requires: [ "Optional UI Tests" ]
+      # - android-native-unit-tests:
+      #     name: Android Native Unit Tests
 
   ui-tests-full-scheduled:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
           command: |
             source bin/sauce-pre-upload.sh
             curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" -X POST -H "Content-Type: application/octet-stream" https://saucelabs.com/rest/v1/storage/automattic/Gutenberg-$SAUCE_FILENAME.apk?overwrite=true --data-binary @./gutenberg/packages/react-native-editor/android/app/build/outputs/apk/debug/app-debug.apk
-      - add-jest-reporter-dir
+      - run: mkdir /home/circleci/test-results
       - run:
           name: Run Device Tests
           command: npm run device-tests<<parameters.is-canary>>
@@ -125,9 +125,9 @@ jobs:
           environment:
             TEST_RN_PLATFORM: android
             TEST_ENV: sauce
-            JEST_JUNIT_OUTPUT: "reports/test-results/android-test-results.xml"
+            JEST_JUNIT_OUTPUT: "/home/circleci/test-results/android-test-results.xml"
       - store_test_results:
-          path: ./reports/test-results
+          path: /home/circleci/test-results
       - when:
           condition: << parameters.post-to-slack >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
       - run: node -v
       - run: npm install -g yarn
       - npm-install
-      - run: npm run bundle:android
+      - run: npm run test:e2e:bundle:android
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,20 +84,6 @@ jobs:
             JEST_JUNIT_OUTPUT: "reports/test-results/android-test-results.xml"
       - store_test_results:
           path: ./reports/test-results
-  bundle-android-js:
-    machine:
-      image: ubuntu-1604:202007-01
-    steps:
-      - checkout
-      - checkout-submodules
-      - run: node -v
-      - run: npm install -g yarn
-      - npm-install
-      - run: npm run test:e2e:bundle:android
-      - persist_to_workspace:
-          root: .
-          paths:
-            - "gutenberg/packages/react-native-editor/android/app/src/main"
   android-device-checks:
     parameters:
       post-to-slack:
@@ -107,23 +93,29 @@ jobs:
       is-canary:
         type: string
         default: ""
-    docker:
-    - image: circleci/android:api-29-node@sha256:71d61d6c21b29948d57120f476a83cc322a280979bce355c5a0ad771293ca380
-    environment:
-      JAVA_OPTS: '-Xms512m -Xmx2g'
-      GRADLE_OPTS: '-Xmx3g -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xmx2g -XX:+HeapDumpOnOutOfMemoryError"'
+    machine:
+      image: ubuntu-1604:202007-01
     steps:
       - checkout
       - checkout-submodules
+      - run: node -v
+      - run: npm install -g yarn
       - npm-install
       - add-jest-reporter-dir
-      - attach_workspace:
-          at: "gutenberg/packages/react-native-editor/android/app/src/main"
+      - run: npm run test:e2e:bundle:android
       - run:
           name: Set Environment Variables
           command: |
             echo 'export TEST_RN_PLATFORM=android' >> $BASH_ENV
             echo 'export TEST_ENV=sauce' >> $BASH_ENV
+      - run: |
+          docker run --rm -it \
+          --volume $(pwd):/home/circleci/project \
+          --workdir /home/circleci/project \
+          --env JAVA_OPTS='-Xms512m -Xmx2g' \
+          --env GRADLE_OPTS='-Xmx3g -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xmx2g -XX:+HeapDumpOnOutOfMemoryError"' \
+          circleci/android@sha256:71d61d6c21b29948d57120f476a83cc322a280979bce355c5a0ad771293ca380 \
+          npm run core test:e2e:build-app:android
       - run:
           name: Generate debug .apk file for testing
           command: npm run core test:e2e:build-app:android
@@ -263,12 +255,9 @@ workflows:
       # - ios-device-checks:
       #     name: Test iOS on Device - Canaries
       #     is-canary: "-canary"
-      - bundle-android-js
       - android-device-checks:
           name: Test Android on Device - Canaries
           is-canary: "-canary"
-          requires:
-            - bundle-android-js
       # - Optional UI Tests:
       #     type: approval
       #     filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,7 @@ jobs:
           docker run --rm -it \
           --volume $(pwd):/home/circleci/project \
           --workdir /home/circleci/project \
+          --user $(id -u):$(id -g) \
           --env JAVA_OPTS='-Xms512m -Xmx2g' \
           --env GRADLE_OPTS='-Xmx3g -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xmx2g -XX:+HeapDumpOnOutOfMemoryError"' \
           circleci/android@sha256:71d61d6c21b29948d57120f476a83cc322a280979bce355c5a0ad771293ca380 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,7 @@ jobs:
       - checkout
       - checkout-submodules
       - run: node -v
+      - run: npm install -g yarn
       - npm-install
       - add-jest-reporter-dir
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,37 +240,37 @@ jobs:
 workflows:
   gutenberg-mobile:
     jobs:
-      # - checks:
-      #     name: Check Correctness
-      #     check-correctness: true
-      # - checks:
-      #     name: Test iOS
-      #     platform: ios
-      #     check-tests: true
-      # - checks:
-      #     name: Test Android
-      #     platform: android
-      #     check-tests: true
-      # - ios-device-checks:
-      #     name: Test iOS on Device - Canaries
-      #     is-canary: "-canary"
+      - checks:
+          name: Check Correctness
+          check-correctness: true
+      - checks:
+          name: Test iOS
+          platform: ios
+          check-tests: true
+      - checks:
+          name: Test Android
+          platform: android
+          check-tests: true
+      - ios-device-checks:
+          name: Test iOS on Device - Canaries
+          is-canary: "-canary"
       - android-device-checks:
           name: Test Android on Device - Canaries
           is-canary: "-canary"
-      # - Optional UI Tests:
-      #     type: approval
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - develop
-      # - ios-device-checks:
-      #     name: Test iOS on Device - Full
-      #     requires: [ "Optional UI Tests" ]
-      # - android-device-checks:
-      #     name: Test Android on Device - Full
-      #     requires: [ "Optional UI Tests" ]
-      # - android-native-unit-tests:
-      #     name: Android Native Unit Tests
+      - Optional UI Tests:
+          type: approval
+          filters:
+            branches:
+              ignore:
+                - develop
+      - ios-device-checks:
+          name: Test iOS on Device - Full
+          requires: [ "Optional UI Tests" ]
+      - android-device-checks:
+          name: Test Android on Device - Full
+          requires: [ "Optional UI Tests" ]
+      - android-native-unit-tests:
+          name: Android Native Unit Tests
 
   ui-tests-full-scheduled:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,14 +93,17 @@ jobs:
       is-canary:
         type: string
         default: ""
-    docker:
-    - image: circleci/android:api-29-node@sha256:71d61d6c21b29948d57120f476a83cc322a280979bce355c5a0ad771293ca380
+    machine:
+      image: ubuntu-1604:202007-01
     environment:
       JAVA_OPTS: '-Xms512m -Xmx2g'
       GRADLE_OPTS: '-Xmx3g -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xmx2g -XX:+HeapDumpOnOutOfMemoryError"'
     steps:
       - checkout
       - checkout-submodules
+      - run:
+          name: Set Node Version
+          command: cd gutenberg && nvm install --latest-npm && cd ..
       - npm-install
       - add-jest-reporter-dir
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,6 @@ jobs:
       - run: node -v
       - run: npm install -g yarn
       - npm-install
-      - add-jest-reporter-dir
       - run: npm run test:e2e:bundle:android
       - run:
           name: Set Environment Variables
@@ -123,6 +122,7 @@ jobs:
           command: |
             source bin/sauce-pre-upload.sh
             curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" -X POST -H "Content-Type: application/octet-stream" https://saucelabs.com/rest/v1/storage/automattic/Gutenberg-$SAUCE_FILENAME.apk?overwrite=true --data-binary @./gutenberg/packages/react-native-editor/android/app/build/outputs/apk/debug/app-debug.apk
+      - add-jest-reporter-dir
       - run:
           name: Run Device Tests
           command: npm run device-tests<<parameters.is-canary>>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,14 +108,16 @@ jobs:
           command: |
             echo 'export TEST_RN_PLATFORM=android' >> $BASH_ENV
             echo 'export TEST_ENV=sauce' >> $BASH_ENV
-      - run: |
-          docker run --rm -it \
-          --volume $(pwd):/home/circleci/project \
-          --workdir /home/circleci/project \
-          --env JAVA_OPTS='-Xms512m -Xmx2g' \
-          --env GRADLE_OPTS='-Xmx3g -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xmx2g -XX:+HeapDumpOnOutOfMemoryError"' \
-          circleci/android@sha256:71d61d6c21b29948d57120f476a83cc322a280979bce355c5a0ad771293ca380 \
-          /bin/bash -c "sudo chown -R circleci:circleci . && npm run core test:e2e:build-app:android"
+      - run:
+          name: Build apk
+          command: |
+            docker run --rm -it \
+            --volume $(pwd):/home/circleci/project \
+            --workdir /home/circleci/project \
+            --env JAVA_OPTS='-Xms512m -Xmx2g' \
+            --env GRADLE_OPTS='-Xmx3g -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xmx2g -XX:+HeapDumpOnOutOfMemoryError"' \
+            circleci/android@sha256:71d61d6c21b29948d57120f476a83cc322a280979bce355c5a0ad771293ca380 \
+            /bin/bash -c "sudo chown -R circleci:circleci . && npm run core test:e2e:build-app:android"
       - run:
           name: Upload apk to sauce labs
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,9 +117,6 @@ jobs:
           circleci/android@sha256:71d61d6c21b29948d57120f476a83cc322a280979bce355c5a0ad771293ca380 \
           npm run core test:e2e:build-app:android
       - run:
-          name: Generate debug .apk file for testing
-          command: npm run core test:e2e:build-app:android
-      - run:
           name: Upload apk to sauce labs
           command: |
             source bin/sauce-pre-upload.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
         type: string
         default: ""
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202010-01
     steps:
       - checkout
       - checkout-submodules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,11 +103,6 @@ jobs:
       - npm-install
       - run: npm run test:e2e:bundle:android
       - run:
-          name: Set Environment Variables
-          command: |
-            echo 'export TEST_RN_PLATFORM=android' >> $BASH_ENV
-            echo 'export TEST_ENV=sauce' >> $BASH_ENV
-      - run:
           name: Build apk
           command: |
             docker run --rm -it \
@@ -128,6 +123,8 @@ jobs:
           command: npm run device-tests<<parameters.is-canary>>
           no_output_timeout: 1200
           environment:
+            TEST_RN_PLATFORM: android
+            TEST_ENV: sauce
             JEST_JUNIT_OUTPUT: "reports/test-results/android-test-results.xml"
       - store_test_results:
           path: ./reports/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
             --workdir /home/circleci/project \
             --env JAVA_OPTS='-Xms512m -Xmx2g' \
             --env GRADLE_OPTS='-Xmx3g -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xmx2g -XX:+HeapDumpOnOutOfMemoryError"' \
-            circleci/android@sha256:71d61d6c21b29948d57120f476a83cc322a280979bce355c5a0ad771293ca380 \
+            circleci/android:api-29-node \
             /bin/bash -c "sudo chown -R circleci:circleci . && npm run core test:e2e:build-app:android"
       - run:
           name: Upload apk to sauce labs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
           --env JAVA_OPTS='-Xms512m -Xmx2g' \
           --env GRADLE_OPTS='-Xmx3g -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xmx2g -XX:+HeapDumpOnOutOfMemoryError"' \
           circleci/android@sha256:71d61d6c21b29948d57120f476a83cc322a280979bce355c5a0ad771293ca380 \
-          sudo chown circleci:circleci * && npm run core test:e2e:build-app:android
+          /bin/bash -c "sudo chown -R circleci:circleci . && npm run core test:e2e:build-app:android"
       - run:
           name: Upload apk to sauce labs
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
         type: string
         default: ""
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2004:202010-01 # Latest supported ubuntu image from https://circleci.com/docs/2.0/configuration-reference/#available-machine-images
     steps:
       - checkout
       - checkout-submodules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - "bundle/android"
+            - "gutenberg/packages/react-native-editor/android/app/src/main"
   android-device-checks:
     parameters:
       post-to-slack:
@@ -118,7 +118,7 @@ jobs:
       - npm-install
       - add-jest-reporter-dir
       - attach_workspace:
-          at: "bundle/android"
+          at: "gutenberg/packages/react-native-editor/android/app/src/main"
       - run:
           name: Set Environment Variables
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,12 @@ commands:
             name: Create reports directory
             command: mkdir reports && mkdir reports/test-results
 
+parameters:
+  android-docker-image:
+    type: string
+    # Hash points to previous version with node 12. When everything works with node 14 it can be removed
+    default: "circleci/android:api-29-node@sha256:71d61d6c21b29948d57120f476a83cc322a280979bce355c5a0ad771293ca380" 
+
 jobs:
   checks:
     parameters:
@@ -110,7 +116,7 @@ jobs:
             --workdir /home/circleci/project \
             --env JAVA_OPTS='-Xms512m -Xmx2g' \
             --env GRADLE_OPTS='-Xmx3g -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xmx2g -XX:+HeapDumpOnOutOfMemoryError"' \
-            circleci/android:api-29-node \
+            << pipeline.parameters.android-docker-image >> \
             /bin/bash -c "sudo chown -R circleci:circleci . && npm run core test:e2e:build-app:android"
       - run:
           name: Upload apk to sauce labs
@@ -143,7 +149,7 @@ jobs:
         type: boolean
         default: false
     docker:
-    - image: circleci/android:api-29-node@sha256:71d61d6c21b29948d57120f476a83cc322a280979bce355c5a0ad771293ca380
+    - image: << pipeline.parameters.android-docker-image >>
     steps:
       - checkout
       - checkout-submodules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,9 +101,7 @@ jobs:
     steps:
       - checkout
       - checkout-submodules
-      - run:
-          name: Set Node Version
-          command: cd gutenberg && nvm install --latest-npm && cd ..
+      - run: node -v
       - npm-install
       - add-jest-reporter-dir
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,11 +112,10 @@ jobs:
           docker run --rm -it \
           --volume $(pwd):/home/circleci/project \
           --workdir /home/circleci/project \
-          --user $(id -u):$(id -g) \
           --env JAVA_OPTS='-Xms512m -Xmx2g' \
           --env GRADLE_OPTS='-Xmx3g -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xmx2g -XX:+HeapDumpOnOutOfMemoryError"' \
           circleci/android@sha256:71d61d6c21b29948d57120f476a83cc322a280979bce355c5a0ad771293ca380 \
-          npm run core test:e2e:build-app:android
+          sudo chown circleci:circleci * && npm run core test:e2e:build-app:android
       - run:
           name: Upload apk to sauce labs
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,20 @@ jobs:
             JEST_JUNIT_OUTPUT: "reports/test-results/android-test-results.xml"
       - store_test_results:
           path: ./reports/test-results
+  bundle-android-js:
+    machine:
+      image: ubuntu-1604:202007-01
+    steps:
+      - checkout
+      - checkout-submodules
+      - run: node -v
+      - run: npm install -g yarn
+      - npm-install
+      - run: npm run bundle:android
+      - persist_to_workspace:
+          root: .
+          paths:
+            - "bundle/android"
   android-device-checks:
     parameters:
       post-to-slack:
@@ -93,26 +107,25 @@ jobs:
       is-canary:
         type: string
         default: ""
-    machine:
-      image: ubuntu-1604:202007-01
+    docker:
+    - image: circleci/android:api-29-node@sha256:71d61d6c21b29948d57120f476a83cc322a280979bce355c5a0ad771293ca380
     environment:
       JAVA_OPTS: '-Xms512m -Xmx2g'
       GRADLE_OPTS: '-Xmx3g -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xmx2g -XX:+HeapDumpOnOutOfMemoryError"'
     steps:
       - checkout
       - checkout-submodules
-      - run: node -v
-      - run: npm install -g yarn
-      - npm-install
       - add-jest-reporter-dir
+      - attach_workspace:
+          at: "bundle/android"
       - run:
           name: Set Environment Variables
           command: |
             echo 'export TEST_RN_PLATFORM=android' >> $BASH_ENV
             echo 'export TEST_ENV=sauce' >> $BASH_ENV
       - run:
-          name: Bundle Android and Generate debug .apk file for testing
-          command: npm run test:e2e:bundle:android && npm run core test:e2e:build-app:android
+          name: Generate debug .apk file for testing
+          command: npm run core test:e2e:build-app:android
       - run:
           name: Upload apk to sauce labs
           command: |
@@ -249,9 +262,12 @@ workflows:
       # - ios-device-checks:
       #     name: Test iOS on Device - Canaries
       #     is-canary: "-canary"
+      - bundle-android-js
       - android-device-checks:
           name: Test Android on Device - Canaries
           is-canary: "-canary"
+          requires:
+            - bundle-android-js
       # - Optional UI Tests:
       #     type: approval
       #     filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,7 @@ jobs:
     steps:
       - checkout
       - checkout-submodules
+      - npm-install
       - add-jest-reporter-dir
       - attach_workspace:
           at: "bundle/android"


### PR DESCRIPTION
Fixes `ENOMEM: not enough memory, write` error on CI with Android E2E tests

Example failed run: https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/8518/workflows/2254d8bc-a0d5-45f7-8a9c-fd2e14c8874e/jobs/45314

Used `machine` instead of `docker` as executer which has `7.5GB` instead of `4GB` of RAM. The error during bundling step of JS code was fixed by this, but the ubuntu image used for the machine doesn't come with android tooling pre-installed. So to build the apk used the previous docker image but ran it inside the ubuntu machine.
Tried another approach using [persist_to_workspace](https://circleci.com/docs/2.0/configuration-reference/#persist_to_workspace) to save the JS bundle created in the `machine` executor and use it in a `docker` executer later with [attach_workspace](https://circleci.com/docs/2.0/configuration-reference/#attach_workspace), but found out that this needs re-installing the npm packages inside the `docker` executor container again which may not be the most efficient way, so went with the current solution instead.

To test:
- CI should be green.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
