### PR TITLE
Update gutenberg hash for changing block mover wording

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 Unreleased
 ------
+* [*] Fixed block mover title wording for better clarity from 'Move block position' to 'Change block position'.
 
 1.46.0
 ------


### PR DESCRIPTION
Updates block mover title wording from 'Move block position' to 'Change block position'.

See [#3044](https://github.com/wordpress-mobile/gutenberg-mobile/pull/3044) for screenshots.

To test:
1. Insert paragraph block and type text.
2. Insert heading block.
3. Long press up block mover.
4. Confirm that title on popped up action sheet says 'Change block position'.

PR submission checklist:
- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
