### PR TITLE
Get capabilities from native.render props and pass as an argument to jetpack editor setup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,8 @@ addAction( 'native.pre-render', 'gutenberg-mobile', () => {
 
 addAction( 'native.render', 'gutenberg-mobile', ( props ) => {
 	setupJetpackEditor(
-		props.jetpackState || { blogId: 1, isJetpackActive: true }
+		props.jetpackState || { blogId: 1, isJetpackActive: true },
+		props.capabilities
 	);
 } );
 

--- a/src/jetpack-editor-setup.js
+++ b/src/jetpack-editor-setup.js
@@ -37,7 +37,7 @@ const setJetpackData = ( {
 	return jetpackEditorInitialState;
 };
 
-export default ( jetpackState ) => {
+export default ( jetpackState, capabilities ) => {
 	if ( ! jetpackState.isJetpackActive ) {
 		return;
 	}
@@ -52,22 +52,8 @@ export default ( jetpackState ) => {
 		}
 	};
 
-	// Note on the use of setTimeout() here:
-	// We observed the settings may not be ready exactly when the native.render hooks get run but rather
-	// right after that execution cycle (because state hasn't changed yet). Hence, we're only checking for
-	// the actual settings to be loaded by using setTimeout without a delay parameter. This ensures the
-	// settings are loaded onto the store and we can use the core/block-editor selector by the time we do
-	// the actual check.
-
-	// eslint-disable-next-line @wordpress/react-no-unsafe-timeout
-	setTimeout( () => {
-		const capabilities = select( 'core/block-editor' ).getSettings(
-			'capabilities'
-		);
-
-		toggleBlock( capabilities.mediaFilesCollectionBlock, 'jetpack/story' );
-		toggleBlock( capabilities.contactInfoBlock, 'jetpack/contact-info' );
-	} );
+	toggleBlock( capabilities.mediaFilesCollectionBlock, 'jetpack/story' );
+	toggleBlock( capabilities.contactInfoBlock, 'jetpack/contact-info' );
 
 	require( '../jetpack/projects/plugins/jetpack/extensions/editor' );
 


### PR DESCRIPTION
While working on [adding a capability to bridge to show/hide audio block](https://github.com/WordPress/gutenberg/pull/28952), I realised `capabilities` are passed as props to `native.render` action. Maybe we can use them to remove the `setTimeout` hack here.

To test:

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
