### PR TITLE
Try running full tests on release PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,6 +363,7 @@ workflows:
               ignore:
                 - develop
                 - /^dependabot/submodules/.*/
+                - /^release.*/
       - ios-device-checks:
           name: Test iOS on Device - Full
           requires: [ "Optional UI Tests" ]
@@ -376,14 +377,30 @@ workflows:
           post-to-slack: true
           filters:
             branches:
-              only: /^dependabot/submodules/.*/
+              only: 
+                - /^dependabot/submodules/.*/
       - android-device-checks:
           name: Test Android on Device - Full (Submodule Update)
           post-to-slack: true
           filters:
             branches:
-              only: /^dependabot/submodules/.*/
-
+              only:
+                - /^dependabot/submodules/.*/
+      - ios-device-checks:
+          name: Test iOS on Device - Full (Release)
+          post-to-slack: true
+          filters:
+            branches:
+              only: 
+                - /^release.*/
+      - android-device-checks:
+          name: Test Android on Device - Full (Release)
+          post-to-slack: true
+          filters:
+            branches:
+              only:
+                - /^release.*/
+                
   ui-tests-full-scheduled:
     jobs:
       - ios-device-checks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,15 +377,13 @@ workflows:
           post-to-slack: true
           filters:
             branches:
-              only: 
-                - /^dependabot/submodules/.*/
+              only: /^dependabot/submodules/.*/
       - android-device-checks:
           name: Test Android on Device - Full (Submodule Update)
           post-to-slack: true
           filters:
             branches:
-              only:
-                - /^dependabot/submodules/.*/
+              only: /^dependabot/submodules/.*/
       - ios-device-checks:
           name: Test iOS on Device - Full (Release)
           post-to-slack: true


### PR DESCRIPTION
This change proposes creating new jobs on CircleCI that will run full tests on release PRs. Previously these changes were optional.

Addresses https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/issues/78 (this issue can only be marked resolved when https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/pull/79 is also merged)

### To test
1. Note that this PR's base branch is of the format `release/.*`, which should make this PR behave like a release PR in that optional tests should be run automatically.
2. Verify that the full tests suite is ran for both platforms.

This PR currently creates a new job to run the tests. We already have a job, `Test Android on Device - Full (Submodule Update)`, to run tests automatically on Dependabot PRs, but I chose to make a new job to allow customizing the job name to `Test Android on Device - Full (Release)`. If you think it's best to combine these jobs under a more generic name such as `Test Android on Device - Full`, that's also something we can do.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
