### PR TITLE
Add fallback cache key to NPM install steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ commands:
           name: Restore NPM Cache
           keys:
             - npm-i18n-v4-cache-v{{ .Environment.CACHE_TRIGGER_VERSION }}-job-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
+            - npm-i18n-v4-cache-v{{ .Environment.CACHE_TRIGGER_VERSION }}-job-{{ .Environment.CIRCLE_JOB }}-
       - run:
           name: NPM Install
           command: |
@@ -27,6 +28,7 @@ commands:
           name: Restore NPM Cache
           keys:
             - npm-i18n-v4-cache-v{{ .Environment.CACHE_TRIGGER_VERSION }}-job-{{ .Environment.CIRCLE_JOB }}-{{ checksum "gutenberg/package-lock.json" }}
+            - npm-i18n-v4-cache-v{{ .Environment.CACHE_TRIGGER_VERSION }}-job-{{ .Environment.CIRCLE_JOB }}-
       - run:
           name: NPM Install Full
           command: |


### PR DESCRIPTION
This PR addresses the issue that happens randomly on CI jobs leading to the error `cb() never called!` when installing the dependencies.

Using a fallback cache key will assure that the NPM cache is always present, which as far as we know, looks like this is the only way to prevent the issue. It's important to note that this practice is not recommended because will lead to an increase of the NPM cache size over time (more info in [this interesting article](https://glebbahmutov.com/blog/do-not-let-npm-cache-snowball/)). Nevertheless, since the frequency of this issue is increasing and is slowing down the development on most of PRs, I think it's worth the sacrifice.

**To test:**
- Run all CI jobs.
- Verify that all of them pass.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
