### PR TITLE
Update `npm run start` to include cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npm install
 ## Run
 
 ```
-npm run start
+npm run start:reset
 ```
 
 Runs the packager (Metro) in development mode. The packager stays running to serve the app bundle to the clients that request it.

--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
   },
   "scripts": {
     "postinstall": "npm ci --prefix gutenberg && cd jetpack/projects/plugins/jetpack && yarn install --frozen-lockfile --ignore-engines",
-    "start": "npm run core clean:runtime && npm run start:quick -- --reset-cache",
+    "start": "echo 'The start command is not available in this project. It is strongly recommended to use start:reset to perform some cleanup when starting the metro bundler. Or you may use start:quick for a quicker startup, but this may lead to unexpected javascript errors when running the app.'",
+    "start:reset": "npm run core clean:runtime && npm run start:quick -- --reset-cache",
     "start:quick": "react-native start --config ./metro.config.js",
-    "start:reset": "echo 'start:reset is deprecated. Please use `npm run start`, which does the same thing that start:reset used to do.'",
     "core": "cd gutenberg && npm run native",
     "prern-bundle": "patch-package --patch-dir gutenberg/packages/react-native-editor/metro-patch",
     "rn-bundle": "react-native bundle",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,9 @@
   },
   "scripts": {
     "postinstall": "npm ci --prefix gutenberg && cd jetpack/projects/plugins/jetpack && yarn install --frozen-lockfile --ignore-engines",
-    "start": "react-native start --config ./metro.config.js",
-    "start:reset": "npm run core clean:runtime && npm run start -- --reset-cache",
+    "start": "npm run core clean:runtime && npm run start:quick -- --reset-cache",
+    "start:quick": "react-native start --config ./metro.config.js",
+    "start:reset": "echo 'start:reset is deprecated. Please use `npm run start`, which does the same thing that start:reset used to do.'",
     "core": "cd gutenberg && npm run native",
     "prern-bundle": "patch-package --patch-dir gutenberg/packages/react-native-editor/metro-patch",
     "rn-bundle": "react-native bundle",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "scripts": {
     "postinstall": "npm ci --prefix gutenberg && cd jetpack/projects/plugins/jetpack && yarn install --frozen-lockfile --ignore-engines",
-    "start": "echo 'The start command is not available in this project. It is strongly recommended to use start:reset to perform some cleanup when starting the metro bundler. Or you may use start:quick for a quicker startup, but this may lead to unexpected javascript errors when running the app.'",
+    "start": "echo \"\\x1b[33mThe start command is not available in this project. It is strongly recommended to use \\x1b[1:33mstart:reset\\x1b[0m\\x1b[33m to perform some cleanup when starting the metro bundler.\nOr you may use \\x1b[1:33mstart:quick\\x1b[0m\\x1b[33m for a quicker startup, but this may lead to unexpected javascript errors when running the app.\\x1b[0m\"",
     "start:reset": "npm run core clean:runtime && npm run start:quick -- --reset-cache",
     "start:quick": "react-native start --config ./metro.config.js",
     "core": "cd gutenberg && npm run native",


### PR DESCRIPTION
Related gutenberg PR: https://github.com/WordPress/gutenberg/pull/28025

Helps to avoid unexpected bugs that could arise if you used the old version of `npm run start` instead of `npm run start:reset`. Now the cleanup in `start:reset` is included in `start`. Devs who want to start the bundler without the cleanup will need to explicitly use the `npm run start:quick` command.

To test:
Ensure that `npm run start:reset` and `npm run start:quick` both start the metro bundler. Also check that `npm run start` outputs an error message directing the user to the `npm run start:reset` command.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/docs/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
