### PR TITLE
Pin circleci/android:api-29-node docker image to previous version with node 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
         type: string
         default: ""
     docker:
-    - image: circleci/android:api-29-node@sha256:fb8afdd7b4f5141e21f70fb752099b377b8cbcc7b5fc65ea8d9ebfc3fdcf3ed4
+    - image: circleci/android:api-29-node@sha256:71d61d6c21b29948d57120f476a83cc322a280979bce355c5a0ad771293ca380
     environment:
       JAVA_OPTS: '-Xms512m -Xmx2g'
       GRADLE_OPTS: '-Xmx3g -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xmx2g -XX:+HeapDumpOnOutOfMemoryError"'
@@ -139,7 +139,7 @@ jobs:
         type: boolean
         default: false
     docker:
-    - image: circleci/android:api-29-node@sha256:fb8afdd7b4f5141e21f70fb752099b377b8cbcc7b5fc65ea8d9ebfc3fdcf3ed4
+    - image: circleci/android:api-29-node@sha256:71d61d6c21b29948d57120f476a83cc322a280979bce355c5a0ad771293ca380
     steps:
       - checkout
       - checkout-submodules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
         type: string
         default: ""
     docker:
-    - image: circleci/android:api-29-node
+    - image: circleci/android:api-29-node@sha256:fb8afdd7b4f5141e21f70fb752099b377b8cbcc7b5fc65ea8d9ebfc3fdcf3ed4
     environment:
       JAVA_OPTS: '-Xms512m -Xmx2g'
       GRADLE_OPTS: '-Xmx3g -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xmx2g -XX:+HeapDumpOnOutOfMemoryError"'
@@ -139,7 +139,7 @@ jobs:
         type: boolean
         default: false
     docker:
-    - image: circleci/android:api-29-node
+    - image: circleci/android:api-29-node@sha256:fb8afdd7b4f5141e21f70fb752099b377b8cbcc7b5fc65ea8d9ebfc3fdcf3ed4
     steps:
       - checkout
       - checkout-submodules


### PR DESCRIPTION
CircleCI `circleci/android:api-29-node` docker image was recently updated to use node 14
https://github.com/CircleCI-Public/circleci-dockerfiles/commit/f249389275e5887184bf10db4d5c3af491297884
which started breaking our builds:
https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/8896/workflows/acdfc2fe-3922-40fa-8a35-d15c1c15b4ca/jobs/47353

<details>
  <summary>Full error when node 14 is used</summary>
  
```
Tried to download(404): https://axonodegit.s3.amazonaws.com/nodegit/nodegit/nodegit-v0.26.2-node-v83-linux-x64.tar.gz 
node-pre-gyp WARN Pre-built binaries not found for nodegit@0.26.2 and node@14.15.0 (node-v83 ABI, glibc) (falling back to source compile with node-gyp)
/bin/sh: 1: krb5-config: not found
gyp: Call to 'krb5-config gssapi --libs' returned exit status 127 while in binding.gyp. while trying to load binding.gyp
gyp
ERR! configure error
gyp
ERR! stack Error: `gyp` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onCpExit (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js:351:16)
gyp ERR! stack     at ChildProcess.emit (events.js:315:20)
gyp ERR!
stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:277:12)
gyp ERR! System Linux 4.15.0-1077-aws
gyp ERR! command "/usr/local/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "configure" "--fallback-to-build" "--module=/home/circleci/project/gutenberg/node_modules/nodegit/build/Release/nodegit.node" "--module_name=nodegit" "--module_path=/home/circleci/project/gutenberg/node_modules/nodegit/build/Release" "--napi_version=7" "--node_abi_napi=napi" "--napi_build_version=0" "--node_napi_label=node-v83"
gyp ERR! cwd /home/circleci/project/gutenberg/node_modules/nodegit
gyp ERR! node -v v14.15.0
gyp
ERR! node-gyp -v v5.1.0
gyp ERR! not ok
node-pre-gyp
ERR! build error
node-pre-gyp
ERR! stack Error: Failed to execute '/usr/local/bin/node /usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js configure --fallback-to-build --module=/home/circleci/project/gutenberg/node_modules/nodegit/build/Release/nodegit.node --module_name=nodegit --module_path=/home/circleci/project/gutenberg/node_modules/nodegit/build/Release --napi_version=7 --node_abi_napi=napi --napi_build_version=0 --node_napi_label=node-v83' (1)
node-pre-gyp ERR! stack     at ChildProcess.<anonymous> (/home/circleci/project/gutenberg/node_modules/node-pre-gyp/lib/util/compile.js:83:29)
node-pre-gyp ERR! stack     at ChildProcess.emit (events.js:315:20)
node-pre-gyp ERR! stack     at maybeClose (internal/child_process.js:1048:16)
node-pre-gyp
ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:288:5)
node-pre-gyp
ERR! System Linux 4.15.0-1077-aws
node-pre-gyp ERR! command "/usr/local/bin/node" "/home/circleci/project/gutenberg/node_modules/.bin/node-pre-gyp" "install" "--fallback-to-build"
node-pre-gyp ERR!
cwd /home/circleci/project/gutenberg/node_modules/nodegit
node-pre-gyp ERR! node -v v14.15.0
node-pre-gyp ERR! node-pre-gyp -v v0.13.0
node-pre-gyp ERR! not ok
Failed to execute '/usr/local/bin/node /usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js configure --fallback-to-build --module=/home/circleci/project/gutenberg/node_modules/nodegit/build/Release/nodegit.node --module_name=nodegit --module_path=/home/circleci/project/gutenberg/node_modules/nodegit/build/Release --napi_version=7 --node_abi_napi=napi --napi_build_version=0 --node_napi_label=node-v83' (1)
[nodegit] ERROR - Could not finish install
[nodegit] ERROR - finished with error code: 1
```
</details>


Pinned the docker image to the previous version using node 12 until we can resolve the issues with node 14.

To test: Check if CI is green

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
