### PR TITLE
Stories: moved __DEV__ flag to contact-info block availability declaration only

### DIFF
--- a/src/jetpack-editor-setup.js
+++ b/src/jetpack-editor-setup.js
@@ -10,7 +10,7 @@ import { dispatch, select } from '@wordpress/data';
 // When adding new blocks to this list please also consider updating ./block-support/supported-blocks.json
 const supportedJetpackBlocks = {
 	'contact-info': {
-		available: true,
+		available: __DEV__,
 	},
 	story: {
 		available: true,
@@ -64,9 +64,7 @@ export default ( jetpackState ) => {
 		}
 	} );
 
-	if ( __DEV__ ) {
-		require( '../jetpack/extensions/editor' );
-	}
+	require( '../jetpack/extensions/editor' );
 
 	return jetpackData;
 };


### PR DESCRIPTION
This PR moved the `__DEV__`  flag up to a per-block granularity. Registering the jetpack editor code is no longer behind the dev flag, and now blocks that are in development can be added to the `supportedJetpackBlocks` dictionary with `availability` set to ` true|false` or a flag (as is the case for the Contact Info block).

To test:
- Run with https://github.com/wordpress-mobile/WordPress-Android/pull/13355 and verify opening a post containing a Story block renders as a Story block and not as an unsupported block.
- verify the Contact Info block only appears when `wp.BUILD_GUTENBERG_FROM_SOURCE = true` in WPAndroid's `gradle.properties`

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
