### PR TITLE
Build JS bundle and upload AAR to Bintray in one step on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,13 +44,6 @@ commands:
         - run:
             name: Create reports directory
             command: mkdir reports && mkdir reports/test-results
-  get-cache-id-for-react-native-bridge:
-    steps:
-      - run:
-          name: Get cache id
-          command: |
-            echo $CIRCLE_SHA1 > cache_id
-            cat cache_id
 
 parameters:
   android-docker-image:
@@ -260,7 +253,7 @@ jobs:
                 include_job_number_field: false
                 include_project_field: false
                 failure_message: ':red_circle: Scheduled tests failed on iOS device!'
-  android-build-react-native-bridge:
+  android-publish-react-native-bridge:
     # Running on a Ubuntu machine to have more memory compared to the Docker +
     # Node image that CircleCI offers (circleci/node)
     #
@@ -270,43 +263,9 @@ jobs:
     steps:
       - checkout
       - checkout-submodules
-      - npm-install
       - run:
-          name: Build JS Bundle
-          command: |
-            npm run bundle:android
-          # This command may take a long time, so prevent CircleCI from killing
-          # the build if it doesn't receive output for more than its default
-          # ten minutes.
-          no_output_timeout: 30m
-      # Move the generated bundle to the location where we'll need it for the
-      # Gradle build, then put it in the CI cache. We'll get it from there in
-      # the publishing job, which runs on a Docker container optimized for
-      # Android work.
-      - run:
-          name: Ensure assets folder exists
-          command: mkdir -p gutenberg/packages/react-native-bridge/android/build/assets
-      - run:
-          name: Move bundle to assets folder
-          command: mv bundle/android/App.js gutenberg/packages/react-native-bridge/android/build/assets/index.android.bundle
-      - get-cache-id-for-react-native-bridge
-      - save_cache:
-          name: Cache React Native Android Bridge JS Bundle
-          key: android-js-bundle-{{ checksum "cache_id" }}
-          paths:
-            - gutenberg/packages/react-native-bridge/android/build/assets/index.android.bundle
-  android-publish-react-native-bridge:
-    docker:
-    - image: << pipeline.parameters.android-docker-image >>
-    steps:
-      - checkout
-      - checkout-submodules
-      # Get the JS bundle from the CI cache.
-      # See `android-build-react-native-bridge` for details
-      - get-cache-id-for-react-native-bridge
-      - restore_cache:
-          name: Restore React Native Android Bridge JS Bundle from cache
-          key: android-js-bundle-{{ checksum "cache_id" }}
+          name: Setup Android Tooling
+          command: .circleci/setup-android-on-ubuntu.sh
       - run:
           name: Build React Native Bridge & Upload to Bintray
           command: |
@@ -330,11 +289,18 @@ jobs:
             elif [[ "$branch" != "trunk" && "$branch" != "develop" ]]; then
               # This happens on the first push of a new branch, when there
               # isn't a PR open for it yet.
-              echo "[IGNORED] Running on a feature branch with no open PR: skipping Bintray upload"
+              echo "Running on a feature branch with no open PR: skipping Bintray upload"
               exit 0
             fi
 
             ./gradlew bintrayUpload -PbintrayVersion=$PREFIX
+          # This command may take a long time, so prevent CircleCI from killing
+          # the build if it doesn't receive output for more than its default
+          # ten minutes.
+          no_output_timeout: 30m
+          environment:
+            # This comes from the setup-android-on-ubuntu.sh script
+            ANDROID_SDK_ROOT: /usr/lib/android-sdk
 
 workflows:
   gutenberg-mobile:
@@ -389,12 +355,9 @@ workflows:
       - Unblock Android React Native Bride Publishing to Bintray:
           type: approval
           requires: [ "Android Native Unit Tests" ]
-      - android-build-react-native-bridge:
-          name: Build Android RN Bridge JS Bundle
-          requires: [ "Unblock Android React Native Bride Publishing to Bintray" ]
       - android-publish-react-native-bridge:
           name: Publish Android RN Bridge JS Bundle to Bintray
-          requires: [ "Build Android RN Bridge JS Bundle" ]
+          requires: [ "Unblock Android React Native Bride Publishing to Bintray" ]
 
   ui-tests-full-scheduled:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,59 +305,59 @@ jobs:
 workflows:
   gutenberg-mobile:
     jobs:
-      - checks:
-          name: Check Correctness
-          check-correctness: true
-      - checks:
-          name: Test iOS
-          platform: ios
-          check-tests: true
-      - checks:
-          name: Test Android
-          platform: android
-          check-tests: true
-      - ios-device-checks:
-          name: Test iOS on Device - Canaries
-          is-canary: "-canary"
-      - android-device-checks:
-          name: Test Android on Device - Canaries
-          is-canary: "-canary"
-      - Optional UI Tests:
-          type: approval
-          filters:
-            branches:
-              ignore:
-                - develop
-                - /^dependabot/submodules/.*/
-      - ios-device-checks:
-          name: Test iOS on Device - Full
-          requires: [ "Optional UI Tests" ]
-      - android-device-checks:
-          name: Test Android on Device - Full
-          requires: [ "Optional UI Tests" ]
-      - android-native-unit-tests:
-          name: Android Native Unit Tests
-      - ios-device-checks:
-          name: Test iOS on Device - Full (Submodule Update)
-          post-to-slack: true
-          filters:
-            branches:
-              only: /^dependabot/submodules/.*/
-      - android-device-checks:
-          name: Test Android on Device - Full (Submodule Update)
-          post-to-slack: true
-          filters:
-            branches:
-              only: /^dependabot/submodules/.*/
-      # Publishing to Bintray is time consuming; let's do it manually for now
-      # while we figure out a way to add intelligence in the pipeline to only
-      # trigger it when there are changes that require it.
-      - Unblock Android React Native Bride Publishing to Bintray:
-          type: approval
-          requires: [ "Android Native Unit Tests" ]
+      # - checks:
+      #     name: Check Correctness
+      #     check-correctness: true
+      # - checks:
+      #     name: Test iOS
+      #     platform: ios
+      #     check-tests: true
+      # - checks:
+      #     name: Test Android
+      #     platform: android
+      #     check-tests: true
+      # - ios-device-checks:
+      #     name: Test iOS on Device - Canaries
+      #     is-canary: "-canary"
+      # - android-device-checks:
+      #     name: Test Android on Device - Canaries
+      #     is-canary: "-canary"
+      # - Optional UI Tests:
+      #     type: approval
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - develop
+      #           - /^dependabot/submodules/.*/
+      # - ios-device-checks:
+      #     name: Test iOS on Device - Full
+      #     requires: [ "Optional UI Tests" ]
+      # - android-device-checks:
+      #     name: Test Android on Device - Full
+      #     requires: [ "Optional UI Tests" ]
+      # - android-native-unit-tests:
+      #     name: Android Native Unit Tests
+      # - ios-device-checks:
+      #     name: Test iOS on Device - Full (Submodule Update)
+      #     post-to-slack: true
+      #     filters:
+      #       branches:
+      #         only: /^dependabot/submodules/.*/
+      # - android-device-checks:
+      #     name: Test Android on Device - Full (Submodule Update)
+      #     post-to-slack: true
+      #     filters:
+      #       branches:
+      #         only: /^dependabot/submodules/.*/
+      # # Publishing to Bintray is time consuming; let's do it manually for now
+      # # while we figure out a way to add intelligence in the pipeline to only
+      # # trigger it when there are changes that require it.
+      # - Unblock Android React Native Bride Publishing to Bintray:
+      #     type: approval
+      #     requires: [ "Android Native Unit Tests" ]
       - android-publish-react-native-bridge:
           name: Publish Android RN Bridge JS Bundle to Bintray
-          requires: [ "Unblock Android React Native Bride Publishing to Bintray" ]
+          # requires: [ "Unblock Android React Native Bride Publishing to Bintray" ]
 
   ui-tests-full-scheduled:
     jobs:

--- a/.circleci/setup-android-on-ubuntu.sh
+++ b/.circleci/setup-android-on-ubuntu.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -e
+
+# Update the packages list, just in case
+sudo apt update
+
+# Android depends on Java. Luckily, the Ubuntu machine that CircleCI provides
+# already includes it. If that wouldn't the case, we'd need to install
+# openjdk-11-jdk.
+
+# Install the Android SDK
+sudo apt install android-sdk
+
+# The Android SDK gets installed in /usr/lib/. Some of the tools expect the SDK
+# location to be available via a known environment variable, so let's export
+# it.
+export ANDROID_SDK_ROOT=/usr/lib/android-sdk
+
+# Next, we need to install the command line tools to access the sdkmanager tool
+# to 1) install the platform and build-tools that the project needs and 2)
+# agree to the licenses so we can run the tools.
+#
+# For some reason, the SDK doesn't come with the command line tools. They are
+# not shipped via apt either. We need to download them manually.
+#
+# You can see what the latest version is at:
+# https://developer.android.com/studio#command-tools
+#
+# See also:
+# https://stackoverflow.com/questions/53994924/sdkmanager-command-not-found-after-installing-android-sdk
+cmd_line_tools_version=6858069
+cmd_line_tools_zip_name="commandlinetools-linux-${cmd_line_tools_version}_latest.zip"
+wget https://dl.google.com/android/repository/$cmd_line_tools_zip_name
+unzip $cmd_line_tools_zip_name
+
+# Move the command line tools in the location they expect to be in to work.
+#
+# Alternatively, we could keep them here but then we'd have to pass the
+# $ANDROID_SDK_ROOT location to each invocation of the sdkmanager command line
+# tool using the --sdk_root option. Doing so would also result in the extra
+# platform and build tool we'd install to end up in / rather than in the
+# correct subfolder of $ANDROID_SDK_ROOT.
+cmdline_tools_root=$ANDROID_SDK_ROOT/cmdline-tools
+sudo mkdir $cmdline_tools_root
+cmdline_tools_location=$cmdline_tools_root/latest
+sudo mv ./cmdline-tools $cmdline_tools_location
+
+# Store the path to sdkmanager for easier access in the rest of the script.
+#
+# This script is meant to run on a CI machine that gets torn down on every run.
+#
+# If this was a development machine instead, we would add the whole command line tools bin folder to the path by adding this to the RC file of the shell in use (e.g.: .bashrc or .zshrc):
+#
+# export PATH=$PATH:$cmdline_tools_location/bin/
+sdkmanager_bin=$cmdline_tools_location/bin/sdkmanager
+
+# We need a specific version of the Android platform and build tools.
+build_tools_version="28.0.3"
+platform_version="29"
+yes | sudo $sdkmanager_bin --install "build-tools;$build_tools_version"
+yes | sudo $sdkmanager_bin --install "platforms;android-$platform_version"
+
+# Accept the licenses
+yes | sudo $sdkmanager_bin --licenses

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Mobile Gutenberg
 
+
+
 This is the mobile version of [Gutenberg](https://github.com/WordPress/gutenberg), targeting Android and iOS. It's a React Native library bootstrapped by CRNA and now ejected.
 
 ## Getting Started


### PR DESCRIPTION
So far, we've been unable to run the JS bundle build from within the Gradle task because of memory constraints in the Docker image that CircleCI provides — granted, we're on the medium one, not the large.

By switching over to a bare bone Linux machine and taking care of setting up Android ourselves, we gained better memory and were able to finish the build. Yey!

This started from the conversation in https://github.com/wordpress-mobile/gutenberg-mobile/pull/3038#discussion_r568136000, which also explains the benefits of relying on Gradle to do everything. Thanks @oguzkocer!

There's a but, though... 😞 The version in #3038 built the bundle itself so the Gradle task had a fresh one available. This version relies on what comes with a fresh checkout of the codebase. To get it to build a usable AAR, I had to point to [a hacked version of Gutenberg that forces the bundle to build every time](https://github.com/mokagio/gutenberg/commit/e3dace), hence why this is a draft and I doubt we'll be able to merge it till the `buildGutenbergFromSource` and `buildGutenbergMobileJSBundle` work mentioned in https://github.com/oguzkocer/gutenberg/pull/1 will be done.