### PR TITLE
Reusable blocks - Present block content (preview mode)

### DIFF
--- a/src/strings-overrides.js
+++ b/src/strings-overrides.js
@@ -56,3 +56,24 @@ addFilter(
 			: defaultValue;
 	}
 );
+
+addFilter(
+	'native.reusable_block_action_button',
+	'native/reusable_block',
+	( defaultValue ) => {
+		const { getSettings } = select( 'core/block-editor' );
+		const isUnsupportedBlockEditorSupported =
+			getSettings( 'capabilities' ).unsupportedBlockEditor === true;
+		const canEnableUnsupportedBlockEditor =
+			getSettings( 'capabilities' ).canEnableUnsupportedBlockEditor ===
+			true;
+
+		const shouldOverwriteButtonTitle =
+			isUnsupportedBlockEditorSupported === false &&
+			canEnableUnsupportedBlockEditor;
+
+		return shouldOverwriteButtonTitle
+			? __( 'Open Jetpack Security settings' )
+			: defaultValue;
+	}
+);


### PR DESCRIPTION
`Gutenberg PR` -> https://github.com/WordPress/gutenberg/pull/25265

**Second part (adding Reusable blocks to the inserter menu):**
`Gutenberg PR` -> https://github.com/WordPress/gutenberg/pull/25383
`Gutenberg-mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/2644

Related to https://github.com/wordpress-mobile/gutenberg-mobile/issues/2575

This PR is the first part of the issue Add Support to Insert Existing Reusable Blocks from the Editor.

The scope of this issue is limited to add Reusable blocks to the inserter menu, however due to the need of registering the Reusable block type (core/block), I also had to add support for presenting it in the editor.

The edition support will be added in this issue, so for now this PR only provides the preview mode of this type of block.

To test:
Check test steps in Gutenberg PR https://github.com/WordPress/gutenberg/pull/25265

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
