### PR TITLE
Column block: Translate column width's control labels

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@ Unreleased
 * [**] Fix Android-only issue of main toolbar initial position being wrong when RTL [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3923]
 * [*] Embed block: Add device's locale to preview content [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3788]
 * [*] Embed block: Fix content disappearing on Android when switching light/dark mode [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3859]
+* [*] Column block: Translate column width's control labels [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3952]
 
 1.61.0
 ------

--- a/bundle/android/strings.xml
+++ b/bundle/android/strings.xml
@@ -72,6 +72,8 @@
     <string name="gutenberg_native_choose_images" tools:ignore="UnusedResources">Choose images</string>
     <string name="gutenberg_native_choose_video" tools:ignore="UnusedResources">Choose video</string>
     <string name="gutenberg_native_clear_search" tools:ignore="UnusedResources">Clear search</string>
+    <!-- translators: %d: column index. -->
+    <string name="gutenberg_native_column_d" tools:ignore="UnusedResources">Column %d</string>
     <string name="gutenberg_native_columns_settings" tools:ignore="UnusedResources">Columns Settings</string>
     <string name="gutenberg_native_copied_block" tools:ignore="UnusedResources">Copied block</string>
     <string name="gutenberg_native_copy_block" tools:ignore="UnusedResources">Copy block</string>

--- a/bundle/ios/GutenbergNativeTranslations.swift
+++ b/bundle/ios/GutenbergNativeTranslations.swift
@@ -74,6 +74,7 @@ private func dummy() {
     _ = NSLocalizedString("Choose images", comment: "")
     _ = NSLocalizedString("Choose video", comment: "")
     _ = NSLocalizedString("Clear search", comment: "")
+    _ = NSLocalizedString("Column %d", comment: "translators: %d: column index.")
     _ = NSLocalizedString("Columns Settings", comment: "")
     _ = NSLocalizedString("Copied block", comment: "")
     _ = NSLocalizedString("Copy block", comment: "")


### PR DESCRIPTION
`gutenberg` PR: https://github.com/WordPress/gutenberg/pull/34777

Fixes https://github.com/WordPress/gutenberg/issues/31051.

To test:
Follow the testing instructions described in `gutenberg` PR: https://github.com/WordPress/gutenberg/pull/34777

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
