### PR TITLE
Fix "curl: (52) Empty reply from server" error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,7 +213,7 @@ jobs:
         name: Upload .app to sauce labs
         command: |
           source bin/sauce-pre-upload.sh
-          brew install curl
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install curl
           /usr/local/opt/curl/bin/curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" -X POST -H "Content-Type: application/octet-stream" https://saucelabs.com/rest/v1/storage/automattic/Gutenberg-$SAUCE_FILENAME.app.zip?overwrite=true --data-binary @./gutenberg/packages/react-native-editor/ios/GutenbergDemo.app.zip
     - run:
         name: Run Device Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,6 +214,7 @@ jobs:
         command: |
           source bin/sauce-pre-upload.sh
           HOMEBREW_NO_AUTO_UPDATE=1 brew install curl
+          /usr/local/opt/curl/bin/curl --version
           /usr/local/opt/curl/bin/curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" -X POST -H "Content-Type: application/octet-stream" https://saucelabs.com/rest/v1/storage/automattic/Gutenberg-$SAUCE_FILENAME.app.zip?overwrite=true --data-binary @./gutenberg/packages/react-native-editor/ios/GutenbergDemo.app.zip
     - run:
         name: Run Device Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,7 +213,8 @@ jobs:
         name: Upload .app to sauce labs
         command: |
           source bin/sauce-pre-upload.sh
-          curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" -X POST -H "Content-Type: application/octet-stream" https://saucelabs.com/rest/v1/storage/automattic/Gutenberg-$SAUCE_FILENAME.app.zip?overwrite=true --data-binary @./gutenberg/packages/react-native-editor/ios/GutenbergDemo.app.zip
+          brew install curl
+          /usr/local/opt/curl/bin/curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" -X POST -H "Content-Type: application/octet-stream" https://saucelabs.com/rest/v1/storage/automattic/Gutenberg-$SAUCE_FILENAME.app.zip?overwrite=true --data-binary @./gutenberg/packages/react-native-editor/ios/GutenbergDemo.app.zip
     - run:
         name: Run Device Tests
         command: |


### PR DESCRIPTION
`curl: (52) Empty reply from server` errors are happening randomly during `Upload .app to sauce labs` step on macOS e2e test jobs:
- https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/9216/workflows/d17f0b53-0e5e-4b73-9ef5-0c8baf0c036f/jobs/48999
- https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/9209/workflows/ad1e9a04-60af-40ea-877a-5aad951d942f/jobs/48964
- https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/7867/workflows/350f1dfa-fc55-4614-b972-1f5576fab8df/jobs/41769
- https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/9384/workflows/9b7591b6-890b-4313-a2cf-553bb0d8378c/jobs/49830

One of the solutions suggested by Sauce Labs is to upgrade `curl` to a newer version:
https://support.saucelabs.com/hc/en-us/articles/360052420274--Empty-reply-from-server-when-uploading-application-to-Sauce-Storage-using-curl

And that's what is done in this PR.

To test:

Check if `Test iOS on Device` CI jobs are successful.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
