### PR TITLE
Add SafeAreaView to Help & Support view

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@ Unreleased
 * [*] Embed block: Fix inline preview cut-off when editing URL [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4072]
 * [**] Embed block: Include Jetpack embed variants [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4008]
 * [*] Fixed erroneous overflow within editor Help screens. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4105]
+* [*] Fixed an issue where the Help screens may not respect an iOS device's notch. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4110]
 
 1.63.0
 ------

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 Unreleased
 ---
 * [**] Search block - Text and background color support [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4127]
+* [*] Fixed an issue where the Help screens may not respect an iOS device's notch. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4110]
 
 1.64.0
 ------
@@ -16,7 +17,6 @@ Unreleased
 ------
 * [*] Fixed missing modal backdrop for Android help section [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4106]
 * [*] Fixed erroneous overflow within editor Help screens. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4105]
-* [*] Fixed an issue where the Help screens may not respect an iOS device's notch. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4110]
 
 1.63.0
 ------


### PR DESCRIPTION
## Related PRs

- https://github.com/WordPress/gutenberg/pull/35570

## Description

Fixes #4030. When rotating the Help view from portrait to landscape and back to portrait, it wasn't staying within the Safe Area boundaries.

To test: See https://github.com/WordPress/gutenberg/pull/35570

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
