### PR TITLE
Fix connection errors causing failed jobs on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,7 +307,7 @@ jobs:
         name: Upload .app to sauce labs
         command: |
           source bin/sauce-pre-upload.sh
-          HOMEBREW_NO_AUTO_UPDATE=1 brew install curl
+          brew install curl
           /usr/local/opt/curl/bin/curl --version
           /usr/local/opt/curl/bin/curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" -X POST -H "Content-Type: application/octet-stream" https://saucelabs.com/rest/v1/storage/automattic/Gutenberg-$SAUCE_FILENAME.app.zip?overwrite=true --data-binary @./gutenberg/packages/react-native-editor/ios/GutenbergDemo.app.zip
     - run:


### PR DESCRIPTION
This aims to fix errors we're seeing similar to `Error: Failed to download resource "nghttp2"` and `ssh: connect to host github.com port 22: Operation timed out`.

Running `brew update` was the suggested fix [here](https://github.community/t/curl-7-failed-to-connect-to-api-github-com-port-443-connection-refused/14853/3) and [here](https://stackoverflow.com/a/67700844/1305067) for similar-sounding issues.

As @dcalhoun noted, https://github.com/wordpress-mobile/gutenberg-mobile/pull/2860 updated `curl` but also added `HOMEBREW_NO_AUTO_UPDATE=1` which prevents brew from updating when `curl` is installed. To try to determine if this change will cause a performance issue, the job was ran twice and both times it finished in a "normal" duration (20 to 30 minutes).

### To test

Check if all CI tests pass (especially `Test iOS on Device - Canaries` → `Upload .app to sauce labs`).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
