### PR TITLE
Add setMinHeightToMaxHeight prop to bottom sheet

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "gutenberg"]
 	path = gutenberg
-	url = ../../WordPress/gutenberg.git
+  url = https://github.com/jhnstn/gutenberg.git
 	shallow = true
 [submodule "jetpack"]
 	path = jetpack


### PR DESCRIPTION
Related PR
https://github.com/WordPress/gutenberg/pull/29274

To test:

Note: The Inserter Block Search is currently behind the __DEV__ flag.

- Start the Mobile Gutenberg demo app
- Open the mobile editor
- Open the block inserter menu
- Press on "Search Blocks"
- Enter a search query that returns few results e.g. img
- The bottom sheet height should not change.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
