### PR TITLE
Fix error "nvm not found" in CircleCI workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ commands:
           command: |
             curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash
             if [ -z "${NVM_DIR}" ] ; then
-              echo 'Appending nvm source string to BASH_ENV'
+              echo 'Default NVM_DIR to .nvm in home'
               echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
             fi
             echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ commands:
             # Set the installed version as the default one
             nvm alias default $(nvm current)
             # Enforce to use the default version in the rest of workflow
-            echo 'nvm use default' >> $BASH_ENV
+            echo 'nvm use default --silent' >> $BASH_ENV
 
 parameters:
   android-docker-image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ commands:
             # Set the installed version as the default one
             nvm alias default $(nvm current)
             # Enforce to use the default version in the rest of workflow
-            echo 'nvm use default --silent' >> $BASH_ENV
+            echo 'nvm use default' >> $BASH_ENV
 
 parameters:
   android-docker-image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,8 +121,8 @@ commands:
             if [ -z "${NVM_DIR}" ] ; then
               echo 'Appending nvm source string to BASH_ENV'
               echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
-              echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
             fi
+            echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
       - run:
           name: Install node version specified in Gutenberg using nvm
           command: |


### PR DESCRIPTION
Fixes the error `nvm: command not found` that is shown in some steps of the CircleCI workflows like "Check correctness":
https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/14186/workflows/9eb80d13-b000-4ad3-b494-b2999c204598/jobs/77249

The issue was caused when running bash scripts, as far as I checked, before executing the script, it was running the command `nvm use default` that is set in the Bash environment (`$BASH_ENV`) but failed due to not having the command `nvm` defined. This was fixed by adding the NVM loading command to the Bash environment that assures that NVM will be always available.

**To test:**
Verify that all CI checks pass and that the error is no longer shown in the logs.

**Last "Check correctness" run job:**
https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/14161/workflows/a43133cd-e79f-43d4-9b27-97998319ab71/jobs/77133?invite=true#step-110-3

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
