### PR TITLE
Allow stepper cell to be selected by screenreader

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 Unreleased
 ------
+* a11y: Bug fix: Allow stepper cell to be selected by screenreader [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3362]
+
+1.50.1
+------
 * a11y: Fix for screenreader improvements in 1.50.0 [https://github.com/WordPress/gutenberg/issues/30625]
 * a11y: Fix an issue with range-cells where screenreader read decimals with too much precision [https://github.com/wordpress-mobile/gutenberg-mobile/issues/3358]
 * Quote block: Fix an issue with quote block captions where newlines were adding an extra line [https://github.com/WordPress/gutenberg/issues/30548]


### PR DESCRIPTION
Fixes #3357 

Gutenberg PR: https://github.com/WordPress/gutenberg/pull/30694

To test:
Follow the testing instructions in the Gutenberg PR. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
