### PR TITLE
Enforce Node.js v14 to align with Gutenberg repository

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,10 +17,12 @@ steps:
           image: "public.ecr.aws/automattic/gb-mobile-image:latest"
           environment:
             - "CI=true"
+    # Node.js 14 enforced to align with the Gutenberg repository. This
+    # should be updated each time Gutenberg upgrades. https://git.io/Ji8qj
     command: |
         source /root/.bashrc
 
-        nvm install && nvm use
+        nvm install 14 && nvm use 14
         npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 
         npm run prebundle:js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,9 +124,11 @@ commands:
             fi
             echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
       - run:
-          name: Install node version specified in .nvmrc using nvm
+          name: Install node version
+          # Node.js 14 enforced to align with the Gutenberg repository. This
+          # should be updated each time Gutenberg upgrades. https://git.io/Ji8qj
           command: |
-            nvm install
+            nvm install 14
             # Set the installed version as the default one
             nvm alias default $(nvm current)
             # Enforce to use the default version in the rest of workflow


### PR DESCRIPTION
Alternative to #4163. Please review both to consider the best approach. 

Our CI configuration currently installs the [latest Node.js LTS](https://nodejs.org/en/about/releases/), which means the CI upgraded to v16 automatically. Node.js v16 defaults to npm@7, but we cannot yet utilize npm@7 until we resolve [dependency conflicts](https://git.io/Ji8Lm).

While the Gutenberg repository [leverages a `.nvmrc`](https://github.com/WordPress/gutenberg/blob/0c5e279cf4bb0e80d1b310dfbaf409046b2627a3/.nvmrc) file to install the latest Node.js LTS for local development, its CI configuration declares an [explicit versions of Node.js](https://github.com/WordPress/gutenberg/blob/0c5e279cf4bb0e80d1b310dfbaf409046b2627a3/.github/workflows/unit-test.yml#L29). This change updates the CI configuration in this repository to match this approach, which also avoids the unwanted upgraded to npm@7.

To test:
1. Observe [CI failure](https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/14746/workflows/ea4d0a29-e05e-40b2-82fc-0848f3a408a8/jobs/80199?invite=true#step-106-2357) experienced within https://github.com/wordpress-mobile/gutenberg-mobile/pull/4066/commits/1e2a4ffbc99a21f5b048ecb47b00b7a311d017f5.
2. Verify all CI tasks pass in this PR.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
