### PR TITLE
Fix Tiled Gallery JS test failure

### DIFF
--- a/src/test/jetpack-editor-setup.js
+++ b/src/test/jetpack-editor-setup.js
@@ -35,7 +35,11 @@ const defaultProps = {
 		smartframeEmbed: true,
 	},
 };
-const jetpackBlocks = [ 'jetpack/contact-info', 'jetpack/story' ];
+const jetpackBlocks = [
+	'jetpack/contact-info',
+	'jetpack/story',
+	'jetpack/tiled-gallery',
+];
 const jetpackEmbedVariations = [
 	'facebook',
 	'instagram',
@@ -74,6 +78,7 @@ describe( 'Jetpack blocks', () => {
 			available_blocks: {
 				'contact-info': { available: true },
 				story: { available: true },
+				'tiled-gallery': { available: true },
 			},
 			jetpack: { is_active: true },
 			siteFragment: null,


### PR DESCRIPTION
To test, ensure CI is green.

Related:
- https://github.com/Automattic/jetpack/pull/22252

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
