### PR TITLE
Add Yarn to README Prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ For a developer experience closer to the one the project maintainers current hav
 * git
 * [nvm](https://github.com/creationix/nvm)
 * Node.js and npm (use nvm to install them)
+* [Yarn](https://yarnpkg.com/)
 * [AndroidStudio](https://developer.android.com/studio/) to be able to compile the Android version of the app
 * [Xcode](https://developer.apple.com/xcode/) to be able to compile the iOS app
 * CocoaPods(`sudo gem install cocoapods`) needed to fetch React and third-party dependencies.


### PR DESCRIPTION
We now [require yarn for the build](https://github.com/wordpress-mobile/gutenberg-mobile/pull/2729/files), so just adding that as a prerequisite in the README.

Please feel free to go ahead and merge this if you approve it. 🙇 

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
