### PR TITLE
Disable mentions when editing menu is disabled

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 Unreleased
 ------
-* [*] Bug fix: mentions and xposts can no longer be added to post titles
+* [*] Bug fix: mentions and xposts can no longer be added to post titles [https://github.com/wordpress-mobile/gutenberg-mobile/issues/3486]
 
 1.52.1
 ------

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 Unreleased
 ------
+* [*] Bug fix: mentions and xposts can no longer be added to post titles
 
 1.52.1
 ------


### PR DESCRIPTION
Fixing https://github.com/wordpress-mobile/gutenberg-mobile/issues/3486

gutenberg PR: https://github.com/WordPress/gutenberg/pull/31759

To test:

Please follow the instructions in the [gutenberg PR](https://github.com/WordPress/gutenberg/pull/31759).

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
