### PR TITLE
[Embed block] Add entry related to "Include Jetpack embed variants" into release notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@ Unreleased
 * [*] Embed block: Fix URL update when edited after setting a bad URL of a provider [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4002]
 * [**] Users can now contact support from inside the block editor screen. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3975]
 * [*] Embed block: Fix inline preview cut-off when editing URL [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4072]
+* [**] Embed block: Include Jetpack embed variants [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4008]
 
 1.62.2
 ------

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,13 +1,13 @@
 Unreleased
 ---
+* [*] Embed block: Fix inline preview cut-off when editing URL [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4072]
+* [**] Embed block: Include Jetpack embed variants [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4008]
 
 1.63.0
 ------
 * [**] Embed block: Add the top 5 specific embed blocks to the Block inserter list. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3995]
 * [*] Embed block: Fix URL update when edited after setting a bad URL of a provider. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4002]
 * [**] Users can now contact support from inside the block editor screen. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3975]
-* [*] Embed block: Fix inline preview cut-off when editing URL [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4072]
-* [**] Embed block: Include Jetpack embed variants [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4008]
 
 1.62.2
 ------


### PR DESCRIPTION
This PR only updates the release notes to include the change introduced in https://github.com/wordpress-mobile/gutenberg-mobile/pull/4008.

To test:
N/A


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
