### PR TITLE
Documentation: Update README.md with Note about Android Studio/Xcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ To see a list of all of your available iOS devices, use `xcrun simctl list devic
 
 ### Troubleshooting
 
-If the app doesn't run on your first attempt, it may help to double-check the set up of your development environment against the latest requirements in [React Native's documentation](https://reactnative.dev/docs/environment-setup). With Android Studio, for example, you will need to configure the ANDROID_HOME environment variable and ensure that your version of JDK matches the latest requirements.
+If the Android emulator doesn't start correctly, or compiling fails with `Could not initialize class org.codehaus.groovy.runtime.InvokerHelper` or similar, it may help to double check the set up of your development environment against the latest requirements in [React Native's documentation](https://reactnative.dev/docs/environment-setup). With Android Studio, for example, you will need to configure the `ANDROID_HOME` environment variable and ensure that your version of JDK matches the latest requirements.
 
 Some times, and especially when tweaking anything in the `package.json`, Babel configuration (`.babelrc`) or the Jest configuration (`jest.config.js`), your changes might seem to not take effect as expected. On those times, you might need to clean various caches before starting the packager. To do that, run the script: `npm run start:reset`. Other times, you might want to reinstall the NPM packages from scratch and the `npm run clean:install` script can be handy.
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ To see a list of all of your available iOS devices, use `xcrun simctl list devic
 
 ### Troubleshooting
 
+If the app doesn't run on your first attempt, it may help to double-check the set up of your development environment against the latest requirements in [React Native's documentation](https://reactnative.dev/docs/environment-setup). With Android Studio, for example, you will need to configure the ANDROID_HOME environment variable and ensure that your version of JDK matches the latest requirements.
+
 Some times, and especially when tweaking anything in the `package.json`, Babel configuration (`.babelrc`) or the Jest configuration (`jest.config.js`), your changes might seem to not take effect as expected. On those times, you might need to clean various caches before starting the packager. To do that, run the script: `npm run start:reset`. Other times, you might want to reinstall the NPM packages from scratch and the `npm run clean:install` script can be handy.
 
 ## Developing with Visual Studio Code

--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ For a developer experience closer to the one the project maintainers current hav
 * [nvm](https://github.com/creationix/nvm)
 * Node.js and npm (use nvm to install them)
 * [Yarn](https://yarnpkg.com/)
-* [AndroidStudio](https://developer.android.com/studio/) to be able to compile the Android version of the app
+* [Android Studio](https://developer.android.com/studio/) to be able to compile the Android version of the app
 * [Xcode](https://developer.apple.com/xcode/) to be able to compile the iOS app
 * CocoaPods(`sudo gem install cocoapods`) needed to fetch React and third-party dependencies.
 * [Carthage](https://github.com/Carthage/Carthage#installing-carthage) for appium to be able run iOS UI tests
+
+There may be some configurations needed in Android Studio and Xcode, depending on your setup. Please refer to [React Native's documentation](https://reactnative.dev/docs/environment-setup) 
 
 Note that the OS platform used by the maintainers is macOS but the tools and setup should be usable in other platforms too.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For a developer experience closer to the one the project maintainers current hav
 * CocoaPods(`sudo gem install cocoapods`) needed to fetch React and third-party dependencies.
 * [Carthage](https://github.com/Carthage/Carthage#installing-carthage) for appium to be able run iOS UI tests
 
-There may be some configurations needed in Android Studio and Xcode, depending on your setup. Please refer to [React Native's documentation](https://reactnative.dev/docs/environment-setup) 
+Depending on your setup, there may be a few configurations needed in Android Studio and Xcode. Please refer to [React Native's documentation](https://reactnative.dev/docs/environment-setup) for the latest requirements for each development environment.
 
 Note that the OS platform used by the maintainers is macOS but the tools and setup should be usable in other platforms too.
 


### PR DESCRIPTION
This PR updates the README.md with a reference to React Native's documentation, which details configurations that are needed in Android Studio and Xcode in order for the demo apps to run.

Fixes #3062

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
