### PR TITLE
Scroll header toolbar to end when RTL

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 Unreleased
 ---
 * [**] Enable WordPress embed preview [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3853]
+* [**] Fix main toolbar initial position when RTL [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3923]
 
 1.61.0
 ------

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 Unreleased
 ---
 * [**] Enable WordPress embed preview [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3853]
-* [**] Fix main toolbar initial position when RTL [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3923]
+* [**] Fix Android-only issue of main toolbar initial position being wrong when RTL [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3923]
 * [*] Embed block: Add device's locale to preview content [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3788]
 * [*] Embed block: Fix content disappearing on Android when switching light/dark mode [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3859]
 


### PR DESCRIPTION
Fixes #3889

### Related PRs
* https://github.com/WordPress/gutenberg/pull/34617

### To test

1. Set the device/emulator to an RTL language like Hebrew
2. Run the demo app on a device narrow enough to not be able to show the main toolbar when a text block is selected
3. Tap to select a text block(for instance, paragraph or header) in the demo content
4. Notice that the main toolbar scrolls to reveal the inserter button. See the video in the GB PR as an example.

### PR submission checklist

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
