### PR TITLE
Update submodule dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7339,6 +7339,7 @@
 				"@babel/eslint-parser": "^7.16.0",
 				"@typescript-eslint/eslint-plugin": "^5.3.0",
 				"@typescript-eslint/parser": "^5.3.0",
+				"@wordpress/babel-preset-default": "file:gutenberg/packages/babel-preset-default",
 				"@wordpress/prettier-config": "file:gutenberg/packages/prettier-config",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^8.3.0",


### PR DESCRIPTION
Update Gutenberg version and capture lock file changes resulting from dependency
update in the Gutenberg submodule: https://github.com/WordPress/gutenberg/commit/585692bcc2db26cf417b08eda13fcc3ace4f2e68#diff-691525462f8b4cac47c3c2e0e2668606f539ed0b3f62f8f6b79dffe7ef38bd9dR37

To test: Passing CI checks should suffice.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
