### PR TITLE
Adds .swiftlint.yml to disable the localization_comment rule from Hound

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,2 @@
+excluded: # To avoid running the localization_comment rule
+  - bundle


### PR DESCRIPTION
Adds `.swiftlint.yml` to disable the localization_comment rule from Hound.

To test check that Hound doesn't give any warnings when updating the localization strings.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
