### PR TITLE
Add clean i18n cache command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,9 +117,11 @@ bin/wp-cli.phar
 /junit.xml
 
 # Cocoapods
-
 ios/Pods
 ios/vendor
 
 # i18n update
 i18n-test/
+
+# i18n cache
+src/i18n-cache/

--- a/package.json
+++ b/package.json
@@ -87,9 +87,9 @@
 		"test:e2e:ios:local": "npm run test:e2e:bundle:ios && npm run core test:e2e:build-app:ios && npm run core test:e2e:build-wda && TEST_RN_PLATFORM=ios npm run device-tests:local",
 		"sync:android": "bin/sync-android.sh",
 		"build:gutenberg": "cd gutenberg && npm run build",
-		"clean": "npm run core clean; npm run clean:gutenberg; npm run clean:pot",
+		"clean": "npm run core clean; npm run clean:gutenberg; npm run clean:i18n",
 		"clean:gutenberg": "cd gutenberg && npm run clean:packages",
-		"clean:pot": "rm -f gutenberg*.pot",
+		"clean:i18n": "rm -rf src/i18n-cache",
 		"lint": "eslint . --ext .js",
 		"lint:fix": "npm run lint -- --fix",
 		"version": "npm run bundle && git add -A bundle"

--- a/src/i18n-cache/.gitignore
+++ b/src/i18n-cache/.gitignore
@@ -1,4 +1,0 @@
-# ignore all the contents of this folder except .gitignore and index.js
-*
-!.gitignore
-!index.js


### PR DESCRIPTION
Adds a clean command for removing the i18n cache.

**To test:**
1. Run command `npm run clean`.
2. Observe that the folder `src/i18n-cache` is removed.
3. Run command `npm run ci`.
4. Observe that the folder `src/i18n-cache` is created and contains translation files for supported plugins: Gutenberg (`gutenberg` folder) , Jetpack (`jetpack` folder) and Layout Grid (`layout-grid` folder).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
