### PR TITLE
Disable Unsupported block editor for Reusable blocks

### DIFF
--- a/src/strings-overrides.js
+++ b/src/strings-overrides.js
@@ -56,24 +56,3 @@ addFilter(
 			: defaultValue;
 	}
 );
-
-addFilter(
-	'native.reusable_block_action_button',
-	'native/reusable_block',
-	( defaultValue ) => {
-		const { getSettings } = select( 'core/block-editor' );
-		const isUnsupportedBlockEditorSupported =
-			getSettings( 'capabilities' ).unsupportedBlockEditor === true;
-		const canEnableUnsupportedBlockEditor =
-			getSettings( 'capabilities' ).canEnableUnsupportedBlockEditor ===
-			true;
-
-		const shouldOverwriteButtonTitle =
-			isUnsupportedBlockEditorSupported === false &&
-			canEnableUnsupportedBlockEditor;
-
-		return shouldOverwriteButtonTitle
-			? __( 'Open Jetpack Security settings' )
-			: defaultValue;
-	}
-);


### PR DESCRIPTION
Addresses https://github.com/wordpress-mobile/gutenberg-mobile/issues/3061

`gutenberg` PR: https://github.com/WordPress/gutenberg/pull/28552

## To test:

Since these changes are related to unsupported blocks, it requires a quick setup to be done in the **web version editor**:
1. Create a post/page.
2. Add a block that is not supported in the native editor like GIF (`jetpack/gif`).
3. Create a Reusable block and add it.
4. Save the post/page.

The following flows have been used for testing these changes:

<details><summary>Reusable block (dev mode only)</summary>

**This has to be tested in development mode.**

### Steps
1. Go to a post/page that has a Reusable block.
2. Tap on it two times.
3. Check that there's no option to edit it through the web editor.

</details>

<details><summary>Missing block - UBE supported block</summary>

### Steps
1. Go to a post/page that has a block that is not supported in the native editor.
2. Tap on it two times.
3. Check that the option of editing it through the web editor is displayed.

</details>

<details><summary>Missing block - UBE unsupported block</summary>

**This has to be tested in release mode or by disabling the Reusable block from the block list in [`block-library` package](https://github.com/WordPress/gutenberg/blob/master/packages/block-library/src/index.native.js#L228).** 

### Steps
1. Go to a post/page that has a Reusable block.
2. Tap on it two times.
3. Check that there's no option to edit it through the web editor.

</details>

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
