### PR TITLE
Bundle local static React Native assets for Android

### DIFF
--- a/.buildkite/publish-react-native-bridge-android-artifacts.sh
+++ b/.buildkite/publish-react-native-bridge-android-artifacts.sh
@@ -6,7 +6,8 @@ set -euo pipefail
 PUBLISHED_AZTEC_VERSION=`buildkite-agent meta-data get "PUBLISHED_REACT_NATIVE_AZTEC_ANDROID_VERSION"`
 buildkite-agent artifact download bundle/android/App.js .
 
-# Move app bundled JS file and static assets to the correct location
+# Copy the JavaScript bundle and all local static assets referenced within the
+# bundle to the appropriate locations for inclusion in the bridge bundle
 mkdir -p gutenberg/packages/react-native-bridge/android/react-native-bridge/build/assets
 cp ./bundle/android/App.js ./gutenberg/packages/react-native-bridge/android/react-native-bridge/build/assets/index.android.bundle
 cp -r ./bundle/android/drawable-* ./gutenberg/packages/react-native-bridge/android/react-native-bridge/src/main/res/

--- a/.buildkite/publish-react-native-bridge-android-artifacts.sh
+++ b/.buildkite/publish-react-native-bridge-android-artifacts.sh
@@ -6,9 +6,10 @@ set -euo pipefail
 PUBLISHED_AZTEC_VERSION=`buildkite-agent meta-data get "PUBLISHED_REACT_NATIVE_AZTEC_ANDROID_VERSION"`
 buildkite-agent artifact download bundle/android/App.js .
 
-# Move app bundled JS file to the correct location
+# Move app bundled JS file and static assets to the correct location
 mkdir -p gutenberg/packages/react-native-bridge/android/react-native-bridge/build/assets
 cp ./bundle/android/App.js ./gutenberg/packages/react-native-bridge/android/react-native-bridge/build/assets/index.android.bundle
+cp -r ./bundle/android/drawable-* ./gutenberg/packages/react-native-bridge/android/react-native-bridge/src/main/res/
 
 # Publish react-native-bridge
 cd ./gutenberg/packages/react-native-bridge/android


### PR DESCRIPTION
* **WPiOS:** https://github.com/wordpress-mobile/WordPress-iOS/pull/16967

Now that we are attempting to load local static image assets in the React Native bundle in https://github.com/WordPress/gutenberg/pull/33790, we must copy those assets to the react-native-bridge app for them to properly show up in the WordPress Android app.

To test: 
1. Use an app build that does not rely upon a local React Native Metro server. 
2. Open the block editor. 
3. Tap the three-dot menu button in the top-right corner. 
4. Tap Help. 
5. Tap one of the available articles.
6. ℹ️ **Expected:** Verify the images are displayed and not missing. 

<details><summary>Screenshot of Help Image</summary>

<img alt="Gutenberg Help image" src="https://user-images.githubusercontent.com/438664/128776669-eb8f4f24-6fb5-408c-a662-4d7ccfcddc84.jpg" width="300" />

</details>

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
