### PR TITLE
[Android] Fix undo/redo functionality in links when applying text format

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@ Unreleased
 * [**] Adds Clipboard Link Suggestion to Image block and Button block [https://github.com/WordPress/gutenberg/pull/35972]
 * [*] [Embed block] Included Link in Block Settings [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4189]
 * [**] Fix tab titles translation of inserter menu [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4248]
+* [**] Fix undo/redo functionality in links when applying text format [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4279]
 
 1.66.0
 ---


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/3136

To test:
Follow testing instructions from Gutenberg PR https://github.com/WordPress/gutenberg/pull/36766.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
