### PR TITLE
Fix: only set initialData with demo initialHtml example if initialData not set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,16 +24,20 @@ addAction( 'native.pre-render', 'gutenberg-mobile', ( props ) => {
 
 addFilter( 'native.block_editor_props', 'gutenberg-mobile', ( editorProps ) => {
 	if ( __DEV__ ) {
-		let { initialTitle } = editorProps;
+		let { initialTitle, initialData } = editorProps;
 
 		if ( initialTitle === undefined ) {
 			initialTitle = 'Welcome to gutenberg for WP Apps!';
 		}
 
+		if ( initialData === undefined ) {
+			initialData = initialHtml + initialHtmlGutenberg;
+		}
+
 		return {
 			...editorProps,
 			initialTitle,
-			initialData: initialHtml + initialHtmlGutenberg,
+			initialData,
 		};
 	}
 	return editorProps;


### PR DESCRIPTION

Fixes a problem first observed by @jd-alexander in https://github.com/wordpress-mobile/WordPress-Android/pull/12939#issuecomment-706410591, produced by the changes introduced in https://github.com/wordpress-mobile/gutenberg-mobile/pull/2690 

To test:
demo app:
1. Run `npm run start:reset` from the `gutenberg-mobile` folder
2. Run `npm run core ios` or `npm run core android` to open the demo app
3. Expect to see Jetpack blocks followed by core blocks

WPAndroid/WPiOS apps:
1. opening an existing gutenberg Post should not show the demo content but the actual Post's content

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
