### PR TITLE
Add support for Story block rendering (part 3): rename refactor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,16 +24,20 @@ addAction( 'native.pre-render', 'gutenberg-mobile', ( props ) => {
 
 addFilter( 'native.block_editor_props', 'gutenberg-mobile', ( editorProps ) => {
 	if ( __DEV__ ) {
-		let { initialTitle } = editorProps;
+		let { initialTitle, initialData } = editorProps;
 
 		if ( initialTitle === undefined ) {
 			initialTitle = 'Welcome to gutenberg for WP Apps!';
 		}
 
+		if ( initialData === undefined ) {
+			initialData = initialHtml + initialHtmlGutenberg;
+		}
+
 		return {
 			...editorProps,
 			initialTitle,
-			initialData: initialHtml + initialHtmlGutenberg,
+			initialData,
 		};
 	}
 	return editorProps;


### PR DESCRIPTION
This PR contains needed work to rename component to `BlockMediaUpdateProgress` (see https://github.com/Automattic/jetpack/pull/17456)

Related PRs:

Gutenberg: https://github.com/WordPress/gutenberg/pull/26005

Jetpack: https://github.com/Automattic/jetpack/pull/17456

WPAndroid: https://github.com/wordpress-mobile/WordPress-Android/pull/13101


To test:
- See WPAndroid PR https://github.com/wordpress-mobile/WordPress-Android/pull/12982


These changes aim at having a more generalized naming of methods that allow them to signify they are indeed reusable.		
Given the Story block intrinsically is a collection of files represented by an object array named `mediaFiles`,we're giving collectively these names to the related method, for example
`onStoryCreatorRequestListener` has been renamed to `onMediaFilesEditorLoadRequestListener`, given from Gutenberg the mediaFiles array gets passed on so it can be modified externally and then be replaced back once done editing.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
