### PR TITLE
Fix heading block newline on split

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@ Unreleased
 * [*] [Preformatted block] Fix an issue where the background color is not showing up for standard themes [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4292]
 * [**] Update Gallery Block to default to the new format and auto-convert old galleries to the new format [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4315]
 * [***] Highlight text - enables color customization for specific text within a Paragraph block [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4175]
+* [**] Fix empty line appearing when splitting heading blocks on Android 12 [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4365]
 
 1.67.0
 ---


### PR DESCRIPTION
Fixes #4322 

### Related PRs:
* https://github.com/WordPress/gutenberg/pull/37279

To test:

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
