### PR TITLE
Global styles - Add support to render font sizes and line height

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6715,7 +6715,7 @@
 					}
 				},
 				"prettier": {
-					"version": "npm:wp-prettier@2.2.1-beta-1",
+					"version": "npm:prettier@2.2.1-beta-1",
 					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
 					"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
 					"dev": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -6295,10 +6295,16 @@
 						"get-intrinsic": "^1.0.2"
 					}
 				},
+				"comment-parser": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.2.4.tgz",
+					"integrity": "sha512-pm0b+qv+CkWNriSTMsfnjChF9kH0kxz55y44Wo5le9qLxMj5xDQAaEd9ZN1ovSuk9CsrncWaFwgpOMg7ClJwkw==",
+					"dev": true
+				},
 				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
@@ -6492,26 +6498,37 @@
 					}
 				},
 				"eslint-plugin-jsdoc": {
-					"version": "34.8.2",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-34.8.2.tgz",
-					"integrity": "sha512-UOU9A40Cl806JMtla2vF+RM6sNqfLPbhLv9FZqhcC7+LmChD3DVaWqM7ADxpF0kMyZNWe1QKUnqGnXaA3NTn+w==",
+					"version": "36.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-36.1.0.tgz",
+					"integrity": "sha512-Qpied2AJCQcScxfzTObLKRiP5QgLXjMU/ITjBagEV5p2Q/HpumD1EQtazdRYdjDSwPmXhwOl2yquwOGQ4HOJNw==",
 					"dev": true,
 					"requires": {
-						"@es-joy/jsdoccomment": "^0.6.0",
-						"comment-parser": "1.1.5",
-						"debug": "^4.3.1",
+						"@es-joy/jsdoccomment": "0.10.8",
+						"comment-parser": "1.2.4",
+						"debug": "^4.3.2",
 						"esquery": "^1.4.0",
-						"jsdoctypeparser": "^9.0.0",
+						"jsdoc-type-pratt-parser": "^1.1.1",
 						"lodash": "^4.17.21",
-						"regextras": "^0.7.1",
+						"regextras": "^0.8.0",
 						"semver": "^7.3.5",
 						"spdx-expression-parse": "^3.0.1"
 					},
 					"dependencies": {
-						"comment-parser": {
-							"version": "1.1.5",
-							"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.1.5.tgz",
-							"integrity": "sha512-RePCE4leIhBlmrqiYTvaqEeGYg7qpSl4etaIabKtdOQVi+mSTIBBklGUwIr79GXYnl3LpMwmDw4KeR2stNc6FA==",
+						"@es-joy/jsdoccomment": {
+							"version": "0.10.8",
+							"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.10.8.tgz",
+							"integrity": "sha512-3P1JiGL4xaR9PoTKUHa2N/LKwa2/eUdRqGwijMWWgBqbFEqJUVpmaOi2TcjcemrsRMgFLBzQCK4ToPhrSVDiFQ==",
+							"dev": true,
+							"requires": {
+								"comment-parser": "1.2.4",
+								"esquery": "^1.4.0",
+								"jsdoc-type-pratt-parser": "1.1.1"
+							}
+						},
+						"regextras": {
+							"version": "0.8.0",
+							"resolved": "https://registry.npmjs.org/regextras/-/regextras-0.8.0.tgz",
+							"integrity": "sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ==",
 							"dev": true
 						}
 					}
@@ -6620,15 +6637,6 @@
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 					"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 					"dev": true
-				},
-				"lru-cache": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-					"dev": true,
-					"requires": {
-						"yallist": "^4.0.0"
-					}
 				},
 				"object-inspect": {
 					"version": "1.10.3",
@@ -6751,12 +6759,6 @@
 						"call-bind": "^1.0.2",
 						"define-properties": "^1.1.3"
 					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
 				}
 			}
 		},
@@ -19479,6 +19481,12 @@
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
 			"dev": true
 		},
+		"jsdoc-type-pratt-parser": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-1.1.1.tgz",
+			"integrity": "sha512-uelRmpghNwPBuZScwgBG/OzodaFk5RbO5xaivBdsAY70icWfShwZ7PCMO0x1zSkOa8T1FzHThmrdoyg/0AwV5g==",
+			"dev": true
+		},
 		"jsdoctypeparser": {
 			"version": "9.0.0",
 			"resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-9.0.0.tgz",
@@ -19960,6 +19968,15 @@
 			"dev": true,
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
+			}
+		},
+		"lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"requires": {
+				"yallist": "^4.0.0"
 			}
 		},
 		"make-dir": {
@@ -23995,6 +24012,12 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
 			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+			"dev": true
+		},
+		"yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
 		},
 		"yaml": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6261,7 +6261,7 @@
 				"eslint-config-prettier": "^7.1.0",
 				"eslint-plugin-import": "^2.23.4",
 				"eslint-plugin-jest": "^24.1.3",
-				"eslint-plugin-jsdoc": "^34.1.0",
+				"eslint-plugin-jsdoc": "^36.0.8",
 				"eslint-plugin-jsx-a11y": "^6.4.1",
 				"eslint-plugin-prettier": "^3.3.0",
 				"eslint-plugin-react": "^7.22.0",
@@ -6707,7 +6707,7 @@
 					}
 				},
 				"prettier": {
-					"version": "npm:prettier@2.2.1-beta-1",
+					"version": "npm:wp-prettier@2.2.1-beta-1",
 					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
 					"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
 					"dev": true


### PR DESCRIPTION
`Gutenberg PR` -> https://github.com/WordPress/gutenberg/pull/34144

This PR is a follow-up of https://github.com/WordPress/gutenberg/pull/33605 and adds the functionality to render custom font sizes and line height in the editor.

This is under the DEV flag.

To test check the Gutenberg PR description.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
