### PR TITLE
[Embed block] Enable embed preview for a list of providers

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 Unreleased
 ---
 * [***] Inserter: Add Inserter Block Search [https://github.com/WordPress/gutenberg/pull/33237]
-* [**] Enable embed inline previews (for now only YouTube and Twitter will be available) [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3900]
+* [**] Enable embed preview for a list of providers (for now only YouTube and Twitter) [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3900]
 
 1.60.1
 * [*] RNmobile: Fix the cancel button on Block Variation Picker / Columns Block. [https://github.com/wordpress-mobile/gutenberg/pull/34249]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 Unreleased
 ---
 * [***] Inserter: Add Inserter Block Search [https://github.com/WordPress/gutenberg/pull/33237]
+* [**] Enable embed inline previews (for now only YouTube and Twitter will be available) [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3900]
 
 1.60.1
 * [*] RNmobile: Fix the cancel button on Block Variation Picker / Columns Block. [https://github.com/wordpress-mobile/gutenberg/pull/34249]


### PR DESCRIPTION
`gutenberg` PR: https://github.com/WordPress/gutenberg/pull/34446

To test:
Follow testing instructions from `gutenberg` PR: https://github.com/WordPress/gutenberg/pull/34446.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
