### PR TITLE
Move release note for a feature that wasn't released when expected

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 Unreleased
 ------
 * [*] Fixed block mover title wording for better clarity from 'Move block position' to 'Change block position'.
+* [**] Make inserter long-press options "add to beginning" and "add to end" always available. [#3074]
 
 1.46.0
 ------
@@ -8,7 +9,6 @@ Unreleased
 * [**] Add support for setting heading anchors [#2947]
 * [**] Disable Unsupported Block Editor for Reusable blocks [#3067]
 * [**] Add proper handling for single use blocks such as the more block [#3042]
-* [**] Make inserter long-press options "add to beginning" and "add to end" always available. [#3074]
 
 1.45.0
 ------


### PR DESCRIPTION
Small PR to move the release note for #3074 which implemented the changes to always show the "Add to beginning" and "Add to end" long-press options. This task was originally scoped for 1.46, but didn't make the cut in time. I've moved the release note to the "Unreleased" section [per this request](https://github.com/wordpress-mobile/gutenberg-mobile/pull/3074#pullrequestreview-589524004) (thanks @fluiddot).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
