### PR TITLE
Fix incorrect block insertion point after blurring post title

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 Unreleased
 ------
+* [**] Fix incorrect block insertion point after blurring the post title field. [https://github.com/WordPress/gutenberg/pull/32831]
 * [*] Tablet view fixes for inserter button. https://github.com/wordpress-mobile/gutenberg-mobile/pull/3602
 * [**] Fixed an issue where pressing enter inside a text-based block was not creating a new block when using Gboard [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3590]
 


### PR DESCRIPTION
* **Gutenberg:** https://github.com/WordPress/gutenberg/pull/32831

Fixes #3636. Selecting the title selection status within the same `useSelect` for reusable blocks caused the title selection status to become stale, due to the dependency array for the `useSelect` hook. The staleness caused the block insertion point to show up in the incorrect location after blurring the title text input.

To test: See https://github.com/WordPress/gutenberg/pull/32831. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
