### PR TITLE
[Embed Block] Set EmbedLinkSettings URL input cursor at start of link

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 Unreleased
 ---
 * [**] Image block: Add ability to quickly link images to Media Files and Attachment Pages [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3971]
+[* [**] Embed Block] Set EmbedLinkSettings URL input cursor at start of link [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4211]
 
 1.65.0
 ------


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/35888

To test:
https://github.com/WordPress/gutenberg/pull/36100

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
