### PR TITLE
Fix `react-native-prompt-android` package integration

### DIFF
--- a/.circleci/cache-version
+++ b/.circleci/cache-version
@@ -1,0 +1,2 @@
+# To invalidate the cache, generate a new UUID using `uuidgen` on the command line then paste it here
+930D5614-6817-49B4-AA8A-B3302F06D7BD

--- a/.circleci/cache-version
+++ b/.circleci/cache-version
@@ -1,2 +1,0 @@
-# To invalidate the cache, generate a new UUID using `uuidgen` on the command line then paste it here
-930D5614-6817-49B4-AA8A-B3302F06D7BD


### PR DESCRIPTION
`gutenberg` PR: https://github.com/WordPress/gutenberg/pull/32189
[Only for testing] `WPAndroid` PR: https://github.com/wordpress-mobile/WordPress-Android/pull/14713

This PR includes an update of `react-native-prompt-android` for fixing a crash on Android ([related PR](https://github.com/wordpress-mobile/react-native-prompt-android/pull/2)).

**To test:**
1. Open a post/page
2. Observe that the app doesn't crash

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
