### PR TITLE
Centrally Align Multiline Block Titles in the Inserter

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 Unreleased
 ---
+* [*] Give multi-line block names central alignment in inserter [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4343]
 * [**] Fix undo/redo functionality in links when applying text format [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4290]
 * [**] [iOS] Fix scroll update when typing in RichText component [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4299]
 * [*] [Preformatted block] Fix an issue where the background color is not showing up for standard themes. [#4292]


### PR DESCRIPTION
Fixes [#34748](https://github.com/WordPress/gutenberg/issues/34748)

To test:
Follow the testing instructions for [the Gutenberg PR](https://github.com/WordPress/gutenberg/pull/37185).

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
