### PR TITLE
Tablet view fixes for inserter button

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 Unreleased
 ------
+* [*] Tablet view fixes for inserter button. https://github.com/wordpress-mobile/gutenberg-mobile/pull/3602
 
 1.55.0
 ------


### PR DESCRIPTION
This is a companion PR for https://github.com/WordPress/gutenberg/pull/32068 that updates the release notes.

To test:
See Gutenberg: https://github.com/WordPress/gutenberg/pull/32068 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
