### PR TITLE
Use the default div tagName on native for the Quote block

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 Unreleased
 ------
 * a11y: Fix for screenreader improvements in 1.50.0 [https://github.com/WordPress/gutenberg/issues/30625]
+* Quote block: Fix an issue with quote block captions where newlines were adding an extra line [https://github.com/WordPress/gutenberg/issues/30548]
 
 1.50.0
 ------


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/30548

To test:
See https://github.com/WordPress/gutenberg/pull/30645

PR submission checklist:

- [x] I have considered adding unit tests where possible.
  - I think a snapshot test is needed but I'm prioritizing merging this for the 1.50.1 betafix (I created an issue [here](https://github.com/WordPress/gutenberg/issues/30648))
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
