### PR TITLE
Fix undo/redo functionality in links when applying text format [Android]

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@ Unreleased
 * [*] [Embed block] Included Link in Block Settings [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4189]
 * [**] Fix tab titles translation of inserter menu [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4248]
 * [**] [Gallery block] When a gallery block is added, the media options are auto opened for v2 of the Gallery block. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4277]
+* [**] Fix undo/redo functionality in links when applying text format [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4290]
 
 1.66.0
 ---


### PR DESCRIPTION
- Gutenberg PR: https://github.com/WordPress/gutenberg/pull/36861
- WordPress-Android PR: https://github.com/wordpress-mobile/WordPress-Android/pull/15618

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/3136

This fix was made in `Aztec-Android` ([reference](https://github.com/wordpress-mobile/AztecEditor-Android/pull/945)), so the Gutenberg reference points to a commit where the version of `Aztec-Android` has been bumped to the newer version `v1.5.1`.

**To test:**

1. Run the command `npm run core android` to build the demo app.
1. Add a a rich-text based component with content (Paragraph, Heading, Quote, Media Caption, etc...).
1. Write a word and select it.
1. Press the link format button.
1. Fill the options and dismiss to add a link.
1. Select the word.
1. Press the bold, italic or strikethrough button to apply text format.
1. Press the Undo button multiple times until all changes are reverted.
1. Observe that the undo functionality works as expected and that doesn't get blocked as described in Undo/redo - Apply text format to a link breaks the undo functionality wordpress-mobile/gutenberg-mobile#3136.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
