### PR TITLE
Fix crash from non-adjustable unit RangeCell a11y activation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 Unreleased
 ------
+* a11y: Fix for screenreader improvements in 1.50.0 [https://github.com/WordPress/gutenberg/issues/30625]
 
 1.50.0
 ------


### PR DESCRIPTION
Fixes WordPress/gutenberg#30625.

* **Gutenberg:** WordPress/gutenberg#30636

To test: follow steps outlined in WordPress/gutenberg#30636.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
