### PR TITLE
[Embed block] Fix inline preview cut-off when editing URL

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@ Unreleased
 * [**] Embed block: Add the top 5 specific embed blocks to the Block inserter list [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3995]
 * [*] Embed block: Fix URL update when edited after setting a bad URL of a provider [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4002]
 * [**] Users can now contact support from inside the block editor screen. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3975]
+* [*] Embed block: Fix inline preview cut-off when editing URL [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4072]
 
 1.62.2
 ------


### PR DESCRIPTION
Gutenberg PR: https://github.com/WordPress/gutenberg/pull/35321

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4059

To test:
Follow testing instructions from https://github.com/WordPress/gutenberg/pull/35321.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
