### PR TITLE
Fix invisible bottom sheet backdrop on Android

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@ Unreleased
 * [*] [Unsupported Block Editor] Fix text selection bug for Android [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3937]
 * [*] Embed block: Fix inline preview cut-off when editing URL [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4072]
 * [**] Embed block: Include Jetpack embed variants [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4008]
+* [*] Fixed missing modal backdrop for Android help section [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4106]
 
 1.63.0
 ------


### PR DESCRIPTION
## Related PRs

* https://github.com/WordPress/gutenberg/pull/35557

## Description

Fixes #4104. Animating the opacity for the initial modal results in the backdrop provided by `react-native-modal` to never transition from transparent to partially opaque black. The core issue was not idenfited, but it may relate to the [experimental state of LayoutAnimation for Android](https://reactnative.dev/docs/layoutanimation). 

To test: See https://github.com/WordPress/gutenberg/pull/35557.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
