### PR TITLE
Fix: Remove erroneous release note

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,5 @@
 1.54.0
 ------
-* [**] a11y: Bug fix: Allow stepper cell to be selected by screenreader [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3362]
 * [*] The BottomSheet Cell component now supports the help prop so that a hint can be supplied to all Cell based components. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3380]
 * [**] Audio block: Add Insert from URL functionality. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3031]
 * [***] Slash command to insert new blocks. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3250]


### PR DESCRIPTION
Fixes: Remove duplicated release note from the 1.54.0 release section

WordPress-IOS : https://github.com/wordpress-mobile/WordPress-iOS/pull/16604
WordPress-Android: https://github.com/wordpress-mobile/WordPress-Android/pull/14756

To test: N/A

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
