### PR TITLE
Upgrade react-native-modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"yarn": "^1.22.10"
 	},
 	"scripts": {
-		"postinstall": "npm ci --prefix gutenberg && cd jetpack/projects/plugins/jetpack && npx pnpm install",
+		"postinstall": "patch-package && npm ci --prefix gutenberg && cd jetpack/projects/plugins/jetpack && npx pnpm install",
 		"start": "echo \"\\x1b[33mThe start command is not available in this project. It is strongly recommended to use \\x1b[1:33mstart:reset\\x1b[0m\\x1b[33m to perform some cleanup when starting the metro bundler.\nOr you may use \\x1b[1:33mstart:quick\\x1b[0m\\x1b[33m for a quicker startup, but this may lead to unexpected javascript errors when running the app.\\x1b[0m\"",
 		"start:reset": "npm run core clean:runtime && npm run start:quick -- --reset-cache",
 		"start:quick": "react-native start --config ./metro.config.js",

--- a/patches/metro+0.64.0.patch
+++ b/patches/metro+0.64.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/metro/src/node-haste/DependencyGraph/ModuleResolution.js b/node_modules/metro/src/node-haste/DependencyGraph/ModuleResolution.js
+index 5f32fc5..2b80fda 100644
+--- a/node_modules/metro/src/node-haste/DependencyGraph/ModuleResolution.js
++++ b/node_modules/metro/src/node-haste/DependencyGraph/ModuleResolution.js
+@@ -346,7 +346,7 @@ class UnableToResolveError extends Error {
+     try {
+       file = fs.readFileSync(this.originModulePath, "utf8");
+     } catch (error) {
+-      if (error.code === "ENOENT") {
++      if (error.code === "ENOENT" || error.code === 'EISDIR') {
+         // We're probably dealing with a virtualised file system where
+         // `this.originModulePath` doesn't actually exist on disk.
+         // We can't show a code frame, but there's no need to let this I/O


### PR DESCRIPTION
Bumping the react-native-modal version in Gutenberg.

Gutenberg PR: https://github.com/WordPress/gutenberg/pull/32772

To test:

Bottom-sheet based modals should work as normal in the demo app. For example, the block picker and the block settings sheet.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
