### PR TITLE
[iOS] Fix scroll update when typing in RichText component

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 Unreleased
 ---
 * [**] Fix undo/redo functionality in links when applying text format [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4290]
+* [**] [iOS] Fix scroll update when typing in RichText component [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4299]
 
 1.67.0
 ---


### PR DESCRIPTION
Gutenberg PR: https://github.com/WordPress/gutenberg/pull/36914

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4069

To test:
- Follow testing instructions from Gutenberg PR https://github.com/WordPress/gutenberg/pull/36914.
- Verify that the issue https://github.com/WordPress/gutenberg/pull/36914 can't be reproduced.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
