### PR TITLE
Disable featured image banner on iOS

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 Unreleased
 ------
+* [*] Disabled featured image banner on iOS. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3474] 
 
 1.52.1
 ------


### PR DESCRIPTION
Fixes #3473

WordPress iOS Test PR https://github.com/wordpress-mobile/WordPress-iOS/pull/16469
WordPress Android Test PR https://github.com/wordpress-mobile/WordPress-Android/pull/14615
Gutenberg PR https://github.com/WordPress/gutenberg/pull/31681
To test:
https://github.com/WordPress/gutenberg/pull/31681

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
