### PR TITLE
Fix overflowing content for native Help screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@ Unreleased
 * [*] [Unsupported Block Editor] Fix text selection bug for Android [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3937]
 * [*] Embed block: Fix inline preview cut-off when editing URL [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4072]
 * [**] Embed block: Include Jetpack embed variants [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4008]
+* [*] Fixed erroneous overflow within editor Help screens. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4105]
 
 1.63.0
 ------


### PR DESCRIPTION
## Related PRs

* https://github.com/WordPress/gutenberg/pull/35552

## Description
Fixes #4100. When navigating to a Help section child screen, the parent screen would remain visible outside of the container. Hiding the overflow of the containing element fixes this.

The reason this occurred for the first time now is likely because it is the first time we have utilized the default navigation transitions for the platforms, which is provided by React Navigation. This means the screen animates from right to left on iOS, rather than a cross-fade.

To test: See https://github.com/WordPress/gutenberg/pull/35552. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
