### PR TITLE
Fix LinkPicker freeze when virtual keyboard is hidden

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@ Unreleased
 * [**] Add Jetpack and Layout Grid translations [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4359]
 * [**] Fix text formatting mode lost after backspace is used [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4423]
 * [*] Add missing translations of unsupported block editor modal [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4410]
+* [*] Fix app freeze when closing link picker while virtual keyboard is hidden [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4443]
 
 1.68.0
 ---


### PR DESCRIPTION
This brings in https://github.com/WordPress/gutenberg/pull/37782 to fix an app freeze after closing the link picker while a device's virtual keyboard is hidden. 

To test: See https://github.com/WordPress/gutenberg/pull/37782. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
