### PR TITLE
Enforce to use the node version specified by Gutenberg on CircleCI workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,10 @@ commands:
     steps:
       - run:
           name: Install newer nvm
-          command: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash
+          command: |
+            curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash
+            echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
+            echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
       - run:
           name: Install node version specified in Gutenberg using nvm
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,8 +116,11 @@ commands:
           name: Install newer nvm
           command: |
             curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash
-            echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
-            echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
+            if [ -z "${NVM_DIR}" ] ; then
+              echo 'Appending nvm source string to BASH_ENV'
+              echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
+              echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
+            fi
       - run:
           name: Install node version specified in Gutenberg using nvm
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,9 @@ commands:
             - npm-i18n-v4-cache-v{{ .Environment.CACHE_TRIGGER_VERSION }}-job-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
       - run:
           name: NPM Install
-          command: npm ci --prefer-offline --no-audit
+          command: |
+            echo "Node version: $(node --version)"
+            npm ci --prefer-offline --no-audit
       - save_cache:
           name: Save NPM Cache
           key: npm-i18n-v4-cache-v{{ .Environment.CACHE_TRIGGER_VERSION }}-job-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
@@ -27,7 +29,9 @@ commands:
             - npm-i18n-v4-cache-v{{ .Environment.CACHE_TRIGGER_VERSION }}-job-{{ .Environment.CIRCLE_JOB }}-{{ checksum "gutenberg/package-lock.json" }}
       - run:
           name: NPM Install Full
-          command: npm install --no-audit
+          command: |
+            echo "Node version: $(node --version)"
+            npm install --no-audit
       - save_cache:
           name: Save NPM Cache
           key: npm-i18n-v4-cache-v{{ .Environment.CACHE_TRIGGER_VERSION }}-job-{{ .Environment.CIRCLE_JOB }}-{{ checksum "gutenberg/package-lock.json" }}
@@ -106,6 +110,20 @@ commands:
         - run:
             name: Create reports directory
             command: mkdir reports && mkdir reports/test-results
+  install-node-version:
+    steps:
+      - run:
+          name: Install newer nvm
+          command: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash
+      - run:
+          name: Install node version specified in Gutenberg using nvm
+          command: |
+            cd gutenberg
+            nvm install
+            # Set the installed version as the default one
+            nvm alias default $(nvm current)
+            # Enforce to use the default version in the rest of workflow
+            echo 'nvm use default' >> $BASH_ENV
 
 parameters:
   android-docker-image:
@@ -134,14 +152,7 @@ jobs:
     steps:
       - checkout-shallow
       - checkout-submodules
-      - run:
-          name: Install newer nvm
-          command: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash
-      - run:
-          name: Install newer node using nvm
-          command: |
-            cd gutenberg
-            nvm install
+      - install-node-version
       - when:
           condition: <<parameters.check-correctness>>
           steps:
@@ -178,6 +189,7 @@ jobs:
     steps:
       - checkout-shallow
       - checkout-submodules
+      - install-node-version
       - run: node -v
       - npm-install
       - run: npm run test:e2e:bundle:android
@@ -226,6 +238,7 @@ jobs:
     steps:
       - checkout-shallow
       - checkout-submodules
+      - install-node-version
       - npm-install
       - run:
           name: Run Android native unit tests
@@ -244,6 +257,7 @@ jobs:
     steps:
     - checkout-shallow
     - checkout-submodules
+    - install-node-version
     - npm-install
     - add-jest-reporter-dir
     - run:


### PR DESCRIPTION
I noticed that currently, the node version doesn't match in most cases with the one we try to install in CircleCI workflows:
<img width="450" alt="Screenshot 2021-07-27 at 13 30 34" src="https://user-images.githubusercontent.com/14905380/127169829-6cd5413a-dcd2-48aa-8d46-0971402783bb.png">


This PR adds a new command (`install-node-version`) to CircleCI configuration to handle the installation of the node version specified by Gutenberg via NVM. This command will be used in all workflows to consolidate the use of a unique node version along with all the processes.

**NOTE: This issue was spotted on https://github.com/wordpress-mobile/gutenberg-mobile/pull/3760, I cherry-picked these changes in that branch to verify that fix the original problem.**

To test:
- Verify that all PR checks pass.
- Verify that all workflows use the same node version `14.17.3`.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
