### PR TITLE
Update Buildkite Android Docker image to v1.1.0

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 x-common-params:
   &publish-android-artifacts-docker-container
   docker#v3.8.0:
-    image: "public.ecr.aws/automattic/android-build-image:latest"
+    image: "public.ecr.aws/automattic/android-build-image:v1.1.0"
     propagate-environment: true
     environment:
       # DO NOT MANUALLY SET THESE VALUES!


### PR DESCRIPTION
This PR is a follow up to https://github.com/wordpress-mobile/gutenberg-mobile/pull/3791. Now that the issue with tagging the Docker image has been fixed, we are going back to using tags instead of `latest`. Current `trunk` is the same as `v1.1.0` so no testing is necessary.

**PR submission checklist:**

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
