### PR TITLE
[SPIKE] Use extra native package and do a Toast

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,10 @@
 /**
+ * External dependencies
+ */
+import { NativeModules } from 'react-native';
+const { RNExampleModule } = NativeModules;
+
+/**
  * WordPress dependencies
  */
 import { addAction, addFilter } from '@wordpress/hooks';
@@ -26,6 +32,7 @@ addAction( 'native.render', 'gutenberg-mobile', ( props ) => {
 	);
 	const capabilities = props.capabilities ?? {};
 	setupBlockExperiments( capabilities );
+	RNExampleModule.justToast( 'Hello from Gutenberg!' );
 } );
 
 addFilter( 'native.block_editor_props', 'gutenberg-mobile', ( editorProps ) => {


### PR DESCRIPTION
Spike to try out a way to add an extra native module accessible via RN but only added on the gb-mobile and WPAndroid side.

No Gutenberg repo side PR needed.

Check out the toast loaded when the editor starts, which is done during "setup". [Here's is the code](https://github.com/wordpress-mobile/gutenberg-mobile/pull/4050/files#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R35) and here's a video:

https://user-images.githubusercontent.com/1032913/135291028-9730667b-4eb3-4cf1-9bd4-8df4935f79bf.mp4

To test:

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
