### PR TITLE
[Embed block] Detect when an embeddable URL is pasted into an empty paragraph

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@ Unreleased
 * [*] Embed block: Fix URL not editable after dismissing the edit URL bottom sheet with empty value [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4094]
 * [*] Fixed missing modal backdrop for Android help section [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4106]
 * [*] Fixed erroneous overflow within editor Help screens. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4105]
+* [**] Embed block: Detect when an embeddable URL is pasted into an empty paragraph. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4048]
 
 1.63.0
 ------


### PR DESCRIPTION
Fixes #3280 #3281

To test:
https://github.com/WordPress/gutenberg/pull/35204
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
