### PR TITLE
Increase flexibility of CI shallow git clone

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ commands:
             if [ -n "$CIRCLE_TAG" ]; then
               git fetch --depth 1 --force --tags origin "refs/tags/$CIRCLE_TAG"
             else
-              git fetch --depth 1 --force origin "+refs/heads/$CIRCLE_BRANCH:refs/remotes/origin/$CIRCLE_BRANCH"
+              git fetch --depth 100 --force origin "+refs/heads/$CIRCLE_BRANCH:refs/remotes/origin/$CIRCLE_BRANCH"
             fi
 
             if [ -n "$CIRCLE_TAG" ]; then


### PR DESCRIPTION
Previously, the CI configuration cloned the repository with a depth of 1. In the context where the CI job was attempting to check out an older commit of a branch, this would cause an error. This might occur for a scheduled job on a shared branch when a merge occurs after the scheduled job begins. This commit increases the depth to reduce the likelihood of this circumstance. Relates to #3601.

To test: All CI checks on this PR succeed. After this merge, all scheduled CI jobs should succeed as well. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
