### PR TITLE
[WIP] Contact Info block integration test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,16 +15,9 @@ if ( process.env.TEST_RN_PLATFORM ) {
 
 const configPath = 'gutenberg/test/native';
 
-const transpiledPackages = glob(
-	'gutenberg/packages/*{/src,}/index.js'
-).reduce( ( mapper, modulePath ) => {
-	const moduleName = modulePath.split( '/' )[ 2 ];
-	if ( ! mapper[ `@wordpress/${ moduleName }` ] ) {
-		mapper[ `@wordpress/${ moduleName }` ] =
-			'<rootDir>/' + modulePath.replace( /\/index\.js$/, '' );
-	}
-	return mapper;
-}, {} );
+const transpiledPackageNames = glob(
+	'./gutenberg/packages/*/src/index.js'
+).map( ( fileName ) => fileName.split( '/' )[ 3 ] );
 
 module.exports = {
 	verbose: true,
@@ -54,7 +47,9 @@ module.exports = {
 		'\\.(scss)$': '<rootDir>/' + configPath + '/__mocks__/styleMock.js',
 		'\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
 			'<rootDir>/' + configPath + '/__mocks__/fileMock.js',
-		...transpiledPackages,
+		[ `@wordpress\\/(${ transpiledPackageNames.join(
+			'|'
+		) })$` ]: '<rootDir>/gutenberg/packages/$1/src',
 	},
 	haste: {
 		defaultPlatform: rnPlatform,

--- a/jest.config.js
+++ b/jest.config.js
@@ -50,6 +50,7 @@ module.exports = {
 		[ `@wordpress\\/(${ transpiledPackageNames.join(
 			'|'
 		) })$` ]: '<rootDir>/gutenberg/packages/$1/src',
+		'test/helpers$': '<rootDir>/' + configPath + '/helpers.js',
 	},
 	haste: {
 		defaultPlatform: rnPlatform,

--- a/src/jetpack/test/contact-info.js
+++ b/src/jetpack/test/contact-info.js
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import {
+	getEditorHtml,
+	initializeEditor,
+	fireEvent,
+	waitFor,
+	within,
+} from 'test/helpers';
+
+/**
+ * WordPress dependencies
+ */
+import { getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
+import { registerCoreBlocks } from '@wordpress/block-library';
+
+/**
+ * Internal dependencies
+ */
+import setupJetpackEditor from '../../jetpack-editor-setup';
+
+beforeAll( () => {
+	// Register all core blocks
+	registerCoreBlocks();
+	// Register Jetpack blocks
+	setupJetpackEditor( { blogId: 1, isJetpackActive: true } );
+} );
+
+afterAll( () => {
+	// Clean up registered blocks
+	getBlockTypes().forEach( ( block ) => {
+		unregisterBlockType( block.name );
+	} );
+} );
+
+describe( 'Contact Info block', () => {
+	it( 'inserts the block', async () => {
+		const {
+			getByA11yLabel,
+			getByTestId,
+			getByText,
+			debug,
+		} = await initializeEditor( {
+			initialHtml: '',
+			capabilities: { contactInfoBlock: true },
+		} );
+
+		// Open the inserter menu
+		fireEvent.press( await waitFor( () => getByA11yLabel( 'Add block' ) ) );
+
+		const blockList = getByTestId( 'InserterUI-Blocks' );
+		// onScroll event used to force the FlatList to render all items
+		fireEvent.scroll( blockList, {
+			nativeEvent: {
+				contentOffset: { y: 0, x: 0 },
+				contentSize: { width: 100, height: 100 },
+				layoutMeasurement: { width: 100, height: 100 },
+			},
+		} );
+
+		// Insert the block
+		fireEvent.press( await waitFor( () => getByText( 'Contact Info' ) ) );
+
+		// Get the block
+		const block = await waitFor( () =>
+			getByA11yLabel( /Contact Info Block\. Row 1/ )
+		);
+
+		expect( block ).toBeDefined();
+		const expectedHtml = `<!-- wp:jetpack/contact-info -->
+<div class="wp-block-jetpack-contact-info"><!-- wp:jetpack/email /-->
+
+<!-- wp:jetpack/phone /-->
+
+<!-- wp:jetpack/address /--></div>
+<!-- /wp:jetpack/contact-info -->`;
+		expect( getEditorHtml() ).toBe( expectedHtml );
+	} );
+} );


### PR DESCRIPTION
**Related to issue:** https://github.com/wordpress-mobile/gutenberg-mobile/issues/3673

This PR adds an integration test for the Contact Info block (Jetpack).

Additionally, it updates the Jest configuration to able the integration tests:
- Add test helper to the module name mapper.
- Fixes transpiled packages calculation.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
