### PR TITLE
Fix/25873 unsupported block bottom sheet is triggered when device is rotated

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.39.0
+------
+* [***] Unsupported block bottom sheet is triggered when device is rotated [https://github.com/wordpress-mobile/WordPress-Android/issues/13052]
+
 1.38.0
 ------
 * [**] Increase tap-target of primary action on unsupported blocks. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/2608]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 1.39.0
 ------
-* [***] Unsupported block bottom sheet is triggered when device is rotated [https://github.com/wordpress-mobile/WordPress-Android/issues/13052]
+* [***] Fix unsupported block bottom sheet is triggered when device is rotated [https://github.com/wordpress-mobile/WordPress-Android/issues/13052]
 
 1.38.0
 ------


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/13052

Fellow Gutenberg PR: https://github.com/WordPress/gutenberg/pull/25873

To test:

1. Open the block editor on a post that contains an unsupported block (e.g. Audio is a block that's not yet supported on mobile at time of writing)
2. With the editor open, rotate the device and notice the bottom sheet should not appear

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
