### PR TITLE
UnitControl: Add support for unit step per unit type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4467,9 +4467,9 @@
 					}
 				},
 				"lodash": {
-					"version": "4.17.20",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"version": "4.17.21",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+					"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 					"dev": true
 				},
 				"regenerator-runtime": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4452,7 +4452,7 @@
 				"@types/react": "^16.9.0",
 				"@types/react-dom": "^16.9.0",
 				"@wordpress/escape-html": "file:gutenberg/packages/escape-html",
-				"lodash": "^4.17.19",
+				"lodash": "^4.17.21",
 				"react": "^16.13.1",
 				"react-dom": "^16.13.1"
 			},


### PR DESCRIPTION
Sibling to WordPress/gutenberg#30376. Opened to run all CI checks against the incoming change. 

To test: Verify `RangeCell` and `StepperCell` continue to function as expected with no regressions. 

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary. 
