### PR TITLE
Add support for the Mark HTML tag and updates Aztec iOS to 1.19.5

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@ Unreleased
 * [*] [Embed Block] Fix loading glitch with resolver resolution approach [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4146]
 * [*] Fixed an issue where the Help screens may not respect an iOS device's notch. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4110]
 * [**] Inserter: Block inserter indicates newly available block types [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4047]
+* [*] Add support for the Mark HTML tag [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4162]
 
 1.64.1
 ------

--- a/RNTAztecView.podspec
+++ b/RNTAztecView.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.xcconfig         = {'OTHER_LDFLAGS' => '-lxml2',
                         'HEADER_SEARCH_PATHS' => '/usr/include/libxml2'}
   s.dependency         'React-Core'
-  s.dependency         'WordPress-Aztec-iOS', '~> 1.19.4'
+  s.dependency         'WordPress-Aztec-iOS', '~> 1.19.5'
 
 end


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4155

- Gutenberg PR: https://github.com/WordPress/gutenberg/pull/35956
- WordPress iOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/17370

Updates Aztec iOS to [1.19.5](https://github.com/wordpress-mobile/AztecEditor-iOS/releases/tag/1.19.5), with this and with the recently released [Aztec Android](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.4.0), it adds support for the `mark` HTML tag.

To test check the Gutenberg PR description.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
