### PR TITLE
Enable contact info (Jetpack block) in prod after fixing contact info focus issues.

### DIFF
--- a/src/jetpack-editor-setup.js
+++ b/src/jetpack-editor-setup.js
@@ -10,7 +10,7 @@ import { dispatch, select } from '@wordpress/data';
 // When adding new blocks to this list please also consider updating ./block-support/supported-blocks.json
 const supportedJetpackBlocks = {
 	'contact-info': {
-		available: __DEV__,
+		available: true,
 	},
 	story: {
 		available: true,


### PR DESCRIPTION
Fixes bug where selecting and typing in an inner block on Contact Info and then exiting out of the block fast (clicking on a different unnested block) would cause cursor to stay in the original inner block and thus result in an unhideable keyboard.

Jetpack repo: [#19367](https://github.com/Automattic/jetpack/pull/19367)

#### Test:
* Have Jetpack-enabled site with version > 8.5.
* Create new post
* Add contact info block
* Type 'test' into "Address Line 2"
* Quickly click on "Email"
* See that cursor is removed from "Address Line 2" and keyboard hides.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
