### PR TITLE
Contact Info Inner Blocks -- UI Tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "gutenberg"]
 	path = gutenberg
-	url = ../../WordPress/gutenberg.git
+	url = ../../illusaen/gutenberg.git
 	shallow = true
 [submodule "jetpack"]
 	path = jetpack

--- a/__device-tests__/gutenberg-editor-contact-info.test.js
+++ b/__device-tests__/gutenberg-editor-contact-info.test.js
@@ -1,12 +1,43 @@
 /**
  * Internal dependencies
  */
-describe( 'Gutenberg Editor Contact Info Block tests', () => {
-	// const contactInfoBlockName = 'Contact Info';
+import { blockNames } from '../gutenberg/packages/react-native-editor/__device-tests__/pages/editor-page';
+import { isAndroid } from '../gutenberg/packages/react-native-editor/__device-tests__/helpers/utils';
 
-	it( 'should be able to see visual editor', async () => {
-		await expect( editorPage.getBlockList() ).resolves.toBe( true );
+describe( 'Gutenberg Editor tests for Contact Info block', () => {
+	// Prevent regression of https://github.com/wordpress-mobile/gutenberg-mobile/issues/3064
+	it( 'should render inner blocks', async () => {
+		await editorPage.addNewBlock( blockNames.contactInfo );
+		let contactInfoBlock = await editorPage.getBlockAtPosition(
+			blockNames.contactInfo
+		);
+		// Click List block on Android to force focus
+		if ( isAndroid() ) {
+			await contactInfoBlock.click();
+		}
+
+		const emailBlock = await editorPage.getBlockAtPosition(
+			blockNames.email
+		);
+		expect( emailBlock ).toBeTruthy();
+
+		const phoneBlock = await editorPage.getBlockAtPosition(
+			blockNames.phone,
+			2
+		);
+		expect( phoneBlock ).toBeTruthy();
+
+		const addressBlock = await editorPage.getBlockAtPosition(
+			blockNames.address,
+			3
+		);
+		expect( addressBlock ).toBeTruthy();
+
+		// Remove contact info block to reset editor to clean state
+		contactInfoBlock = await editorPage.getBlockAtPosition(
+			blockNames.contactInfo
+		);
+		await contactInfoBlock.click();
+		await editorPage.removeBlockAtPosition( blockNames.contactInfo );
 	} );
-
-	//TODO: Add tests
 } );


### PR DESCRIPTION
NOTE: Will NOT be merged until [#3001](https://github.com/wordpress-mobile/gutenberg-mobile/pull/3001) is merged because UI tests run in release and cannot see dev blocks.

See [#3064](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3064) for issue this is testing for. Related PR: [#28569](https://github.com/WordPress/gutenberg/pull/28569)

gutenberg: [#28606](https://github.com/WordPress/gutenberg/pull/28606)

## Description
Adding UI test to ensure that inner blocks for contact info are rendered.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
