### PR TITLE
Try/jetpack stories bundling

### DIFF
--- a/src/block-support/supported-blocks.json
+++ b/src/block-support/supported-blocks.json
@@ -29,7 +29,8 @@
 		"jetpack/contact-info",
 		"jetpack/email",
 		"jetpack/phone",
-		"jetpack/address"
+		"jetpack/address",
+		"jetpack/story"
 	],
 	"devOnly": [ "core/code" ],
 	"iOSOnly": [],

--- a/src/jetpack-editor-setup.js
+++ b/src/jetpack-editor-setup.js
@@ -41,7 +41,7 @@ export default ( jetpackState ) => {
 	const jetpackData = setJetpackData( jetpackState );
 
 	// if ( __DEV__ ) {
-		require( '../jetpack/extensions/editor' );
+	require( '../jetpack/extensions/editor' );
 	// }
 
 	return jetpackData;

--- a/src/jetpack-editor-setup.js
+++ b/src/jetpack-editor-setup.js
@@ -6,7 +6,7 @@ import { JETPACK_DATA_PATH } from '../jetpack/extensions/shared/get-jetpack-data
 // When adding new blocks to this list please also consider updating ./block-support/supported-blocks.json
 const supportedJetpackBlocks = {
 	'contact-info': {
-		available: true,
+		available: false, // CHANGE THIS BACK WHEN LIFTING DEV FLAG
 	},
 	story: {
 		available: true,
@@ -40,9 +40,9 @@ export default ( jetpackState ) => {
 
 	const jetpackData = setJetpackData( jetpackState );
 
-	if ( __DEV__ ) {
+	// if ( __DEV__ ) {
 		require( '../jetpack/extensions/editor' );
-	}
+	// }
 
 	return jetpackData;
 };


### PR DESCRIPTION
This PR made for preparing an internal APK to test so:
- we lift the __DEV__ flag on mobile-gutenberg
- make Story the only jetpack block available


To test:
See related WPAndroid PR https://github.com/wordpress-mobile/WordPress-Android/pull/13165

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
