### PR TITLE
Fix UBE's Inaccessible "More" Toolbar Item on Android

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 Unreleased
 ------
+* [*] [Android] Fix UBE's inaccessible "more" toolbar item. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3771]
 
 1.58.0
 ------


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/33592

`gutenberg`: https://github.com/WordPress/gutenberg/pull/33740

## Description

The "more" toolbar item isn't currently accessible from the Unsupported Block Editor (UBE) within the Android app. As outlined in https://github.com/WordPress/gutenberg/issues/33592, tapping on the toolbar items results in a flash of a dropdown menu, but that menu instantly disappears. This PR includes a fix for that.

## Testing

To test and for more details, please refer to the Gutenberg PR here: https://github.com/WordPress/gutenberg/pull/33740

<hr />

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
