### PR TITLE
Enforce npm@6 usage for CI builds

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,10 +17,12 @@ steps:
           image: "public.ecr.aws/automattic/gb-mobile-image:latest"
           environment:
             - "CI=true"
+    # We cannot yet utilize npm@7 https://git.io/Ji8Lm
     command: |
         source /root/.bashrc
 
         nvm install && nvm use
+        npm install --global npm@6
         npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 
         npm run prebundle:js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,10 @@ commands:
             nvm alias default $(nvm current)
             # Enforce to use the default version in the rest of workflow
             echo 'nvm use default' >> $BASH_ENV
+      - run:
+          # We cannot yet utilize npm@7 https://git.io/Ji8Lm
+          name: Install npm@6
+          command: npm install --global npm@6
 
 parameters:
   android-docker-image:


### PR DESCRIPTION
Alternative to #4164. Please review both to consider the best approach. 

Our CI configuration currently installs the [latest Node.js LTS](https://nodejs.org/en/about/releases/), which means the CI upgraded to v16 automatically. Node.js v16 defaults to npm@7, but we cannot yet utilize npm@7 until we resolve [dependency conflicts](https://git.io/Ji8Lm).

This change explicitly installs npm@6 to avoid usage of the default version of npm@7. 

To test:
1. Observe [CI failure](https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/14746/workflows/ea4d0a29-e05e-40b2-82fc-0848f3a408a8/jobs/80199?invite=true#step-106-2357) experienced within https://github.com/wordpress-mobile/gutenberg-mobile/pull/4066/commits/1e2a4ffbc99a21f5b048ecb47b00b7a311d017f5.
2. Verify all CI tasks pass in this PR.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
