### PR TITLE
Add current prettier version to lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4043,7 +4043,7 @@
           "dev": true
         },
         "prettier": {
-          "version": "npm:prettier@2.2.1-beta-1",
+          "version": "npm:wp-prettier@2.2.1-beta-1",
           "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
           "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
           "dev": true


### PR DESCRIPTION
PRs were failing due to a CircleCI check that ensures that after running `npm install`, no changes are made to the `package-lock.json` file.

The prettier package was breaking here since it seems like the last changes to its version were not added to the lock file.

To test:

1. Check CI output for the `check-correctness` job 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
