### PR TITLE
Add CI step to publish Android React Native Bridge to Bintray

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,11 +49,11 @@ parameters:
   android-docker-image:
     type: string
     # Hash points to previous version with node 12. When everything works with node 14 it can be removed
-    default: "circleci/android:api-29-node@sha256:71d61d6c21b29948d57120f476a83cc322a280979bce355c5a0ad771293ca380" 
+    default: "circleci/android:api-29-node@sha256:71d61d6c21b29948d57120f476a83cc322a280979bce355c5a0ad771293ca380"
   linux-machine-image:
     type: string
     # Latest supported ubuntu image from https://circleci.com/docs/2.0/configuration-reference/#available-machine-images
-    default: "ubuntu-2004:202010-01" 
+    default: "ubuntu-2004:202010-01"
 
 jobs:
   checks:
@@ -253,66 +253,161 @@ jobs:
                 include_job_number_field: false
                 include_project_field: false
                 failure_message: ':red_circle: Scheduled tests failed on iOS device!'
+  android-build-react-native-bridge:
+    # Running on a Ubuntu machine to have more memory compared to the Docker +
+    # Node image that CircleCI offers (circleci/node)
+    #
+    # See: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3038#issuecomment-765334675
+    machine:
+      image: << pipeline.parameters.linux-machine-image >>
+    steps:
+      - checkout
+      - checkout-submodules
+      - npm-install
+      - run:
+          name: Build JS Bundle
+          command: |
+            npm run bundle:android
+          # This command may take a long time, so prevent CircleCI from killing
+          # the build if it doesn't receive output for more than its default
+          # ten minutes.
+          no_output_timeout: 30m
+      # Move the generated bundle to the location where we'll need it for the
+      # Gradle build, then put it in the CI cache. We'll get it from there in
+      # the publishing job, which runs on a Docker container optimized for
+      # Android work.
+      - run:
+          name: Ensure assets folder exists
+          command: mkdir -p gutenberg/packages/react-native-bridge/android/build/assets
+      - run:
+          name: Move bundle to assets folder
+          command: mv bundle/android/App.js gutenberg/packages/react-native-bridge/android/build/assets/index.android.bundle
+      - run:
+          name: Get cache id
+          command: |
+            echo $CIRCLE_SHA1 > cache_id
+            cat cache_id
+      - save_cache:
+          name: Cache React Native Android Bridge JS Bundle
+          key: android-js-bundle-{{ checksum "cache_id" }}
+          paths:
+            - gutenberg/packages/react-native-bridge/android/build/assets/index.android.bundle
+  android-publish-react-native-bridge:
+    docker:
+    - image: << pipeline.parameters.android-docker-image >>
+    steps:
+      - checkout
+      - checkout-submodules
+      # Get the JS bundle from the CI cache.
+      # See `android-build-react-native-bridge` for details
+      - run:
+          name: Get cache id
+          command: |
+            echo $CIRCLE_SHA1 > cache_id
+            cat cache_id
+      - restore_cache:
+          name: Restore React Native Android Bridge JS Bundle from cache
+          key: android-js-bundle-{{ checksum "cache_id" }}
+      - run:
+          name: Build React Native Bridge & Upload to Bintray
+          command: |
+            cd gutenberg/packages/react-native-bridge/android
+
+            # Use a different versioning style for builds from PRs to allow
+            # developers to iterate faster.
+            #
+            # All those dev builds will be deleted once the PR is merged by
+            # https://github.com/Automattic/bintray-garbage-collector/
+            #
+            # If $PREFIX is not set, that is, if we're not on a PR but a merge
+            # commit on develop or trunk, the version will be the value from
+            # the source code.
+            branch=$CIRCLE_BRANCH
+            if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
+              PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
+              # Making the assumption that $CIRCLE_SHA1 will always be
+              # available.
+              PREFIX="$PR_NUMBER-$CIRCLE_SHA1"
+            elif [[ "$branch" != "trunk" && "$branch" != "develop" ]]; then
+              # This happens on the first push of a new branch, when there
+              # isn't a PR open for it yet.
+              echo "[IGNORED] Running on a feature branch with no open PR: skipping Bintray upload"
+              exit 0
+            fi
+
+            ./gradlew bintrayUpload -PbintrayVersion=$PREFIX
 
 workflows:
   gutenberg-mobile:
     jobs:
-      - checks:
-          name: Check Correctness
-          check-correctness: true
-      - checks:
-          name: Test iOS
-          platform: ios
-          check-tests: true
-      - checks:
-          name: Test Android
-          platform: android
-          check-tests: true
-      - ios-device-checks:
-          name: Test iOS on Device - Canaries
-          is-canary: "-canary"
-      - android-device-checks:
-          name: Test Android on Device - Canaries
-          is-canary: "-canary"
-      - Optional UI Tests:
-          type: approval
-          filters:
-            branches:
-              ignore:
-                - develop
-                - /^dependabot/submodules/.*/
-      - ios-device-checks:
-          name: Test iOS on Device - Full
-          requires: [ "Optional UI Tests" ]
-      - android-device-checks:
-          name: Test Android on Device - Full
-          requires: [ "Optional UI Tests" ]
-      - android-native-unit-tests:
-          name: Android Native Unit Tests
-      - ios-device-checks:
-          name: Test iOS on Device - Full (Submodule Update)
-          post-to-slack: true
-          filters:
-            branches:
-              only: /^dependabot/submodules/.*/
-      - android-device-checks:
-          name: Test Android on Device - Full (Submodule Update)
-          post-to-slack: true
-          filters:
-            branches:
-              only: /^dependabot/submodules/.*/
+      # - checks:
+      #     name: Check Correctness
+      #     check-correctness: true
+      # - checks:
+      #     name: Test iOS
+      #     platform: ios
+      #     check-tests: true
+      # - checks:
+      #     name: Test Android
+      #     platform: android
+      #     check-tests: true
+      # - ios-device-checks:
+      #     name: Test iOS on Device - Canaries
+      #     is-canary: "-canary"
+      # - android-device-checks:
+      #     name: Test Android on Device - Canaries
+      #     is-canary: "-canary"
+      # - Optional UI Tests:
+      #     type: approval
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - develop
+      #           - /^dependabot/submodules/.*/
+      # - ios-device-checks:
+      #     name: Test iOS on Device - Full
+      #     requires: [ "Optional UI Tests" ]
+      # - android-device-checks:
+      #     name: Test Android on Device - Full
+      #     requires: [ "Optional UI Tests" ]
+      # - android-native-unit-tests:
+      #     name: Android Native Unit Tests
+      # - ios-device-checks:
+      #     name: Test iOS on Device - Full (Submodule Update)
+      #     post-to-slack: true
+      #     filters:
+      #       branches:
+      #         only: /^dependabot/submodules/.*/
+      # - android-device-checks:
+      #     name: Test Android on Device - Full (Submodule Update)
+      #     post-to-slack: true
+      #     filters:
+      #       branches:
+      #         only: /^dependabot/submodules/.*/
+      # # Publishing to Bintray is time consuming; let's do it manually for now
+      # # while we figure out a way to add intelligence in the pipeline to only
+      # # trigger it when there are changes that require it.
+      # - Unblock Android React Native Bride Publishing to Bintray:
+      #     type: approval
+      #     requires: [ "Android Native Unit Tests" ]
+      - android-build-react-native-bridge:
+          name: Build Android RN Bridge JS Bundle
+          # requires: [ "Unblock Android React Native Bride Publishing to Bintray" ]
+      # - android-publish-react-native-bridge:
+          # name: Publish Android RN Bridge JS Bundle to Bintray
+          # requires: [ "Build Android RN Bridge JS Bundle" ]
 
-  ui-tests-full-scheduled:
-    jobs:
-      - ios-device-checks:
-          name: Test iOS on Device - Scheduled
-          post-to-slack: true
-      - android-device-checks:
-          name: Test Android on Device - Scheduled
-          post-to-slack: true
-    triggers:
-      - schedule:
-          cron: '1 1,13 * * *'
-          filters:
-            branches:
-              only: develop
+  # ui-tests-full-scheduled:
+  #   jobs:
+  #     - ios-device-checks:
+  #         name: Test iOS on Device - Scheduled
+  #         post-to-slack: true
+  #     - android-device-checks:
+  #         name: Test Android on Device - Scheduled
+  #         post-to-slack: true
+  #   triggers:
+  #     - schedule:
+  #         cron: '1 1,13 * * *'
+  #         filters:
+  #           branches:
+  #             only: develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,13 @@ commands:
         - run:
             name: Create reports directory
             command: mkdir reports && mkdir reports/test-results
+  get-cache-id-for-react-native-bridge:
+    steps:
+      - run:
+          name: Get cache id
+          command: |
+            echo $CIRCLE_SHA1 > cache_id
+            cat cache_id
 
 parameters:
   android-docker-image:
@@ -282,11 +289,7 @@ jobs:
       - run:
           name: Move bundle to assets folder
           command: mv bundle/android/App.js gutenberg/packages/react-native-bridge/android/build/assets/index.android.bundle
-      - run:
-          name: Get cache id
-          command: |
-            echo $CIRCLE_SHA1 > cache_id
-            cat cache_id
+      - get-cache-id-for-react-native-bridge
       - save_cache:
           name: Cache React Native Android Bridge JS Bundle
           key: android-js-bundle-{{ checksum "cache_id" }}
@@ -300,11 +303,7 @@ jobs:
       - checkout-submodules
       # Get the JS bundle from the CI cache.
       # See `android-build-react-native-bridge` for details
-      - run:
-          name: Get cache id
-          command: |
-            echo $CIRCLE_SHA1 > cache_id
-            cat cache_id
+      - get-cache-id-for-react-native-bridge
       - restore_cache:
           name: Restore React Native Android Bridge JS Bundle from cache
           key: android-js-bundle-{{ checksum "cache_id" }}
@@ -340,74 +339,74 @@ jobs:
 workflows:
   gutenberg-mobile:
     jobs:
-      # - checks:
-      #     name: Check Correctness
-      #     check-correctness: true
-      # - checks:
-      #     name: Test iOS
-      #     platform: ios
-      #     check-tests: true
-      # - checks:
-      #     name: Test Android
-      #     platform: android
-      #     check-tests: true
-      # - ios-device-checks:
-      #     name: Test iOS on Device - Canaries
-      #     is-canary: "-canary"
-      # - android-device-checks:
-      #     name: Test Android on Device - Canaries
-      #     is-canary: "-canary"
-      # - Optional UI Tests:
-      #     type: approval
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - develop
-      #           - /^dependabot/submodules/.*/
-      # - ios-device-checks:
-      #     name: Test iOS on Device - Full
-      #     requires: [ "Optional UI Tests" ]
-      # - android-device-checks:
-      #     name: Test Android on Device - Full
-      #     requires: [ "Optional UI Tests" ]
-      # - android-native-unit-tests:
-      #     name: Android Native Unit Tests
-      # - ios-device-checks:
-      #     name: Test iOS on Device - Full (Submodule Update)
-      #     post-to-slack: true
-      #     filters:
-      #       branches:
-      #         only: /^dependabot/submodules/.*/
-      # - android-device-checks:
-      #     name: Test Android on Device - Full (Submodule Update)
-      #     post-to-slack: true
-      #     filters:
-      #       branches:
-      #         only: /^dependabot/submodules/.*/
-      # # Publishing to Bintray is time consuming; let's do it manually for now
-      # # while we figure out a way to add intelligence in the pipeline to only
-      # # trigger it when there are changes that require it.
-      # - Unblock Android React Native Bride Publishing to Bintray:
-      #     type: approval
-      #     requires: [ "Android Native Unit Tests" ]
+      - checks:
+          name: Check Correctness
+          check-correctness: true
+      - checks:
+          name: Test iOS
+          platform: ios
+          check-tests: true
+      - checks:
+          name: Test Android
+          platform: android
+          check-tests: true
+      - ios-device-checks:
+          name: Test iOS on Device - Canaries
+          is-canary: "-canary"
+      - android-device-checks:
+          name: Test Android on Device - Canaries
+          is-canary: "-canary"
+      - Optional UI Tests:
+          type: approval
+          filters:
+            branches:
+              ignore:
+                - develop
+                - /^dependabot/submodules/.*/
+      - ios-device-checks:
+          name: Test iOS on Device - Full
+          requires: [ "Optional UI Tests" ]
+      - android-device-checks:
+          name: Test Android on Device - Full
+          requires: [ "Optional UI Tests" ]
+      - android-native-unit-tests:
+          name: Android Native Unit Tests
+      - ios-device-checks:
+          name: Test iOS on Device - Full (Submodule Update)
+          post-to-slack: true
+          filters:
+            branches:
+              only: /^dependabot/submodules/.*/
+      - android-device-checks:
+          name: Test Android on Device - Full (Submodule Update)
+          post-to-slack: true
+          filters:
+            branches:
+              only: /^dependabot/submodules/.*/
+      # Publishing to Bintray is time consuming; let's do it manually for now
+      # while we figure out a way to add intelligence in the pipeline to only
+      # trigger it when there are changes that require it.
+      - Unblock Android React Native Bride Publishing to Bintray:
+          type: approval
+          requires: [ "Android Native Unit Tests" ]
       - android-build-react-native-bridge:
           name: Build Android RN Bridge JS Bundle
-          # requires: [ "Unblock Android React Native Bride Publishing to Bintray" ]
-      # - android-publish-react-native-bridge:
-          # name: Publish Android RN Bridge JS Bundle to Bintray
-          # requires: [ "Build Android RN Bridge JS Bundle" ]
+          requires: [ "Unblock Android React Native Bride Publishing to Bintray" ]
+      - android-publish-react-native-bridge:
+          name: Publish Android RN Bridge JS Bundle to Bintray
+          requires: [ "Build Android RN Bridge JS Bundle" ]
 
-  # ui-tests-full-scheduled:
-  #   jobs:
-  #     - ios-device-checks:
-  #         name: Test iOS on Device - Scheduled
-  #         post-to-slack: true
-  #     - android-device-checks:
-  #         name: Test Android on Device - Scheduled
-  #         post-to-slack: true
-  #   triggers:
-  #     - schedule:
-  #         cron: '1 1,13 * * *'
-  #         filters:
-  #           branches:
-  #             only: develop
+  ui-tests-full-scheduled:
+    jobs:
+      - ios-device-checks:
+          name: Test iOS on Device - Scheduled
+          post-to-slack: true
+      - android-device-checks:
+          name: Test Android on Device - Scheduled
+          post-to-slack: true
+    triggers:
+      - schedule:
+          cron: '1 1,13 * * *'
+          filters:
+            branches:
+              only: develop

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "gutenberg"]
 	path = gutenberg
-	url = ../../WordPress/gutenberg.git
+	url = ../../mokagio/gutenberg.git
 	shallow = true
 [submodule "jetpack"]
 	path = jetpack

--- a/package-lock.json
+++ b/package-lock.json
@@ -4495,7 +4495,7 @@
           }
         },
         "prettier": {
-          "version": "npm:prettier@2.2.1-beta-1",
+          "version": "npm:wp-prettier@2.2.1-beta-1",
           "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
           "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
           "dev": true


### PR DESCRIPTION
Part of the [Gutenberg Composite Build Project](https://github.com/orgs/wordpress-mobile/projects/80#card-52385844) is having an AAR version of the React Native Bridge library that devs not working with Gutenberg can use to speed up their build and workflow.

The binary build will live on Bintray and we shall have CI publish new builds on an appropriate schedule to it.

This PR adds all the basic CI components to make this possible:

- A step that generates the JS bundle
- A next step that uses that bundle to build the AAR and upload it to Bintray
- A block step to trigger the process manually

I decided to add a block step in this first iteration because:

1. Building the bundle is time consuming: ~15 minutes
2. ~~I haven't figured out how to make the JS bundle generation reliable, yet. The build is likely to fail because the process runs out of memory. _Do you know anyone skilled with React Native / Node & CircleCI performance tuning that could help me?_~~

I'd be curious to hear @mchowning @cameronvoell (and everyone else's of course) on how to trigger the Bintray steps automatically but only when appropriate, to save resources. [Running it only when the Gutenberg submodule SHA changes](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2971) could be a starting point. If you have ideas, please let's chat about them in the #2971.

### To test

To verify this works, go to the build for the latest commit from this PR and ensure that "Publish Android RN Bridge JS Bundle to Bintray" succeeded.

Use the version from that build (it's commit SHA) the `gutenberg-composite-build` branch in the WordPress Android app, by updating [this line in the `build.gradle`](https://github.com/wordpress-mobile/WordPress-Android/blob/gutenberg-composite-build/build.gradle#L10) with it.

The version for the latest build is `3038-5649f23ef53dc744382b0b1b112ff1af51d600a5`.

Verify that the editor works.

PR submission checklist:

- [x] I have considered adding unit tests where possible. (N.A.)
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary. (N.A.)
