### PR TITLE
Fix an entry of release notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -16,7 +16,7 @@ Unreleased
 1.62.1
 ------
 * [**] Image block: fix height and border regression. [https://github.com/WordPress/gutenberg/pull/34957]
-* [**] Column block: fix width attribute flout cutoff. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3921]
+* [**] Column block: fix width float attribute cut off. [https://github.com/WordPress/gutenberg/pull/35061]
 
 1.62.0
 ------


### PR DESCRIPTION
Fixes a `1.62.1` section entry of the release notes.

To test:
N/A

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
