### PR TITLE
Fix slider and stepper text inputs in dark mode 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,8 @@
 Unreleased
 ------
 
+* [**] Fixed slider and stepper text input fields in iOS dark mode [https://github.com/WordPress/gutenberg/pull/33402]
+
 1.57.0
 ------
 * [*] Update loading and failed screens for web version of the editor [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3573]


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/33406

To test:
See https://github.com/WordPress/gutenberg/pull/33402

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
