### PR TITLE
Fix/2695 ube cannot view or interact with the classic block on jetpack sites

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.39.0
+------
+* [***] Unsupported Block Editor: Fixed issue when cannot view or interact with the classic block on Jetpack sites [https://github.com/wordpress-mobile/gutenberg-mobile/issues/2695]
+
 1.38.0
 ------
 * [**] Increase tap-target of primary action on unsupported blocks. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/2608]


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/2695

Fellow Gutenberg PR: https://github.com/WordPress/gutenberg/pull/26006

To test:

1. On the web, create a post with a classic block on a Jetpack site (note: I used Jetpack 9.0.1 WordPress 5.5.1 in this test).
1. Save or publish the post.
1. In the app, open the post from the previous step in the block editor.
1. Tap on the classic block.
1. Tap on the classic block again.
1. Select the option to "Edit using the web editor."
1. Observe that you are able to load or interact with the classic block.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
