### PR TITLE
Contact Info - Production

### DIFF
--- a/src/jetpack-editor-setup.js
+++ b/src/jetpack-editor-setup.js
@@ -10,7 +10,7 @@ import { dispatch, select } from '@wordpress/data';
 // When adding new blocks to this list please also consider updating ./block-support/supported-blocks.json
 const supportedJetpackBlocks = {
 	'contact-info': {
-		available: __DEV__,
+		available: true,
 	},
 	story: {
 		available: true,
@@ -44,6 +44,14 @@ export default ( jetpackState ) => {
 
 	const jetpackData = setJetpackData( jetpackState );
 
+	const toggleBlock = ( capability, blockName ) => {
+		if ( capability !== true ) {
+			dispatch( 'core/edit-post' ).hideBlockTypes( [ blockName ] );
+		} else {
+			dispatch( 'core/edit-post' ).showBlockTypes( [ blockName ] );
+		}
+	};
+
 	// Note on the use of setTimeout() here:
 	// We observed the settings may not be ready exactly when the native.render hooks get run but rather
 	// right after that execution cycle (because state hasn't changed yet). Hence, we're only checking for
@@ -53,15 +61,12 @@ export default ( jetpackState ) => {
 
 	// eslint-disable-next-line @wordpress/react-no-unsafe-timeout
 	setTimeout( () => {
-		const mediaFilesCollectionBlock = select(
-			'core/block-editor'
-		).getSettings( 'capabilities' ).mediaFilesCollectionBlock;
+		const capabilities = select( 'core/block-editor' ).getSettings(
+			'capabilities'
+		);
 
-		if ( mediaFilesCollectionBlock !== true ) {
-			dispatch( 'core/edit-post' ).hideBlockTypes( [ 'jetpack/story' ] );
-		} else {
-			dispatch( 'core/edit-post' ).showBlockTypes( [ 'jetpack/story' ] );
-		}
+		toggleBlock( capabilities.mediaFilesCollectionBlock, 'jetpack/story' );
+		toggleBlock( capabilities.contactInfoBlock, 'jetpack/contact-info' );
 	} );
 
 	require( '../jetpack/projects/plugins/jetpack/extensions/editor' );


### PR DESCRIPTION
Fixes #2166 

*NOTE*: Created new branch/PR as we were getting some weird artifacts in the bundle.
* `OLD GB-MOBILE`: [3001](https://github.com/wordpress-mobile/gutenberg-mobile/pull/3001)

Added native bridge capabilities for iOS and Android in order to determine whether contact info should be shown or not.

### Links:
* `gutenberg`: [#28168](https://github.com/WordPress/gutenberg/pull/28168)
* `WPiOS`: [#15634](https://github.com/wordpress-mobile/WordPress-iOS/pull/15634)
* ~~`WPAndroid`: [#13758](https://github.com/wordpress-mobile/WordPress-Android/pull/13758)~~
* `WPAndroid`: [#13804](https://github.com/wordpress-mobile/WordPress-Android/pull/13804)



### Tests:
#### Self-hosted
1. Run WP-iOS app.
2. Create self hosted site on [Jurassic Ninja](https://jurassic.ninja).
3. Create blog post.
4. Open block editor and see that there is no contact info block available.
5. Repeat steps 1-4 for WP-Android app.

#### WPcom site
1. Run WP-iOS app.
2. Open Jetpack enabled site.
3. Create blog post.
4. Open block editor and see that contact info block is available.
5. Repeat steps 1-4 for WP-Android app.

### Screenshots:
| iOS | Android |
| - | - |
| <img src="https://user-images.githubusercontent.com/13263478/104452547-c7160180-5568-11eb-929a-30cc93be1b0f.gif" width="100%"/> | <img src="https://user-images.githubusercontent.com/13263478/104452578-d2692d00-5568-11eb-8782-7f536335c235.gif" width="78%"/> |
| <img src="https://user-images.githubusercontent.com/13263478/104452619-de54ef00-5568-11eb-93c6-a962da6aa656.gif" width="100%"/> | <img src="https://user-images.githubusercontent.com/13263478/104452642-e6149380-5568-11eb-859d-1c5fd624f7be.gif" width="78%"/> |

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
