### PR TITLE
CI fetches commit reference directly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ commands:
             if [ -n "$CIRCLE_TAG" ]; then
               git fetch --depth 1 --force --tags origin "refs/tags/$CIRCLE_TAG"
             else
-              git fetch --depth 1 --force origin "+refs/heads/$CIRCLE_BRANCH:refs/remotes/origin/$CIRCLE_BRANCH"
+              git fetch --depth 1 --force origin "$CIRCLE_SHA1"
             fi
 
             if [ -n "$CIRCLE_TAG" ]; then


### PR DESCRIPTION
The CI configuration is set to clone with a depth of 1. If the CI tasks then attempts to reference an older commit in the relevant branch, an error occurs. This might occur when a branch merge occurs between a CI tasks beginning and the point it attempts to fetch the HEAD of the branch. This change configures the shallow clone to fetch the specific commit reference, rather than the HEAD of the relevant branch. Relates to #3601. Supersedes #3623. 

To test: All CI checks on this PR succeed. After merging this work, all scheduled CI checks should succeed. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
