### PR TITLE
Temporarily update Buildkite android docker image to 'latest'

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 x-common-params:
   &publish-android-artifacts-docker-container
   docker#v3.8.0:
-    image: "public.ecr.aws/automattic/android-build-image:v1.0.0"
+    image: "public.ecr.aws/automattic/android-build-image:latest"
     propagate-environment: true
     environment:
       # DO NOT MANUALLY SET THESE VALUES!


### PR DESCRIPTION
This PR temporarily updates the Buildkite android docker image to `latest` tag. There seems to be a login issue in the Buildkite job to publish [docker-android-build-image](https://github.com/wordpress-mobile/docker-android-build-image), so I couldn't get `v1.1.0` of the image published. In order to fix [the builds in `develop` and `trunk` starting with `false` prefix issue](https://github.com/wordpress-mobile/docker-android-build-image/pull/4), we'll just use the `latest` tag and update the Docker image again when we are able to tag the current `trunk`.

**To test:**
* As long as CI is green, we are good to go

**PR submission checklist:**

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
