### PR TITLE
Add pnpm to environment setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ For a developer experience closer to the one the project maintainers currently h
 * git
 * [nvm](https://github.com/creationix/nvm)
 * Node.js and npm (use nvm to install them)
+* [pnpm](https://pnpm.io/) needed to ensure compatibility with the Jetpack submodule (install via `npm install -g pnpm`)
 * [Android Studio](https://developer.android.com/studio/) to be able to compile the Android version of the app
 * [Xcode](https://developer.apple.com/xcode/) to be able to compile the iOS app
 * CocoaPods(`sudo gem install cocoapods`) needed to fetch React and third-party dependencies.


### PR DESCRIPTION
The Jetpack submodule uses `pnpm` (see docs [here](https://github.com/Automattic/jetpack/blob/master/docs/development-environment.md#pnpm)).

At the moment, not installing `pnpm` can cause warning such as this (when performing a submodule fetch):
```
Can't find pnpx in PATH
```

### To test

Note that this issue never affected CI because the repo is cloned as-is and not "submodule updated" afterwards.

#### Verify the issue is present

```
npm uninstall -g pnpm # uninstall if needed
git clone --recursive git@github.com:wordpress-mobile/gutenberg-mobile.git
cd gutenberg-mobile
npm ci
cd jetpack && git reset head^ --hard # make a change to the submodule ref
cd ..
git submodule update --init --recursive
```

#### Verify the issue is fixed when pnpm is installed

```
npm install -g pnpm
cd jetpack && git reset head^ --hard
cd ..
git submodule update --init --recursive
```


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
