### PR TITLE
Reinstall @wordpress/eslint-plugin to capture lock file changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7725,7 +7725,7 @@
 					}
 				},
 				"prettier": {
-					"version": "npm:wp-prettier@2.2.1-beta-1",
+					"version": "npm:prettier@2.2.1-beta-1",
 					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
 					"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
 					"dev": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -5061,19 +5061,19 @@
 			}
 		},
 		"@babel/runtime-corejs3": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.5.tgz",
-			"integrity": "sha512-roGr54CsTmNPPzZoCP1AmDXuBoNao7tnSA83TXTwt+UK5QVyh1DIJnrgYRPWKCF2flqZQXwa7Yr8v7VmLzF0YQ==",
+			"version": "7.16.3",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.16.3.tgz",
+			"integrity": "sha512-IAdDC7T0+wEB4y2gbIL0uOXEYpiZEeuFUTVbdGq+UwCcF35T/tS8KrmMomEwEc5wBbyfH3PJVpTSUqrhPDXFcQ==",
 			"dev": true,
 			"requires": {
-				"core-js-pure": "^3.0.0",
+				"core-js-pure": "^3.19.0",
 				"regenerator-runtime": "^0.13.4"
 			},
 			"dependencies": {
 				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+					"version": "0.13.9",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+					"integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
 					"dev": true
 				}
 			}
@@ -6475,6 +6475,12 @@
 				"@types/istanbul-lib-report": "*"
 			}
 		},
+		"@types/json-schema": {
+			"version": "7.0.9",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+			"dev": true
+		},
 		"@types/json5": {
 			"version": "0.0.29",
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -6725,6 +6731,49 @@
 				}
 			}
 		},
+		"@typescript-eslint/experimental-utils": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.6.0.tgz",
+			"integrity": "sha512-VDoRf3Qj7+W3sS/ZBXZh3LBzp0snDLEgvp6qj0vOAIiAPM07bd5ojQ3CTzF/QFl5AKh7Bh1ycgj6lFBJHUt/DA==",
+			"dev": true,
+			"requires": {
+				"@types/json-schema": "^7.0.9",
+				"@typescript-eslint/scope-manager": "5.6.0",
+				"@typescript-eslint/types": "5.6.0",
+				"@typescript-eslint/typescript-estree": "5.6.0",
+				"eslint-scope": "^5.1.1",
+				"eslint-utils": "^3.0.0"
+			},
+			"dependencies": {
+				"eslint-scope": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+					"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.3.0",
+						"estraverse": "^4.1.1"
+					}
+				},
+				"esrecurse": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+					"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+					"dev": true,
+					"requires": {
+						"estraverse": "^5.2.0"
+					},
+					"dependencies": {
+						"estraverse": {
+							"version": "5.3.0",
+							"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+							"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+							"dev": true
+						}
+					}
+				}
+			}
+		},
 		"@typescript-eslint/parser": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.6.0.tgz",
@@ -6737,47 +6786,6 @@
 				"debug": "^4.3.2"
 			},
 			"dependencies": {
-				"@typescript-eslint/scope-manager": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.6.0.tgz",
-					"integrity": "sha512-1U1G77Hw2jsGWVsO2w6eVCbOg0HZ5WxL/cozVSTfqnL/eB9muhb8THsP0G3w+BB5xAHv9KptwdfYFAUfzcIh4A==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "5.6.0",
-						"@typescript-eslint/visitor-keys": "5.6.0"
-					}
-				},
-				"@typescript-eslint/types": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.6.0.tgz",
-					"integrity": "sha512-OIZffked7mXv4mXzWU5MgAEbCf9ecNJBKi+Si6/I9PpTaj+cf2x58h2oHW5/P/yTnPkKaayfjhLvx+crnl5ubA==",
-					"dev": true
-				},
-				"@typescript-eslint/typescript-estree": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.6.0.tgz",
-					"integrity": "sha512-92vK5tQaE81rK7fOmuWMrSQtK1IMonESR+RJR2Tlc7w4o0MeEdjgidY/uO2Gobh7z4Q1hhS94Cr7r021fMVEeA==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "5.6.0",
-						"@typescript-eslint/visitor-keys": "5.6.0",
-						"debug": "^4.3.2",
-						"globby": "^11.0.4",
-						"is-glob": "^4.0.3",
-						"semver": "^7.3.5",
-						"tsutils": "^3.21.0"
-					}
-				},
-				"@typescript-eslint/visitor-keys": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.6.0.tgz",
-					"integrity": "sha512-1p7hDp5cpRFUyE3+lvA74egs+RWSgumrBpzBCDzfTFv0aQ7lIeay80yU0hIxgAhwQ6PcasW35kaOCyDOv6O/Ng==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "5.6.0",
-						"eslint-visitor-keys": "^3.0.0"
-					}
-				},
 				"debug": {
 					"version": "4.3.3",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -6786,25 +6794,47 @@
 					"requires": {
 						"ms": "2.1.2"
 					}
-				},
-				"eslint-visitor-keys": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-					"integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
-					"dev": true
-				},
-				"globby": {
-					"version": "11.0.4",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-					"integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+				}
+			}
+		},
+		"@typescript-eslint/scope-manager": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.6.0.tgz",
+			"integrity": "sha512-1U1G77Hw2jsGWVsO2w6eVCbOg0HZ5WxL/cozVSTfqnL/eB9muhb8THsP0G3w+BB5xAHv9KptwdfYFAUfzcIh4A==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/types": "5.6.0",
+				"@typescript-eslint/visitor-keys": "5.6.0"
+			}
+		},
+		"@typescript-eslint/types": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.6.0.tgz",
+			"integrity": "sha512-OIZffked7mXv4mXzWU5MgAEbCf9ecNJBKi+Si6/I9PpTaj+cf2x58h2oHW5/P/yTnPkKaayfjhLvx+crnl5ubA==",
+			"dev": true
+		},
+		"@typescript-eslint/typescript-estree": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.6.0.tgz",
+			"integrity": "sha512-92vK5tQaE81rK7fOmuWMrSQtK1IMonESR+RJR2Tlc7w4o0MeEdjgidY/uO2Gobh7z4Q1hhS94Cr7r021fMVEeA==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/types": "5.6.0",
+				"@typescript-eslint/visitor-keys": "5.6.0",
+				"debug": "^4.3.2",
+				"globby": "^11.0.4",
+				"is-glob": "^4.0.3",
+				"semver": "^7.3.5",
+				"tsutils": "^3.21.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.3",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 					"dev": true,
 					"requires": {
-						"array-union": "^2.1.0",
-						"dir-glob": "^3.0.1",
-						"fast-glob": "^3.1.1",
-						"ignore": "^5.1.4",
-						"merge2": "^1.3.0",
-						"slash": "^3.0.0"
+						"ms": "2.1.2"
 					}
 				},
 				"is-glob": {
@@ -6824,21 +6854,24 @@
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
-				},
-				"slash": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+				}
+			}
+		},
+		"@typescript-eslint/visitor-keys": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.6.0.tgz",
+			"integrity": "sha512-1p7hDp5cpRFUyE3+lvA74egs+RWSgumrBpzBCDzfTFv0aQ7lIeay80yU0hIxgAhwQ6PcasW35kaOCyDOv6O/Ng==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/types": "5.6.0",
+				"eslint-visitor-keys": "^3.0.0"
+			},
+			"dependencies": {
+				"eslint-visitor-keys": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
+					"integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
 					"dev": true
-				},
-				"tsutils": {
-					"version": "3.21.0",
-					"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-					"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-					"dev": true,
-					"requires": {
-						"tslib": "^1.8.1"
-					}
 				}
 			}
 		},
@@ -7321,15 +7354,6 @@
 				"requireindex": "^1.2.0"
 			},
 			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.16.3",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
-					"integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
 				"@es-joy/jsdoccomment": {
 					"version": "0.12.0",
 					"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.12.0.tgz",
@@ -7346,20 +7370,8 @@
 							"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.2.4.tgz",
 							"integrity": "sha512-pm0b+qv+CkWNriSTMsfnjChF9kH0kxz55y44Wo5le9qLxMj5xDQAaEd9ZN1ovSuk9CsrncWaFwgpOMg7ClJwkw==",
 							"dev": true
-						},
-						"jsdoc-type-pratt-parser": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.0.0.tgz",
-							"integrity": "sha512-sUuj2j48wxrEpbFjDp1sAesAxPiLT+z0SWVmMafyIINs6Lj5gIPKh3VrkBZu4E/Dv+wHpOot0m6H8zlHQjwqeQ==",
-							"dev": true
 						}
 					}
-				},
-				"@types/json-schema": {
-					"version": "7.0.9",
-					"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-					"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
-					"dev": true
 				},
 				"@typescript-eslint/eslint-plugin": {
 					"version": "5.6.0",
@@ -7375,88 +7387,6 @@
 						"regexpp": "^3.2.0",
 						"semver": "^7.3.5",
 						"tsutils": "^3.21.0"
-					},
-					"dependencies": {
-						"ignore": {
-							"version": "5.1.9",
-							"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-							"integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
-							"dev": true
-						}
-					}
-				},
-				"@typescript-eslint/experimental-utils": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.6.0.tgz",
-					"integrity": "sha512-VDoRf3Qj7+W3sS/ZBXZh3LBzp0snDLEgvp6qj0vOAIiAPM07bd5ojQ3CTzF/QFl5AKh7Bh1ycgj6lFBJHUt/DA==",
-					"dev": true,
-					"requires": {
-						"@types/json-schema": "^7.0.9",
-						"@typescript-eslint/scope-manager": "5.6.0",
-						"@typescript-eslint/types": "5.6.0",
-						"@typescript-eslint/typescript-estree": "5.6.0",
-						"eslint-scope": "^5.1.1",
-						"eslint-utils": "^3.0.0"
-					}
-				},
-				"@typescript-eslint/scope-manager": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.6.0.tgz",
-					"integrity": "sha512-1U1G77Hw2jsGWVsO2w6eVCbOg0HZ5WxL/cozVSTfqnL/eB9muhb8THsP0G3w+BB5xAHv9KptwdfYFAUfzcIh4A==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "5.6.0",
-						"@typescript-eslint/visitor-keys": "5.6.0"
-					}
-				},
-				"@typescript-eslint/types": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.6.0.tgz",
-					"integrity": "sha512-OIZffked7mXv4mXzWU5MgAEbCf9ecNJBKi+Si6/I9PpTaj+cf2x58h2oHW5/P/yTnPkKaayfjhLvx+crnl5ubA==",
-					"dev": true
-				},
-				"@typescript-eslint/typescript-estree": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.6.0.tgz",
-					"integrity": "sha512-92vK5tQaE81rK7fOmuWMrSQtK1IMonESR+RJR2Tlc7w4o0MeEdjgidY/uO2Gobh7z4Q1hhS94Cr7r021fMVEeA==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "5.6.0",
-						"@typescript-eslint/visitor-keys": "5.6.0",
-						"debug": "^4.3.2",
-						"globby": "^11.0.4",
-						"is-glob": "^4.0.3",
-						"semver": "^7.3.5",
-						"tsutils": "^3.21.0"
-					},
-					"dependencies": {
-						"is-glob": {
-							"version": "4.0.3",
-							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-							"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-							"dev": true,
-							"requires": {
-								"is-extglob": "^2.1.1"
-							}
-						}
-					}
-				},
-				"@typescript-eslint/visitor-keys": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.6.0.tgz",
-					"integrity": "sha512-1p7hDp5cpRFUyE3+lvA74egs+RWSgumrBpzBCDzfTFv0aQ7lIeay80yU0hIxgAhwQ6PcasW35kaOCyDOv6O/Ng==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "5.6.0",
-						"eslint-visitor-keys": "^3.0.0"
-					},
-					"dependencies": {
-						"eslint-visitor-keys": {
-							"version": "3.1.0",
-							"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-							"integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
-							"dev": true
-						}
 					}
 				},
 				"array-includes": {
@@ -7470,17 +7400,6 @@
 						"es-abstract": "^1.19.1",
 						"get-intrinsic": "^1.1.1",
 						"is-string": "^1.0.7"
-					},
-					"dependencies": {
-						"is-string": {
-							"version": "1.0.7",
-							"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-							"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-							"dev": true,
-							"requires": {
-								"has-tostringtag": "^1.0.0"
-							}
-						}
 					}
 				},
 				"array.prototype.flat": {
@@ -7493,23 +7412,6 @@
 						"define-properties": "^1.1.3",
 						"es-abstract": "^1.19.0"
 					}
-				},
-				"array.prototype.flatmap": {
-					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.5.tgz",
-					"integrity": "sha512-08u6rVyi1Lj7oqWbS9nUxliETrtIROT4XGTA4D/LWGten6E3ocm7cy9SIrmNHOL5XVbVuckUp3X6Xyg8/zpvHA==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"es-abstract": "^1.19.0"
-					}
-				},
-				"axe-core": {
-					"version": "4.3.5",
-					"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.5.tgz",
-					"integrity": "sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==",
-					"dev": true
 				},
 				"babel-eslint": {
 					"version": "10.1.0",
@@ -7524,26 +7426,10 @@
 						"resolve": "^1.12.0"
 					}
 				},
-				"call-bind": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-					"dev": true,
-					"requires": {
-						"function-bind": "^1.1.1",
-						"get-intrinsic": "^1.0.2"
-					}
-				},
 				"comment-parser": {
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.0.tgz",
 					"integrity": "sha512-hRpmWIKgzd81vn0ydoWoyPoALEOnF4wt8yKD35Ib1D6XC2siLiYaiqfGkYrunuKdsXGwpBpHU3+9r+RVw2NZfA==",
-					"dev": true
-				},
-				"damerau-levenshtein": {
-					"version": "1.0.7",
-					"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.7.tgz",
-					"integrity": "sha512-VvdQIPGdWP0SqFXghj79Wf/5LArmreyMsGLa6FG6iC4t3j7j5s71TrwWmT/4akbDQIqjfACkLZmjXhA7g2oUZw==",
 					"dev": true
 				},
 				"debug": {
@@ -7554,12 +7440,6 @@
 					"requires": {
 						"ms": "2.1.2"
 					}
-				},
-				"emoji-regex": {
-					"version": "9.2.2",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-					"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-					"dev": true
 				},
 				"es-abstract": {
 					"version": "1.19.1",
@@ -7587,47 +7467,12 @@
 						"string.prototype.trimend": "^1.0.4",
 						"string.prototype.trimstart": "^1.0.4",
 						"unbox-primitive": "^1.0.1"
-					},
-					"dependencies": {
-						"has-symbols": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-							"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-							"dev": true
-						},
-						"is-string": {
-							"version": "1.0.7",
-							"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-							"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-							"dev": true,
-							"requires": {
-								"has-tostringtag": "^1.0.0"
-							}
-						},
-						"unbox-primitive": {
-							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-							"integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
-							"dev": true,
-							"requires": {
-								"function-bind": "^1.1.1",
-								"has-bigints": "^1.0.1",
-								"has-symbols": "^1.0.2",
-								"which-boxed-primitive": "^1.0.2"
-							}
-						}
 					}
 				},
 				"escape-string-regexp": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-					"dev": true
-				},
-				"eslint-config-prettier": {
-					"version": "8.3.0",
-					"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
-					"integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
 					"dev": true
 				},
 				"eslint-import-resolver-node": {
@@ -7647,16 +7492,6 @@
 							"dev": true,
 							"requires": {
 								"ms": "^2.1.1"
-							}
-						},
-						"resolve": {
-							"version": "1.20.0",
-							"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-							"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-							"dev": true,
-							"requires": {
-								"is-core-module": "^2.2.0",
-								"path-parse": "^1.0.6"
 							}
 						}
 					}
@@ -7713,52 +7548,12 @@
 								"ms": "2.0.0"
 							}
 						},
-						"is-glob": {
-							"version": "4.0.3",
-							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-							"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-							"dev": true,
-							"requires": {
-								"is-extglob": "^2.1.1"
-							}
-						},
 						"ms": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 							"dev": true
-						},
-						"resolve": {
-							"version": "1.20.0",
-							"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-							"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-							"dev": true,
-							"requires": {
-								"is-core-module": "^2.2.0",
-								"path-parse": "^1.0.6"
-							}
-						},
-						"tsconfig-paths": {
-							"version": "3.11.0",
-							"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz",
-							"integrity": "sha512-7ecdYDnIdmv639mmDwslG6KQg1Z9STTz1j7Gcz0xa+nshh/gKDAHcPxRbWOsA3SPp0tXP2leTcY9Kw+NAkfZzA==",
-							"dev": true,
-							"requires": {
-								"@types/json5": "^0.0.29",
-								"json5": "^1.0.1",
-								"minimist": "^1.2.0",
-								"strip-bom": "^3.0.0"
-							}
 						}
-					}
-				},
-				"eslint-plugin-jest": {
-					"version": "25.3.0",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-25.3.0.tgz",
-					"integrity": "sha512-79WQtuBsTN1S8Y9+7euBYwxIOia/k7ykkl9OCBHL3xuww5ecursHy/D8GCIlvzHVWv85gOkS5Kv6Sh7RxOgK1Q==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/experimental-utils": "^5.0.0"
 					}
 				},
 				"eslint-plugin-jsdoc": {
@@ -7776,113 +7571,6 @@
 						"regextras": "^0.8.0",
 						"semver": "^7.3.5",
 						"spdx-expression-parse": "^3.0.1"
-					},
-					"dependencies": {
-						"jsdoc-type-pratt-parser": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.0.0.tgz",
-							"integrity": "sha512-sUuj2j48wxrEpbFjDp1sAesAxPiLT+z0SWVmMafyIINs6Lj5gIPKh3VrkBZu4E/Dv+wHpOot0m6H8zlHQjwqeQ==",
-							"dev": true
-						}
-					}
-				},
-				"eslint-plugin-jsx-a11y": {
-					"version": "6.5.1",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.5.1.tgz",
-					"integrity": "sha512-sVCFKX9fllURnXT2JwLN5Qgo24Ug5NF6dxhkmxsMEUZhXRcGg+X3e1JbJ84YePQKBl5E0ZjAH5Q4rkdcGY99+g==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.16.3",
-						"aria-query": "^4.2.2",
-						"array-includes": "^3.1.4",
-						"ast-types-flow": "^0.0.7",
-						"axe-core": "^4.3.5",
-						"axobject-query": "^2.2.0",
-						"damerau-levenshtein": "^1.0.7",
-						"emoji-regex": "^9.2.2",
-						"has": "^1.0.3",
-						"jsx-ast-utils": "^3.2.1",
-						"language-tags": "^1.0.5",
-						"minimatch": "^3.0.4"
-					}
-				},
-				"eslint-plugin-react": {
-					"version": "7.27.1",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.1.tgz",
-					"integrity": "sha512-meyunDjMMYeWr/4EBLTV1op3iSG3mjT/pz5gti38UzfM4OPpNc2m0t2xvKCOMU5D6FSdd34BIMFOvQbW+i8GAA==",
-					"dev": true,
-					"requires": {
-						"array-includes": "^3.1.4",
-						"array.prototype.flatmap": "^1.2.5",
-						"doctrine": "^2.1.0",
-						"estraverse": "^5.3.0",
-						"jsx-ast-utils": "^2.4.1 || ^3.0.0",
-						"minimatch": "^3.0.4",
-						"object.entries": "^1.1.5",
-						"object.fromentries": "^2.0.5",
-						"object.hasown": "^1.1.0",
-						"object.values": "^1.1.5",
-						"prop-types": "^15.7.2",
-						"resolve": "^2.0.0-next.3",
-						"semver": "^6.3.0",
-						"string.prototype.matchall": "^4.0.6"
-					},
-					"dependencies": {
-						"estraverse": {
-							"version": "5.3.0",
-							"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-							"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-							"dev": true
-						},
-						"resolve": {
-							"version": "2.0.0-next.3",
-							"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.3.tgz",
-							"integrity": "sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==",
-							"dev": true,
-							"requires": {
-								"is-core-module": "^2.2.0",
-								"path-parse": "^1.0.6"
-							}
-						},
-						"semver": {
-							"version": "6.3.0",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-							"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-							"dev": true
-						}
-					}
-				},
-				"eslint-plugin-react-hooks": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
-					"integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
-					"dev": true
-				},
-				"eslint-scope": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-					"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-					"dev": true,
-					"requires": {
-						"esrecurse": "^4.3.0",
-						"estraverse": "^4.1.1"
-					}
-				},
-				"eslint-utils": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-					"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-					"dev": true,
-					"requires": {
-						"eslint-visitor-keys": "^2.0.0"
-					},
-					"dependencies": {
-						"eslint-visitor-keys": {
-							"version": "2.1.0",
-							"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-							"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-							"dev": true
-						}
 					}
 				},
 				"esquery": {
@@ -7892,32 +7580,13 @@
 					"dev": true,
 					"requires": {
 						"estraverse": "^5.1.0"
-					},
-					"dependencies": {
-						"estraverse": {
-							"version": "5.3.0",
-							"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-							"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-							"dev": true
-						}
 					}
 				},
-				"esrecurse": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-					"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-					"dev": true,
-					"requires": {
-						"estraverse": "^5.2.0"
-					},
-					"dependencies": {
-						"estraverse": {
-							"version": "5.3.0",
-							"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-							"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-							"dev": true
-						}
-					}
+				"estraverse": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+					"dev": true
 				},
 				"find-up": {
 					"version": "2.1.0",
@@ -7928,17 +7597,6 @@
 						"locate-path": "^2.0.0"
 					}
 				},
-				"get-intrinsic": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-					"dev": true,
-					"requires": {
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.1"
-					}
-				},
 				"globals": {
 					"version": "13.12.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
@@ -7946,40 +7604,19 @@
 					"dev": true,
 					"requires": {
 						"type-fest": "^0.20.2"
-					},
-					"dependencies": {
-						"type-fest": {
-							"version": "0.20.2",
-							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-							"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-							"dev": true
-						}
 					}
 				},
-				"globby": {
-					"version": "11.0.4",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-					"integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
-					"dev": true,
-					"requires": {
-						"array-union": "^2.1.0",
-						"dir-glob": "^3.0.1",
-						"fast-glob": "^3.1.1",
-						"ignore": "^5.1.4",
-						"merge2": "^1.3.0",
-						"slash": "^3.0.0"
-					}
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
 				},
-				"internal-slot": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-					"integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
-					"dev": true,
-					"requires": {
-						"get-intrinsic": "^1.1.0",
-						"has": "^1.0.3",
-						"side-channel": "^1.0.4"
-					}
+				"ignore": {
+					"version": "5.1.9",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+					"integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+					"dev": true
 				},
 				"is-callable": {
 					"version": "1.2.4",
@@ -7987,13 +7624,13 @@
 					"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
 					"dev": true
 				},
-				"is-core-module": {
-					"version": "2.8.0",
-					"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
-					"integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
+				"is-glob": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+					"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
 					"dev": true,
 					"requires": {
-						"has": "^1.0.3"
+						"is-extglob": "^2.1.1"
 					}
 				},
 				"is-regex": {
@@ -8006,23 +7643,13 @@
 						"has-tostringtag": "^1.0.0"
 					}
 				},
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+				"is-string": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+					"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
 					"dev": true,
 					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"jsx-ast-utils": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.1.tgz",
-					"integrity": "sha512-uP5vu8xfy2F9A6LGC22KO7e2/vGTS1MhP+18f++ZNlf0Ohaxbc9nIEwHAsejlJKyzfZzU5UIhe5ItYkitcZnZA==",
-					"dev": true,
-					"requires": {
-						"array-includes": "^3.1.3",
-						"object.assign": "^4.1.2"
+						"has-tostringtag": "^1.0.0"
 					}
 				},
 				"locate-path": {
@@ -8036,9 +7663,9 @@
 					}
 				},
 				"object-inspect": {
-					"version": "1.11.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-					"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+					"version": "1.11.1",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.1.tgz",
+					"integrity": "sha512-If7BjFlpkzzBeV1cqgT3OSWT3azyoxDGajR+iGnFBfVV2EWyDyWaZZW2ERDjUaY2QM8i5jI3Sj7mhsM4DDAqWA==",
 					"dev": true
 				},
 				"object.assign": {
@@ -8051,28 +7678,6 @@
 						"define-properties": "^1.1.3",
 						"has-symbols": "^1.0.1",
 						"object-keys": "^1.1.1"
-					}
-				},
-				"object.entries": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
-					"integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3",
-						"es-abstract": "^1.19.1"
-					}
-				},
-				"object.fromentries": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
-					"integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3",
-						"es-abstract": "^1.19.1"
 					}
 				},
 				"object.values": {
@@ -8120,26 +7725,10 @@
 					}
 				},
 				"prettier": {
-					"version": "npm:prettier@2.2.1-beta-1",
+					"version": "npm:wp-prettier@2.2.1-beta-1",
 					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
 					"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
 					"dev": true
-				},
-				"regenerator-runtime": {
-					"version": "0.13.9",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-					"integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-					"dev": true
-				},
-				"regexp.prototype.flags": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
-					"integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3"
-					}
 				},
 				"regexpp": {
 					"version": "3.2.0",
@@ -8153,6 +7742,15 @@
 					"integrity": "sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ==",
 					"dev": true
 				},
+				"resolve": {
+					"version": "1.20.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+					"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+					"requires": {
+						"is-core-module": "^2.2.0",
+						"path-parse": "^1.0.6"
+					}
+				},
 				"semver": {
 					"version": "7.3.5",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -8160,36 +7758,6 @@
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
-					}
-				},
-				"slash": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-					"dev": true
-				},
-				"string.prototype.matchall": {
-					"version": "4.0.6",
-					"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz",
-					"integrity": "sha512-6WgDX8HmQqvEd7J+G6VtAahhsQIssiZ8zl7zKh1VDMFyL3hRTJP4FTNA3RbIp2TOQ9AYNDcc7e3fH0Qbup+DBg==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3",
-						"es-abstract": "^1.19.1",
-						"get-intrinsic": "^1.1.1",
-						"has-symbols": "^1.0.2",
-						"internal-slot": "^1.0.3",
-						"regexp.prototype.flags": "^1.3.1",
-						"side-channel": "^1.0.4"
-					},
-					"dependencies": {
-						"has-symbols": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-							"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-							"dev": true
-						}
 					}
 				},
 				"string.prototype.trimend": {
@@ -8210,15 +7778,6 @@
 					"requires": {
 						"call-bind": "^1.0.2",
 						"define-properties": "^1.1.3"
-					}
-				},
-				"tsutils": {
-					"version": "3.21.0",
-					"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-					"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-					"dev": true,
-					"requires": {
-						"tslib": "^1.8.1"
 					}
 				}
 			}
@@ -15694,23 +15253,6 @@
 			"requires": {
 				"@babel/runtime": "^7.10.2",
 				"@babel/runtime-corejs3": "^7.10.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-					"integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-					"dev": true
-				}
 			}
 		},
 		"arr-diff": {
@@ -15798,6 +15340,116 @@
 				"es-abstract": "^1.17.0-next.1"
 			}
 		},
+		"array.prototype.flatmap": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.5.tgz",
+			"integrity": "sha512-08u6rVyi1Lj7oqWbS9nUxliETrtIROT4XGTA4D/LWGten6E3ocm7cy9SIrmNHOL5XVbVuckUp3X6Xyg8/zpvHA==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.0",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.19.0"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.19.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+					"integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.1.1",
+						"get-symbol-description": "^1.0.0",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.2",
+						"internal-slot": "^1.0.3",
+						"is-callable": "^1.2.4",
+						"is-negative-zero": "^2.0.1",
+						"is-regex": "^1.1.4",
+						"is-shared-array-buffer": "^1.0.1",
+						"is-string": "^1.0.7",
+						"is-weakref": "^1.0.1",
+						"object-inspect": "^1.11.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.2",
+						"string.prototype.trimend": "^1.0.4",
+						"string.prototype.trimstart": "^1.0.4",
+						"unbox-primitive": "^1.0.1"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				},
+				"is-callable": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+					"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+					"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"has-tostringtag": "^1.0.0"
+					}
+				},
+				"is-string": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+					"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+					"dev": true,
+					"requires": {
+						"has-tostringtag": "^1.0.0"
+					}
+				},
+				"object-inspect": {
+					"version": "1.11.1",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.1.tgz",
+					"integrity": "sha512-If7BjFlpkzzBeV1cqgT3OSWT3azyoxDGajR+iGnFBfVV2EWyDyWaZZW2ERDjUaY2QM8i5jI3Sj7mhsM4DDAqWA==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				},
+				"string.prototype.trimend": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"string.prototype.trimstart": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				}
+			}
+		},
 		"asn1": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -15874,6 +15526,12 @@
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
 			"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
+			"dev": true
+		},
+		"axe-core": {
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.5.tgz",
+			"integrity": "sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==",
 			"dev": true
 		},
 		"axobject-query": {
@@ -16591,13 +16249,13 @@
 			}
 		},
 		"call-bind": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
-			"integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
 			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1",
-				"get-intrinsic": "^1.0.0"
+				"get-intrinsic": "^1.0.2"
 			}
 		},
 		"caller-callsite": {
@@ -17106,9 +16764,9 @@
 			}
 		},
 		"core-js-pure": {
-			"version": "3.8.2",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.8.2.tgz",
-			"integrity": "sha512-v6zfIQqL/pzTVAbZvYUozsxNfxcFb6Ks3ZfEbuneJl3FW9Jb8F6vLWB6f+qTmAu72msUdyb84V8d/yBFf7FNnw==",
+			"version": "3.19.3",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.19.3.tgz",
+			"integrity": "sha512-N3JruInmCyt7EJj5mAq3csCgGYgiSqu7p7TQp2KOztr180/OAIxyIvL1FCjzgmQk/t3Yniua50Fsak7FShI9lA==",
 			"dev": true
 		},
 		"core-util-is": {
@@ -17118,9 +16776,9 @@
 			"dev": true
 		},
 		"cosmiconfig": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
-			"integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+			"integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
 			"dev": true,
 			"requires": {
 				"@types/parse-json": "^4.0.0",
@@ -17257,6 +16915,12 @@
 			"version": "3.0.8",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
 			"integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==",
+			"dev": true
+		},
+		"damerau-levenshtein": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.7.tgz",
+			"integrity": "sha512-VvdQIPGdWP0SqFXghj79Wf/5LArmreyMsGLa6FG6iC4t3j7j5s71TrwWmT/4akbDQIqjfACkLZmjXhA7g2oUZw==",
 			"dev": true
 		},
 		"dashdash": {
@@ -18104,6 +17768,12 @@
 				}
 			}
 		},
+		"eslint-config-prettier": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+			"integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
+			"dev": true
+		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",
@@ -18266,6 +17936,15 @@
 				}
 			}
 		},
+		"eslint-plugin-jest": {
+			"version": "25.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-25.3.0.tgz",
+			"integrity": "sha512-79WQtuBsTN1S8Y9+7euBYwxIOia/k7ykkl9OCBHL3xuww5ecursHy/D8GCIlvzHVWv85gOkS5Kv6Sh7RxOgK1Q==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/experimental-utils": "^5.0.0"
+			}
+		},
 		"eslint-plugin-jsdoc": {
 			"version": "34.8.2",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-34.8.2.tgz",
@@ -18339,14 +18018,362 @@
 				}
 			}
 		},
+		"eslint-plugin-jsx-a11y": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.5.1.tgz",
+			"integrity": "sha512-sVCFKX9fllURnXT2JwLN5Qgo24Ug5NF6dxhkmxsMEUZhXRcGg+X3e1JbJ84YePQKBl5E0ZjAH5Q4rkdcGY99+g==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.16.3",
+				"aria-query": "^4.2.2",
+				"array-includes": "^3.1.4",
+				"ast-types-flow": "^0.0.7",
+				"axe-core": "^4.3.5",
+				"axobject-query": "^2.2.0",
+				"damerau-levenshtein": "^1.0.7",
+				"emoji-regex": "^9.2.2",
+				"has": "^1.0.3",
+				"jsx-ast-utils": "^3.2.1",
+				"language-tags": "^1.0.5",
+				"minimatch": "^3.0.4"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.16.3",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
+					"integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"array-includes": {
+					"version": "3.1.4",
+					"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
+					"integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3",
+						"es-abstract": "^1.19.1",
+						"get-intrinsic": "^1.1.1",
+						"is-string": "^1.0.7"
+					}
+				},
+				"emoji-regex": {
+					"version": "9.2.2",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+					"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+					"dev": true
+				},
+				"es-abstract": {
+					"version": "1.19.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+					"integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.1.1",
+						"get-symbol-description": "^1.0.0",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.2",
+						"internal-slot": "^1.0.3",
+						"is-callable": "^1.2.4",
+						"is-negative-zero": "^2.0.1",
+						"is-regex": "^1.1.4",
+						"is-shared-array-buffer": "^1.0.1",
+						"is-string": "^1.0.7",
+						"is-weakref": "^1.0.1",
+						"object-inspect": "^1.11.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.2",
+						"string.prototype.trimend": "^1.0.4",
+						"string.prototype.trimstart": "^1.0.4",
+						"unbox-primitive": "^1.0.1"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				},
+				"is-callable": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+					"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+					"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"has-tostringtag": "^1.0.0"
+					}
+				},
+				"is-string": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+					"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+					"dev": true,
+					"requires": {
+						"has-tostringtag": "^1.0.0"
+					}
+				},
+				"object-inspect": {
+					"version": "1.11.1",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.1.tgz",
+					"integrity": "sha512-If7BjFlpkzzBeV1cqgT3OSWT3azyoxDGajR+iGnFBfVV2EWyDyWaZZW2ERDjUaY2QM8i5jI3Sj7mhsM4DDAqWA==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.13.9",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+					"integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+					"dev": true
+				},
+				"string.prototype.trimend": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"string.prototype.trimstart": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				}
+			}
+		},
 		"eslint-plugin-prettier": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.1.tgz",
-			"integrity": "sha512-Rq3jkcFY8RYeQLgk2cCwuc0P7SEFwDravPhsJZOQ5N4YI4DSg50NyqJ/9gdZHzQlHf8MvafSesbNJCcP/FF6pQ==",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
+			"integrity": "sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==",
 			"dev": true,
 			"requires": {
 				"prettier-linter-helpers": "^1.0.0"
 			}
+		},
+		"eslint-plugin-react": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.1.tgz",
+			"integrity": "sha512-meyunDjMMYeWr/4EBLTV1op3iSG3mjT/pz5gti38UzfM4OPpNc2m0t2xvKCOMU5D6FSdd34BIMFOvQbW+i8GAA==",
+			"dev": true,
+			"requires": {
+				"array-includes": "^3.1.4",
+				"array.prototype.flatmap": "^1.2.5",
+				"doctrine": "^2.1.0",
+				"estraverse": "^5.3.0",
+				"jsx-ast-utils": "^2.4.1 || ^3.0.0",
+				"minimatch": "^3.0.4",
+				"object.entries": "^1.1.5",
+				"object.fromentries": "^2.0.5",
+				"object.hasown": "^1.1.0",
+				"object.values": "^1.1.5",
+				"prop-types": "^15.7.2",
+				"resolve": "^2.0.0-next.3",
+				"semver": "^6.3.0",
+				"string.prototype.matchall": "^4.0.6"
+			},
+			"dependencies": {
+				"array-includes": {
+					"version": "3.1.4",
+					"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
+					"integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3",
+						"es-abstract": "^1.19.1",
+						"get-intrinsic": "^1.1.1",
+						"is-string": "^1.0.7"
+					}
+				},
+				"es-abstract": {
+					"version": "1.19.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+					"integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.1.1",
+						"get-symbol-description": "^1.0.0",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.2",
+						"internal-slot": "^1.0.3",
+						"is-callable": "^1.2.4",
+						"is-negative-zero": "^2.0.1",
+						"is-regex": "^1.1.4",
+						"is-shared-array-buffer": "^1.0.1",
+						"is-string": "^1.0.7",
+						"is-weakref": "^1.0.1",
+						"object-inspect": "^1.11.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.2",
+						"string.prototype.trimend": "^1.0.4",
+						"string.prototype.trimstart": "^1.0.4",
+						"unbox-primitive": "^1.0.1"
+					}
+				},
+				"estraverse": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+					"dev": true
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				},
+				"is-callable": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+					"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+					"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"has-tostringtag": "^1.0.0"
+					}
+				},
+				"is-string": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+					"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+					"dev": true,
+					"requires": {
+						"has-tostringtag": "^1.0.0"
+					}
+				},
+				"object-inspect": {
+					"version": "1.11.1",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.1.tgz",
+					"integrity": "sha512-If7BjFlpkzzBeV1cqgT3OSWT3azyoxDGajR+iGnFBfVV2EWyDyWaZZW2ERDjUaY2QM8i5jI3Sj7mhsM4DDAqWA==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				},
+				"object.entries": {
+					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
+					"integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3",
+						"es-abstract": "^1.19.1"
+					}
+				},
+				"object.fromentries": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
+					"integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3",
+						"es-abstract": "^1.19.1"
+					}
+				},
+				"object.values": {
+					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
+					"integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3",
+						"es-abstract": "^1.19.1"
+					}
+				},
+				"resolve": {
+					"version": "2.0.0-next.3",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.3.tgz",
+					"integrity": "sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==",
+					"dev": true,
+					"requires": {
+						"is-core-module": "^2.2.0",
+						"path-parse": "^1.0.6"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"string.prototype.trimend": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"string.prototype.trimstart": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				}
+			}
+		},
+		"eslint-plugin-react-hooks": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
+			"integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
+			"dev": true
 		},
 		"eslint-plugin-react-native": {
 			"version": "3.8.1",
@@ -18371,6 +18398,23 @@
 			"requires": {
 				"esrecurse": "^4.1.0",
 				"estraverse": "^4.1.1"
+			}
+		},
+		"eslint-utils": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+			"dev": true,
+			"requires": {
+				"eslint-visitor-keys": "^2.0.0"
+			},
+			"dependencies": {
+				"eslint-visitor-keys": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+					"dev": true
+				}
 			}
 		},
 		"eslint-visitor-keys": {
@@ -18992,8 +19036,7 @@
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
 		"function.prototype.name": {
 			"version": "1.1.2",
@@ -19031,9 +19074,9 @@
 			"dev": true
 		},
 		"get-intrinsic": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
-			"integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+			"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
 			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1",
@@ -19064,29 +19107,6 @@
 			"requires": {
 				"call-bind": "^1.0.2",
 				"get-intrinsic": "^1.1.1"
-			},
-			"dependencies": {
-				"call-bind": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-					"dev": true,
-					"requires": {
-						"function-bind": "^1.1.1",
-						"get-intrinsic": "^1.0.2"
-					}
-				},
-				"get-intrinsic": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-					"dev": true,
-					"requires": {
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.1"
-					}
-				}
 			}
 		},
 		"get-value": {
@@ -19157,6 +19177,28 @@
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
 			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
 		},
+		"globby": {
+			"version": "11.0.4",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+			"integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+			"dev": true,
+			"requires": {
+				"array-union": "^2.1.0",
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.1.1",
+				"ignore": "^5.1.4",
+				"merge2": "^1.3.0",
+				"slash": "^3.0.0"
+			},
+			"dependencies": {
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+					"dev": true
+				}
+			}
+		},
 		"graceful-fs": {
 			"version": "4.2.4",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -19195,7 +19237,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1"
 			}
@@ -19596,6 +19637,17 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
 		},
+		"internal-slot": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+			"integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+			"dev": true,
+			"requires": {
+				"get-intrinsic": "^1.1.0",
+				"has": "^1.0.3",
+				"side-channel": "^1.0.4"
+			}
+		},
 		"invariant": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -19671,6 +19723,14 @@
 			"dev": true,
 			"requires": {
 				"ci-info": "^2.0.0"
+			}
+		},
+		"is-core-module": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
+			"integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
+			"requires": {
+				"has": "^1.0.3"
 			}
 		},
 		"is-data-descriptor": {
@@ -20742,6 +20802,12 @@
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
 			"dev": true
 		},
+		"jsdoc-type-pratt-parser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.0.0.tgz",
+			"integrity": "sha512-sUuj2j48wxrEpbFjDp1sAesAxPiLT+z0SWVmMafyIINs6Lj5gIPKh3VrkBZu4E/Dv+wHpOot0m6H8zlHQjwqeQ==",
+			"dev": true
+		},
 		"jsdoctypeparser": {
 			"version": "9.0.0",
 			"resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-9.0.0.tgz",
@@ -20914,6 +20980,128 @@
 					"dev": true,
 					"requires": {
 						"amdefine": ">=0.0.4"
+					}
+				}
+			}
+		},
+		"jsx-ast-utils": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.1.tgz",
+			"integrity": "sha512-uP5vu8xfy2F9A6LGC22KO7e2/vGTS1MhP+18f++ZNlf0Ohaxbc9nIEwHAsejlJKyzfZzU5UIhe5ItYkitcZnZA==",
+			"dev": true,
+			"requires": {
+				"array-includes": "^3.1.3",
+				"object.assign": "^4.1.2"
+			},
+			"dependencies": {
+				"array-includes": {
+					"version": "3.1.4",
+					"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
+					"integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3",
+						"es-abstract": "^1.19.1",
+						"get-intrinsic": "^1.1.1",
+						"is-string": "^1.0.7"
+					}
+				},
+				"es-abstract": {
+					"version": "1.19.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+					"integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.1.1",
+						"get-symbol-description": "^1.0.0",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.2",
+						"internal-slot": "^1.0.3",
+						"is-callable": "^1.2.4",
+						"is-negative-zero": "^2.0.1",
+						"is-regex": "^1.1.4",
+						"is-shared-array-buffer": "^1.0.1",
+						"is-string": "^1.0.7",
+						"is-weakref": "^1.0.1",
+						"object-inspect": "^1.11.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.2",
+						"string.prototype.trimend": "^1.0.4",
+						"string.prototype.trimstart": "^1.0.4",
+						"unbox-primitive": "^1.0.1"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				},
+				"is-callable": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+					"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+					"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"has-tostringtag": "^1.0.0"
+					}
+				},
+				"is-string": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+					"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+					"dev": true,
+					"requires": {
+						"has-tostringtag": "^1.0.0"
+					}
+				},
+				"object-inspect": {
+					"version": "1.11.1",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.1.tgz",
+					"integrity": "sha512-If7BjFlpkzzBeV1cqgT3OSWT3azyoxDGajR+iGnFBfVV2EWyDyWaZZW2ERDjUaY2QM8i5jI3Sj7mhsM4DDAqWA==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				},
+				"string.prototype.trimend": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"string.prototype.trimstart": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
 					}
 				}
 			}
@@ -22567,16 +22755,6 @@
 				"es-abstract": "^1.19.1"
 			},
 			"dependencies": {
-				"call-bind": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-					"dev": true,
-					"requires": {
-						"function-bind": "^1.1.1",
-						"get-intrinsic": "^1.0.2"
-					}
-				},
 				"es-abstract": {
 					"version": "1.19.1",
 					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
@@ -22605,33 +22783,11 @@
 						"unbox-primitive": "^1.0.1"
 					}
 				},
-				"get-intrinsic": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-					"dev": true,
-					"requires": {
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.1"
-					}
-				},
 				"has-symbols": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
 					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
 					"dev": true
-				},
-				"internal-slot": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-					"integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
-					"dev": true,
-					"requires": {
-						"get-intrinsic": "^1.1.0",
-						"has": "^1.0.3",
-						"side-channel": "^1.0.4"
-					}
 				},
 				"is-callable": {
 					"version": "1.2.4",
@@ -22862,9 +23018,9 @@
 			}
 		},
 		"parse-json": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
-			"integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
@@ -23433,6 +23589,16 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
+		"regexp.prototype.flags": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
+			"integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3"
+			}
+		},
 		"regexpp": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
@@ -23607,6 +23773,7 @@
 			"version": "1.17.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
 			"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -23965,9 +24132,9 @@
 			},
 			"dependencies": {
 				"object-inspect": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+					"version": "1.11.1",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.1.tgz",
+					"integrity": "sha512-If7BjFlpkzzBeV1cqgT3OSWT3azyoxDGajR+iGnFBfVV2EWyDyWaZZW2ERDjUaY2QM8i5jI3Sj7mhsM4DDAqWA==",
 					"dev": true
 				}
 			}
@@ -24332,6 +24499,121 @@
 				"strip-ansi": "^5.1.0"
 			}
 		},
+		"string.prototype.matchall": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz",
+			"integrity": "sha512-6WgDX8HmQqvEd7J+G6VtAahhsQIssiZ8zl7zKh1VDMFyL3hRTJP4FTNA3RbIp2TOQ9AYNDcc7e3fH0Qbup+DBg==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.19.1",
+				"get-intrinsic": "^1.1.1",
+				"has-symbols": "^1.0.2",
+				"internal-slot": "^1.0.3",
+				"regexp.prototype.flags": "^1.3.1",
+				"side-channel": "^1.0.4"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.19.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+					"integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.1.1",
+						"get-symbol-description": "^1.0.0",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.2",
+						"internal-slot": "^1.0.3",
+						"is-callable": "^1.2.4",
+						"is-negative-zero": "^2.0.1",
+						"is-regex": "^1.1.4",
+						"is-shared-array-buffer": "^1.0.1",
+						"is-string": "^1.0.7",
+						"is-weakref": "^1.0.1",
+						"object-inspect": "^1.11.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.2",
+						"string.prototype.trimend": "^1.0.4",
+						"string.prototype.trimstart": "^1.0.4",
+						"unbox-primitive": "^1.0.1"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				},
+				"is-callable": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+					"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+					"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"has-tostringtag": "^1.0.0"
+					}
+				},
+				"is-string": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+					"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+					"dev": true,
+					"requires": {
+						"has-tostringtag": "^1.0.0"
+					}
+				},
+				"object-inspect": {
+					"version": "1.11.1",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.1.tgz",
+					"integrity": "sha512-If7BjFlpkzzBeV1cqgT3OSWT3azyoxDGajR+iGnFBfVV2EWyDyWaZZW2ERDjUaY2QM8i5jI3Sj7mhsM4DDAqWA==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				},
+				"string.prototype.trimend": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"string.prototype.trimstart": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				}
+			}
+		},
 		"string.prototype.trim": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.1.tgz",
@@ -24632,11 +24914,43 @@
 			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
 			"dev": true
 		},
+		"tsconfig-paths": {
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
+			"integrity": "sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==",
+			"dev": true,
+			"requires": {
+				"@types/json5": "^0.0.29",
+				"json5": "^1.0.1",
+				"minimist": "^1.2.0",
+				"strip-bom": "^3.0.0"
+			},
+			"dependencies": {
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				}
+			}
+		},
 		"tslib": {
 			"version": "1.13.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
 			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
 			"dev": true
+		},
+		"tsutils": {
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+			"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+			"dev": true,
+			"requires": {
+				"tslib": "^1.8.1"
+			}
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
@@ -24661,6 +24975,12 @@
 			"requires": {
 				"prelude-ls": "~1.1.2"
 			}
+		},
+		"type-fest": {
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"dev": true
 		},
 		"typescript": {
 			"version": "4.1.3",
@@ -25056,16 +25376,6 @@
 				"is-symbol": "^1.0.3"
 			},
 			"dependencies": {
-				"call-bind": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-					"dev": true,
-					"requires": {
-						"function-bind": "^1.1.1",
-						"get-intrinsic": "^1.0.2"
-					}
-				},
 				"is-boolean-object": {
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
@@ -25166,9 +25476,9 @@
 			"dev": true
 		},
 		"yaml": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-			"integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
 			"dev": true
 		},
 		"yargs": {


### PR DESCRIPTION
To ensure the correct lock file changes were captured, we uninstalled and then
re-installed the `@wordpress/eslint-plugin` plugin. Prior to this, the CI checks
failed due to a missing `eslint-plugin-jsx-a11y` package, which was not hoisted
to the top-level `node_modules` directory.

To test: n/a

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
