### PR TITLE
Tiled Gallery: Register block before running test

### DIFF
--- a/src/jetpack/test/tiled-gallery.js
+++ b/src/jetpack/test/tiled-gallery.js
@@ -18,13 +18,23 @@ import { registerCoreBlocks } from '@wordpress/block-library';
 /**
  * Internal dependencies
  */
-import setupJetpackEditor from '../../jetpack-editor-setup';
+import {
+	registerJetpackBlocks,
+	setupJetpackEditor,
+} from '../../jetpack-editor-setup';
+
+const defaultProps = {
+	capabilities: {
+		tiledGalleryBlock: true,
+	},
+};
 
 beforeAll( () => {
 	// Register all core blocks
 	registerCoreBlocks();
 	// Register Jetpack blocks
 	setupJetpackEditor( { blogId: 1, isJetpackActive: true } );
+	registerJetpackBlocks( defaultProps );
 } );
 
 afterAll( () => {


### PR DESCRIPTION
### Description

With this PR, the Tiled Gallery, added at https://github.com/wordpress-mobile/gutenberg-mobile/blob/add/tiled-gallery-block/src/jetpack/test/tiled-gallery.js, is updated.

The test was previously not running at all due to a conflict caused by some recent file changes/refactors.

To get the test to run, it's necessary to first call `registerJetpackBlocks`, as otherwise the Tiled Gallery block won't be registered while they're being run.

Note, the test is currently failing due to the error outlined at https://github.com/wordpress-mobile/gutenberg-mobile/issues/4168. This PR doesn't address that error. Instead, the purpose of this PR is simply to ensure the test runs.

### Testing

To test, it'll be necessary to first remove the `.skip` command added [here](https://github.com/wordpress-mobile/gutenberg-mobile/blob/add/tiled-gallery-block/src/jetpack/test/tiled-gallery.js#L37) then run `npm run test src/jetpack/test/tiled-gallery.js` while `cd`'d into the `gutenberg-mobile` folder from the terminal.

`.skip` isn't removed with this PR as the test still fails, which will be addressed in a separate PR.

<hr />

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
