### PR TITLE
Font size - Only set font sizes for block based themes 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@ Unreleased
 ---
 * [*] [Embed block] Included Link in Block Settings [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4189]
 * [**] Fix tab titles translation of inserter menu [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4248]
+* [*] [Media&Text block] Fix an issue where the text font size would be bigger than expected in some cases [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4252]
 
 1.66.0
 ---


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/36529

- Gutenberg PR -> https://github.com/WordPress/gutenberg/pull/36570

Support for font sizes on mobile was recently added under a development flag and one of those changes included adding the default font sizes for the editor. An issue was reported where a `Media&Text` block added from the web editor was rendering a bigger font size on mobile for a standard theme. 

Since it's a standard theme the mobile editor doesn't have the font sizes values for it so it uses the default ones and in this case, it matches the font size `large` making the text to be shown bigger than expected.

This PR limits the font size functionality to **not** render font sizes values set to blocks when the current theme is not a block-based one.

To test check the Gutenberg PR description.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
