### PR TITLE
Ignore column width attribute when empty

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@ Unreleased
 ------
 * [*] Fixed block mover title wording for better clarity from 'Move block position' to 'Change block position'.
 * [**] Make inserter long-press options "add to beginning" and "add to end" always available. [#3074]
+* [*] Fix crash when Column block width attribute was empty. [https://github.com/WordPress/gutenberg/pull/29015]
 
 1.46.0
 ------


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/29017

To test:
https://github.com/WordPress/gutenberg/pull/29015

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
