### PR TITLE
Update release notes - Move PR 4048 entry to unreleased section

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,12 +4,12 @@ Unreleased
 * [*] Embed block: Fix inline preview cut-off when editing URL [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4072]
 * [**] Embed block: Include Jetpack embed variants [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4008]
 * [*] Embed block: Fix URL not editable after dismissing the edit URL bottom sheet with empty value [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4094]
+* [**] Embed block: Detect when an embeddable URL is pasted into an empty paragraph. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4048]
 
 1.63.1
 ------
 * [*] Fixed missing modal backdrop for Android help section [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4106]
 * [*] Fixed erroneous overflow within editor Help screens. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4105]
-* [**] Embed block: Detect when an embeddable URL is pasted into an empty paragraph. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4048]
 
 1.63.0
 ------


### PR DESCRIPTION
The entry for https://github.com/wordpress-mobile/gutenberg-mobile/pull/4048 has been moved to the unreleased section because it's not part of the `1.63.1` version.

To test:
N/A

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
