### PR TITLE
Clean-up after enabling UI tests on develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,7 +366,6 @@ workflows:
                 - develop
                 - /^dependabot/submodules/.*/
                 - /^release.*/
-                - try/running-ui-tests-on-updated-develop
       - ios-device-checks:
           name: Test iOS on Device - Full
           requires: [ "Optional UI Tests" ]
@@ -389,20 +388,18 @@ workflows:
               only: /^dependabot/submodules/.*/
       - ios-device-checks:
           name: Test iOS on Device - Full (On Develop)
-          post-to-slack: false
+          post-to-slack: true
           filters:
             branches:
               only: 
                 - develop
-                - try/running-ui-tests-on-updated-develop
       - android-device-checks:
           name: Test Android on Device - Full (On Develop)
-          post-to-slack: false
+          post-to-slack: true
           filters:
             branches:
               only: 
                 - develop
-                - try/running-ui-tests-on-updated-develop
       - ios-device-checks:
           name: Test iOS on Device - Full (Release)
           post-to-slack: true


### PR DESCRIPTION
I merged https://github.com/wordpress-mobile/gutenberg-mobile/pull/4114 without first removing the the test code, so this change does that clean-up.

### To test

Verify that CI checks are green.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
