### PR TITLE
iOS: Use firstChild and lastChild when parsing lists from MS Word

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@ Unreleased
 ---
 * [**] Image block: Add ability to quickly link images to Media Files and Attachment Pages [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3971]
 * [*] Fixed a race condition when autosaving content (Android) [https://github.com/WordPress/gutenberg/pull/36072]
+* [**] Fixed a crash that could occur when copying lists from Microsoft Word. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4174]
 
 1.65.0
 ------


### PR DESCRIPTION
Fixes #4145

### Related PRs:
- https://github.com/WordPress/gutenberg/pull/36019

### To test:
See [Gutenberg PR](https://github.com/WordPress/gutenberg/pull/36019) for testing instructions.

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
