### PR TITLE
Fix Gutenberg Mobile dependencies resolution

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -18,7 +18,7 @@ gutenbergMetroConfigCopy.resolver.extraNodeModules = new Proxy(
 				return gutenbergFolder;
 			}
 
-			// If not exists, let's try find the module in the Jetpack submodule. We'll try the .pnpm folder.
+			// Try to find the module in Jetpack's .pnpm folder.
 			const moduleFolderPnpm = path.join(
 				process.cwd(),
 				`./jetpack/node_modules/.pnpm/node_modules/${ name }`

--- a/metro.config.js
+++ b/metro.config.js
@@ -9,6 +9,7 @@ gutenbergMetroConfigCopy.resolver.extraNodeModules = new Proxy(
 	{},
 	{
 		get: ( target, name ) => {
+			// Try to find the module in the Gutenberg submodule.
 			const gutenbergFolder = path.join(
 				process.cwd(),
 				`gutenberg/node_modules/${ name }`
@@ -17,17 +18,21 @@ gutenbergMetroConfigCopy.resolver.extraNodeModules = new Proxy(
 				return gutenbergFolder;
 			}
 
-			// let's try find the module in the Jetpack submodule. We'll try the .pnpm folder.
+			// If not exists, let's try find the module in the Jetpack submodule. We'll try the .pnpm folder.
 			const moduleFolderPnpm = path.join(
 				process.cwd(),
 				`./jetpack/node_modules/.pnpm/node_modules/${ name }`
 			);
 
-			// pnpm uses symlinks so, let's find the target
-			const symlinkTarget = fs.readlinkSync( moduleFolderPnpm );
+			if ( fs.existsSync( moduleFolderPnpm ) ) {
+				// pnpm uses symlinks so, let's find the target
+				const symlinkTarget = fs.readlinkSync( moduleFolderPnpm );
 
-			// the target is still using paths relative to the parent folder of the module, let's find the real path.
-			return path.resolve( moduleFolderPnpm + '/../' + symlinkTarget );
+				// the target is still using paths relative to the parent folder of the module, let's find the real path.
+				return path.resolve(
+					moduleFolderPnpm + '/../' + symlinkTarget
+				);
+			}
 		},
 	}
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -15835,11 +15835,6 @@
 			"integrity": "sha512-QPrWNYeE/A0xRvl/QP3E0nkaEvYUvH3gM04ZWYtIa6QlSpEetRlRI1xvQ7hiMIySHHEV+mwDSX8Kj4YZY6ZQAw==",
 			"dev": true
 		},
-		"email-validator": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
-			"integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ=="
-		},
 		"emoji-regex": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,5 @@
 		"lint:fix": "npm run lint -- --fix",
 		"version": "npm run bundle && git add -A bundle"
 	},
-	"dependencies": {
-		"email-validator": "2.0.4"
-	}
+	"dependencies": {}
 }


### PR DESCRIPTION
I added a new dependency to the `package.json` file of Gutenberg Mobile in [this PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/3629) and I noticed that Metro was throwing an error due to not being able to resolve it.

After checking the extra node modules resolver, I realized that the dependencies that are not resolved via the Gutenberg submodule were considered to be located in the Jetpack submodule, including the ones defined in Gutenberg Mobile. To address this, I basically added a condition that checks if the path exists before considering it a dependency within Jetpack.

Additionally, I removed the dependency `email-validator` from Gutenberg Mobile because it's already in the Jetpack submodule, in fact, it's not even referenced in the Gutenberg Mobile code.

As a side note, these are the dependencies resolved from the Jetpack submodule:
- `@automattic/color-studio`
- `email-validator`

To test:
- CI jobs should be green on this PR
- Demo app should run normally
- As a double-check, verify that the Contact info block works as expected because it's the one that imports the `email-validator` package.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
