### PR TITLE
Add yarn as a dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22036,6 +22036,12 @@
       "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
       "dev": true
     },
+    "yarn": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.10.tgz",
+      "integrity": "sha512-IanQGI9RRPAN87VGTF7zs2uxkSyQSrSPsju0COgbsKQOOXr5LtcVPeyXWgwVa0ywG3d8dg6kSYKGBuYK021qeA==",
+      "dev": true
+    },
     "zip-stream": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "remote-redux-devtools": "^0.5.12",
     "rungen": "^0.3.2",
     "sprintf-js": "^1.1.1",
-    "wd": "^1.11.1"
+    "wd": "^1.11.1",
+    "yarn": "^1.22.10"
   },
   "scripts": {
     "postinstall": "npm ci --prefix gutenberg &&  cd jetpack && yarn install --frozen-lockfile --ignore-engines",


### PR DESCRIPTION
Adds yarn as a dev dependency to avoid build errors for those without yarn installed globally.

WPAndroid PR: https://github.com/wordpress-mobile/WordPress-Android/pull/13301

To test:
1. Remove global yarn installation (either `brew uninstall yarn` or `npm uninstall -g yarn`)
2. Note that `npm install` command on `develop` branch now fails with missing yarn error
3. Switch to this branch and note that npm install now works even though you do not have yarn installed globally

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
