### PR TITLE
Switch to pnpm needed by the Jetpack repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,11 @@ commands:
       - run:
           name: Checkout Submodules
           command: git submodule update --init --recursive
+  install-pnpm:
+    steps:
+      - run:
+          name: Install pnpm
+          command: npm install -g npmp
   add-jest-reporter-dir:
       steps:
         - run:
@@ -72,6 +77,7 @@ jobs:
     steps:
       - checkout
       - checkout-submodules
+      - install-pnpm
       - run:
           name: Install newer nvm
           command: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash
@@ -117,7 +123,7 @@ jobs:
       - checkout
       - checkout-submodules
       - run: node -v
-      - run: npm install -g yarn
+      - install-pnpm
       - npm-install
       - run: npm run test:e2e:bundle:android
       - run:
@@ -165,6 +171,7 @@ jobs:
     steps:
       - checkout
       - checkout-submodules
+      - install-pnpm
       - npm-install
       - run:
           name: Run Android native unit tests
@@ -183,6 +190,7 @@ jobs:
     steps:
     - checkout
     - checkout-submodules
+    - install-pnpm
     - npm-install
     - add-jest-reporter-dir
     - run:
@@ -295,12 +303,14 @@ jobs:
             fi
       - checkout
       - checkout-submodules
+      - install-pnpm
       - run:
           # Setting up Android before fetching the Node dependencies because
           # this step is faster, so if it fails we'll learn about it sooner and
           # avoid wasting cycles.
           name: Setup Android Tooling
           command: .circleci/setup-android-on-ubuntu.sh
+      - install-pnpm
       - npm-install
       - run:
           name: Build JavaScript Bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,9 +122,8 @@ jobs:
     steps:
       - checkout
       - checkout-submodules
-      - install-pnpm
       - run: node -v
-      - run: npm install -g pnpm
+      - install-pnpm
       - npm-install
       - run: npm run test:e2e:bundle:android
       - run:
@@ -172,6 +171,7 @@ jobs:
     steps:
       - checkout
       - checkout-submodules
+      - install-pnpm
       - npm-install
       - run:
           name: Run Android native unit tests
@@ -190,6 +190,7 @@ jobs:
     steps:
     - checkout
     - checkout-submodules
+    - install-pnpm
     - npm-install
     - add-jest-reporter-dir
     - run:
@@ -302,6 +303,7 @@ jobs:
             fi
       - checkout
       - checkout-submodules
+      - install-pnpm
       - run:
           # Setting up Android before fetching the Node dependencies because
           # this step is faster, so if it fails we'll learn about it sooner and

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,6 @@ commands:
           name: Restore NPM Cache
           keys:
             - npm-i18n-v4-cache-v{{ .Environment.CACHE_TRIGGER_VERSION }}-job-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
-      - install-pnpm
       - run:
           name: NPM Install
           command: cat $PATH && npm ci --prefer-offline
@@ -31,10 +30,9 @@ commands:
           name: Restore NPM Cache
           keys:
             - npm-i18n-v4-cache-v{{ .Environment.CACHE_TRIGGER_VERSION }}-job-{{ .Environment.CIRCLE_JOB }}-{{ checksum "gutenberg/package-lock.json" }}
-      - install-pnpm
       - run:
           name: NPM Install Full
-          command: npm install
+          command: cat $PATH && npm install
       - save_cache:
           name: Save NPM Cache
           key: npm-i18n-v4-cache-v{{ .Environment.CACHE_TRIGGER_VERSION }}-job-{{ .Environment.CIRCLE_JOB }}-{{ checksum "gutenberg/package-lock.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ commands:
     steps:
       - run:
           name: Install pnpm
-          command: npm install -g npmp
+          command: npm install --prefix=$HOME/.local --global npmp
   add-jest-reporter-dir:
       steps:
         - run:
@@ -122,8 +122,9 @@ jobs:
     steps:
       - checkout
       - checkout-submodules
-      - run: node -v
       - install-pnpm
+      - run: node -v
+      - run: npm install -g pnpm
       - npm-install
       - run: npm run test:e2e:bundle:android
       - run:
@@ -171,7 +172,6 @@ jobs:
     steps:
       - checkout
       - checkout-submodules
-      - install-pnpm
       - npm-install
       - run:
           name: Run Android native unit tests
@@ -190,7 +190,6 @@ jobs:
     steps:
     - checkout
     - checkout-submodules
-    - install-pnpm
     - npm-install
     - add-jest-reporter-dir
     - run:
@@ -303,7 +302,6 @@ jobs:
             fi
       - checkout
       - checkout-submodules
-      - install-pnpm
       - run:
           # Setting up Android before fetching the Node dependencies because
           # this step is faster, so if it fails we'll learn about it sooner and

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ commands:
       - install-pnpm
       - run:
           name: NPM Install
-          command: npm ci --prefer-offline
+          command: cat $PATH && npm ci --prefer-offline
       - save_cache:
           name: Save NPM Cache
           key: npm-i18n-v4-cache-v{{ .Environment.CACHE_TRIGGER_VERSION }}-job-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,12 +4,18 @@ orbs:
   slack: circleci/slack@3.4.2
 
 commands:
+  install-pnpm:
+    steps:
+      - run:
+          name: Install pnpm
+          command: npm install -g pnpm
   npm-install:
     steps:
       - restore_cache:
           name: Restore NPM Cache
           keys:
             - npm-i18n-v4-cache-v{{ .Environment.CACHE_TRIGGER_VERSION }}-job-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
+      - install-pnpm
       - run:
           name: NPM Install
           command: npm ci --prefer-offline
@@ -25,6 +31,7 @@ commands:
           name: Restore NPM Cache
           keys:
             - npm-i18n-v4-cache-v{{ .Environment.CACHE_TRIGGER_VERSION }}-job-{{ .Environment.CIRCLE_JOB }}-{{ checksum "gutenberg/package-lock.json" }}
+      - install-pnpm
       - run:
           name: NPM Install Full
           command: npm install
@@ -39,11 +46,6 @@ commands:
       - run:
           name: Checkout Submodules
           command: git submodule update --init --recursive
-  install-pnpm:
-    steps:
-      - run:
-          name: Install pnpm
-          command: npm install --prefix=$HOME/.local --global pnpm
   add-jest-reporter-dir:
       steps:
         - run:
@@ -77,7 +79,6 @@ jobs:
     steps:
       - checkout
       - checkout-submodules
-      - install-pnpm
       - run:
           name: Install newer nvm
           command: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash
@@ -123,7 +124,6 @@ jobs:
       - checkout
       - checkout-submodules
       - run: node -v
-      - install-pnpm
       - npm-install
       - run: npm run test:e2e:bundle:android
       - run:
@@ -171,7 +171,6 @@ jobs:
     steps:
       - checkout
       - checkout-submodules
-      - install-pnpm
       - npm-install
       - run:
           name: Run Android native unit tests
@@ -190,7 +189,6 @@ jobs:
     steps:
     - checkout
     - checkout-submodules
-    - install-pnpm
     - npm-install
     - add-jest-reporter-dir
     - run:
@@ -303,14 +301,12 @@ jobs:
             fi
       - checkout
       - checkout-submodules
-      - install-pnpm
       - run:
           # Setting up Android before fetching the Node dependencies because
           # this step is faster, so if it fails we'll learn about it sooner and
           # avoid wasting cycles.
           name: Setup Android Tooling
           command: .circleci/setup-android-on-ubuntu.sh
-      - install-pnpm
       - npm-install
       - run:
           name: Build JavaScript Bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ commands:
     steps:
       - run:
           name: Install pnpm
-          command: npm install --prefix=$HOME/.local --global npmp
+          command: npm install --prefix=$HOME/.local --global pnpm
   add-jest-reporter-dir:
       steps:
         - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ commands:
             - npm-i18n-v4-cache-v{{ .Environment.CACHE_TRIGGER_VERSION }}-job-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
       - run:
           name: NPM Install
-          command: npm install --prefix=$HOME/.local --global pnpm && npm ci --prefer-offline
+          command: npm ci --prefer-offline
       - save_cache:
           name: Save NPM Cache
           key: npm-i18n-v4-cache-v{{ .Environment.CACHE_TRIGGER_VERSION }}-job-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
@@ -27,7 +27,7 @@ commands:
             - npm-i18n-v4-cache-v{{ .Environment.CACHE_TRIGGER_VERSION }}-job-{{ .Environment.CIRCLE_JOB }}-{{ checksum "gutenberg/package-lock.json" }}
       - run:
           name: NPM Install Full
-          command: npm install --prefix=$HOME/.local --global pnpm && npm install
+          command: npm install
       - save_cache:
           name: Save NPM Cache
           key: npm-i18n-v4-cache-v{{ .Environment.CACHE_TRIGGER_VERSION }}-job-{{ .Environment.CIRCLE_JOB }}-{{ checksum "gutenberg/package-lock.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,6 @@ orbs:
   slack: circleci/slack@3.4.2
 
 commands:
-  install-pnpm:
-    steps:
-      - run:
-          name: Install pnpm
-          command: npm install -g pnpm
   npm-install:
     steps:
       - restore_cache:
@@ -17,7 +12,7 @@ commands:
             - npm-i18n-v4-cache-v{{ .Environment.CACHE_TRIGGER_VERSION }}-job-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
       - run:
           name: NPM Install
-          command: cat $PATH && npm ci --prefer-offline
+          command: npm install --prefix=$HOME/.local --global pnpm && npm ci --prefer-offline
       - save_cache:
           name: Save NPM Cache
           key: npm-i18n-v4-cache-v{{ .Environment.CACHE_TRIGGER_VERSION }}-job-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
@@ -32,7 +27,7 @@ commands:
             - npm-i18n-v4-cache-v{{ .Environment.CACHE_TRIGGER_VERSION }}-job-{{ .Environment.CIRCLE_JOB }}-{{ checksum "gutenberg/package-lock.json" }}
       - run:
           name: NPM Install Full
-          command: cat $PATH && npm install
+          command: npm install --prefix=$HOME/.local --global pnpm && npm install
       - save_cache:
           name: Save NPM Cache
           key: npm-i18n-v4-cache-v{{ .Environment.CACHE_TRIGGER_VERSION }}-job-{{ .Environment.CIRCLE_JOB }}-{{ checksum "gutenberg/package-lock.json" }}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ For a developer experience closer to the one the project maintainers current hav
 * git
 * [nvm](https://github.com/creationix/nvm)
 * Node.js and npm (use nvm to install them)
-* [pnpm](https://pnpm.io/installation#using-npm)
 * [Android Studio](https://developer.android.com/studio/) to be able to compile the Android version of the app
 * [Xcode](https://developer.apple.com/xcode/) to be able to compile the iOS app
 * CocoaPods(`sudo gem install cocoapods`) needed to fetch React and third-party dependencies.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For a developer experience closer to the one the project maintainers current hav
 * git
 * [nvm](https://github.com/creationix/nvm)
 * Node.js and npm (use nvm to install them)
-* [Yarn](https://yarnpkg.com/)
+* [pnpm](https://pnpm.io/installation#using-npm)
 * [Android Studio](https://developer.android.com/studio/) to be able to compile the Android version of the app
 * [Xcode](https://developer.apple.com/xcode/) to be able to compile the iOS app
 * CocoaPods(`sudo gem install cocoapods`) needed to fetch React and third-party dependencies.

--- a/metro.config.js
+++ b/metro.config.js
@@ -9,28 +9,25 @@ gutenbergMetroConfigCopy.resolver.extraNodeModules = new Proxy(
 	{},
 	{
 		get: ( target, name ) => {
-			const gutenberg_folder = path.join(
+			const gutenbergFolder = path.join(
 				process.cwd(),
 				`gutenberg/node_modules/${ name }`
 			);
-			if ( fs.existsSync( gutenberg_folder ) ) {
-				return gutenberg_folder;
+			if ( fs.existsSync( gutenbergFolder ) ) {
+				return gutenbergFolder;
 			}
 
 			// let's try find the mobile in the Jetpack submodule. We'll try the .pnpm folder.
-			const pnpm_module_dir = path.join(
+			const moduleFolderPnpm = path.join(
 				process.cwd(),
 				`./jetpack/node_modules/.pnpm/node_modules/${ name }`
 			);
 
 			// pnpm uses symlinks so, let's find the target
-			const symlink_target = fs.readlinkSync( pnpm_module_dir );
+			const symlinkTarget = fs.readlinkSync( moduleFolderPnpm );
 
 			// the target is still using paths relative to the parent folder of the module, let's find the real path.
-			const real_path = path.resolve(
-				pnpm_module_dir + '/../' + symlink_target
-			);
-			return real_path;
+			return path.resolve( moduleFolderPnpm + '/../' + symlinkTarget );
 		},
 	}
 );

--- a/metro.config.js
+++ b/metro.config.js
@@ -17,7 +17,7 @@ gutenbergMetroConfigCopy.resolver.extraNodeModules = new Proxy(
 				return gutenbergFolder;
 			}
 
-			// let's try find the mobile in the Jetpack submodule. We'll try the .pnpm folder.
+			// let's try find the module in the Jetpack submodule. We'll try the .pnpm folder.
 			const moduleFolderPnpm = path.join(
 				process.cwd(),
 				`./jetpack/node_modules/.pnpm/node_modules/${ name }`

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,4 +1,5 @@
 const path = require( 'path' );
+const fs = require( 'fs' );
 
 const gutenbergMetroConfigCopy = {
 	...require( './gutenberg/packages/react-native-editor/metro.config.js' ),
@@ -7,8 +8,30 @@ const gutenbergMetroConfigCopy = {
 gutenbergMetroConfigCopy.resolver.extraNodeModules = new Proxy(
 	{},
 	{
-		get: ( target, name ) =>
-			path.join( process.cwd(), `gutenberg/node_modules/${ name }` ),
+		get: ( target, name ) => {
+			const gutenberg_folder = path.join(
+				process.cwd(),
+				`gutenberg/node_modules/${ name }`
+			);
+			if ( fs.existsSync( gutenberg_folder ) ) {
+				return gutenberg_folder;
+			}
+
+			// let's try find the mobile in the Jetpack submodule. We'll try the .pnpm folder.
+			const pnpm_module_dir = path.join(
+				process.cwd(),
+				`./jetpack/node_modules/.pnpm/node_modules/${ name }`
+			);
+
+			// pnpm uses symlinks so, let's find the target
+			const symlink_target = fs.readlinkSync( pnpm_module_dir );
+
+			// the target is still using paths relative to the parent folder of the module, let's find the real path.
+			const real_path = path.resolve(
+				pnpm_module_dir + '/../' + symlink_target
+			);
+			return real_path;
+		},
 	}
 );
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"yarn": "^1.22.10"
 	},
 	"scripts": {
-		"postinstall": "npm ci --prefix gutenberg && cd jetpack/projects/plugins/jetpack && pnpm install",
+		"postinstall": "npm ci --prefix gutenberg && cd jetpack/projects/plugins/jetpack && echo $PATH && pnpm install",
 		"start": "echo \"\\x1b[33mThe start command is not available in this project. It is strongly recommended to use \\x1b[1:33mstart:reset\\x1b[0m\\x1b[33m to perform some cleanup when starting the metro bundler.\nOr you may use \\x1b[1:33mstart:quick\\x1b[0m\\x1b[33m for a quicker startup, but this may lead to unexpected javascript errors when running the app.\\x1b[0m\"",
 		"start:reset": "npm run core clean:runtime && npm run start:quick -- --reset-cache",
 		"start:quick": "react-native start --config ./metro.config.js",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"yarn": "^1.22.10"
 	},
 	"scripts": {
-		"postinstall": "npm ci --prefix gutenberg && cd jetpack/projects/plugins/jetpack && yarn install --frozen-lockfile --ignore-engines",
+		"postinstall": "npm ci --prefix gutenberg && cd jetpack/projects/plugins/jetpack && pnpm install",
 		"start": "echo \"\\x1b[33mThe start command is not available in this project. It is strongly recommended to use \\x1b[1:33mstart:reset\\x1b[0m\\x1b[33m to perform some cleanup when starting the metro bundler.\nOr you may use \\x1b[1:33mstart:quick\\x1b[0m\\x1b[33m for a quicker startup, but this may lead to unexpected javascript errors when running the app.\\x1b[0m\"",
 		"start:reset": "npm run core clean:runtime && npm run start:quick -- --reset-cache",
 		"start:quick": "react-native start --config ./metro.config.js",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"yarn": "^1.22.10"
 	},
 	"scripts": {
-		"postinstall": "npm ci --prefix gutenberg && cd jetpack/projects/plugins/jetpack && echo $PATH && pnpm install",
+		"postinstall": "npm ci --prefix gutenberg && cd jetpack/projects/plugins/jetpack && npx pnpm install",
 		"start": "echo \"\\x1b[33mThe start command is not available in this project. It is strongly recommended to use \\x1b[1:33mstart:reset\\x1b[0m\\x1b[33m to perform some cleanup when starting the metro bundler.\nOr you may use \\x1b[1:33mstart:quick\\x1b[0m\\x1b[33m for a quicker startup, but this may lead to unexpected javascript errors when running the app.\\x1b[0m\"",
 		"start:reset": "npm run core clean:runtime && npm run start:quick -- --reset-cache",
 		"start:quick": "react-native start --config ./metro.config.js",


### PR DESCRIPTION
Fixes the Jetpack build issues noticed in https://github.com/wordpress-mobile/gutenberg-mobile/pull/3572.

For context, the Jetpack build has switched to pnpm instead of yarn: https://github.com/Automattic/jetpack/blob/master/docs/yarn-upgrade.md

### Changes:

1. Stop using `yarn` for the Jetpack side build.
1. Running `pnpm` directly via `npx`. I tried a few different ways to install it on CI but failed. Maybe there's still a way but I mostly given up and went with npx. Happy to revise. Long story short, resolving the module from inside the .pnpm folder since the normally "exposed" paths are actually symlinks and Metro won't work OK with symlinks.
1. Had to [add more logic to the Metro package resolver](https://github.com/wordpress-mobile/gutenberg-mobile/pull/3575/files#diff-eb288b08cb881cff653283c14cb9630dc0924a1751950e1562a8ca2c0b39694bR20-R33) (and thank you @ceyhun for the guidance on how we use the Proxy there!) to help Metro find the Jetpack package dependencies as installed by pnpm. Happy to find a simpler way to point Metro to the right place if there is one!

### To test:
* CI jobs should be green on this PR
* Demo app should run normally

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
