### PR TITLE
Update WordPress Aztec iOS version to 1.19.6

### DIFF
--- a/RNTAztecView.podspec
+++ b/RNTAztecView.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.xcconfig         = {'OTHER_LDFLAGS' => '-lxml2',
                         'HEADER_SEARCH_PATHS' => '/usr/include/libxml2'}
   s.dependency         'React-Core'
-  s.dependency         'WordPress-Aztec-iOS', '~> 1.19.5'
+  s.dependency         'WordPress-Aztec-iOS', '~> 1.19.6'
 
 end


### PR DESCRIPTION
This is a follow-up of https://github.com/wordpress-mobile/gutenberg-mobile/pull/4175 to update the pending WordPress-Aztec-iOS to `1.19.6`

To test CI checks should pass

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
