### PR TITLE
Gallery block: turn on auto-migration of v1 Gallery blocks to v2 format when edited

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@ Unreleased
 * [**] Fix undo/redo functionality in links when applying text format [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4290]
 * [**] [iOS] Fix scroll update when typing in RichText component [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4299]
 * [*] [Preformatted block] Fix an issue where the background color is not showing up for standard themes. [#4292]
+* [**] Update Gallery Block to default to the new format and auto-convert old galleries to the new format [#4315]
 
 1.67.0
 ---


### PR DESCRIPTION
### Related PR

`gutenberg`: https://github.com/WordPress/gutenberg/pull/36191

## Description

This PR updates the reference to include changes in the `gutenberg` PR:

Turns on automigration of v1 gallery blocks to v2 format unless a site has `use_BalanceTags`  enabled and is not running WP >= 5.9. See related PR for more details.

To test:

See [related PR](https://github.com/WordPress/gutenberg/pull/36191) for testing instructions

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
