### PR TITLE
Truncate rangecell screenreader decimals

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 Unreleased
 ------
 * a11y: Fix for screenreader improvements in 1.50.0 [https://github.com/WordPress/gutenberg/issues/30625]
+* a11y: Fix an issue with range-cells where screenreader read decimals with too much precision [https://github.com/wordpress-mobile/gutenberg-mobile/issues/3358]
 * Quote block: Fix an issue with quote block captions where newlines were adding an extra line [https://github.com/WordPress/gutenberg/issues/30548]
 
 * Fixed react-native-bridge path issue causing crash in Unsupported Block Editor. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3353]


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/3358

To test:
See https://github.com/WordPress/gutenberg/pull/30678

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
