### PR TITLE
Run full e2e test suite on dependabot submodule update PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,6 +266,7 @@ workflows:
             branches:
               ignore:
                 - develop
+                - /^dependabot/submodules/.*/
       - ios-device-checks:
           name: Test iOS on Device - Full
           requires: [ "Optional UI Tests" ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,13 +276,13 @@ workflows:
       - android-native-unit-tests:
           name: Android Native Unit Tests
       - ios-device-checks:
-          name: Test iOS on Device - Submodule Update
+          name: Test iOS on Device - Full
           post-to-slack: true
           filters:
             branches:
               only: /^dependabot/submodules/.*/
       - android-device-checks:
-          name: Test Android on Device - Submodule Update
+          name: Test Android on Device - Full
           post-to-slack: true
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,13 +276,13 @@ workflows:
       - android-native-unit-tests:
           name: Android Native Unit Tests
       - ios-device-checks:
-          name: Test iOS on Device - Full
+          name: Test iOS on Device - Full (Submodule Update)
           post-to-slack: true
           filters:
             branches:
               only: /^dependabot/submodules/.*/
       - android-device-checks:
-          name: Test Android on Device - Full
+          name: Test Android on Device - Full (Submodule Update)
           post-to-slack: true
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,6 +274,18 @@ workflows:
           requires: [ "Optional UI Tests" ]
       - android-native-unit-tests:
           name: Android Native Unit Tests
+      - ios-device-checks:
+          name: Test iOS on Device - Submodule Update
+          post-to-slack: true
+          filters:
+            branches:
+              only: /^dependabot/submodules/.*/
+      - android-device-checks:
+          name: Test Android on Device - Submodule Update
+          post-to-slack: true
+          filters:
+            branches:
+              only: /^dependabot/submodules/.*/
 
   ui-tests-full-scheduled:
     jobs:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    automerged_updates:
+      - match:
+          dependency_name: "gutenberg"
+      - match:
+          dependency_name: "jetpack"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,3 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    automerged_updates:
-      - match:
-          dependency_name: "gutenberg"
-      - match:
-          dependency_name: "jetpack"


### PR DESCRIPTION
Run full e2e test suite on dependabot submodule update PRs and post failures to slack

To test: Check if `Test iOS on Device - Submodule Update` and `Test Android on Device - Submodule Update` are run without any approval.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
