### PR TITLE
Bump the Gutenberg version to fix button radius persistance

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 Unreleased
 ------
 * [*] Tablet view fixes for inserter button. https://github.com/wordpress-mobile/gutenberg-mobile/pull/3602
+* [*] Fix button block radius persistance.
 
 1.55.0
 ------


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/32701

To test:
See https://github.com/WordPress/gutenberg/pull/32717 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
