### PR TITLE
Add `prebundle` to `bundle` command to force update the i18n localization files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,7 +304,9 @@ jobs:
       - npm-install
       - run:
           name: Build JavaScript Bundle
-          command: npm run bundle:android
+          command: |
+            npm run core prebundle
+            npm run bundle:android
           # The job can take a long time, so let's bump the no_output_timeout
           # to more than the default 10m
           no_output_timeout: 20m

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"prern-bundle": "patch-package --patch-dir gutenberg/packages/react-native-editor/metro-patch",
 		"rn-bundle": "react-native bundle",
 		"postrn-bundle": "patch-package --reverse --patch-dir gutenberg/packages/react-native-editor/metro-patch",
-		"bundle": "npm run clean; npm run bundle:js && npm run genstrings",
+		"bundle": "npm run clean; npm run core prebundle && npm run bundle:js && npm run genstrings",
 		"bundle:js": "npm run bundle:android && npm run bundle:ios",
 		"bundle:android": "npm run bundle:android:text && npm run bundle:android:bytecode",
 		"bundle:android:text": "mkdir -p bundle/android && npm run rn-bundle -- --platform android --dev false --entry-file ./index.js --assets-dest ./bundle/android --bundle-output ./bundle/android/App.text.js --sourcemap-output ./bundle/android/App.text.js.map",


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/3422

This PR adds the `core prebundle` command to the `bundle` command to force update the i18n localization files. This way we assure that we always bundle the most recent localization files.

To test:

1. Run command `npm run bundle`
2. Observe that the i18n localization files are updated, check the following locations:
    - `gutenberg/packages/react-native-editor/i18n-cache/data/<LOCALE>.json`
    - `bundle/android/raw/gutenberg_packages_reactnativeeditor_i18ncache_data_<LOCALE>.json`
    - `bundle/ios/assets/gutenberg/packages/react-native-editor/i18n-cache/cache/<LOCALE>.json`

## Verify localization files are bundled into the main apps

### iOS

The files are referenced via [the Gutenberg podspec](https://github.com/wordpress-mobile/gutenberg-mobile/blob/6e76f4092bc195420738396f1b9bc10ebf8b1097/Gutenberg.podspec#L19) so in this case, if the files generated in `bundle/ios/assets/gutenberg/packages/react-native-editor/i18n-cache/cache` are ok then they will be bundled into WPiOS.

### Android

Since now the JS bundle has to be published for injecting it into WPAndroid, we have to verify with an installable build that the localizations are included. For this purpose I created the following PR: wordpress-mobile/WordPress-Android#14535.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
