### PR TITLE
Adds Clipboard Link Suggestion to Image block and Button block

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 Unreleased
 ---
+* [**] Adds Clipboard Link Suggestion to Image block and Button block [https://github.com/WordPress/gutenberg/pull/35972]
 
 1.66.0
 ---


### PR DESCRIPTION
Fixes #4058 

This [Gutenberg PR](https://github.com/WordPress/gutenberg/pull/35972) brings the changes from `Gutenberg` to `Gutenberg Mobile`.

To test:

Please see this [Gutenberg PR](https://github.com/WordPress/gutenberg/pull/35972) for further information.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
