### PR TITLE
Force check i18n cache when cleaning project

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
 		"build:gutenberg": "cd gutenberg && npm run build",
 		"clean": "npm run core clean; npm run clean:gutenberg; npm run clean:i18n",
 		"clean:gutenberg": "cd gutenberg && npm run clean:packages",
-		"clean:i18n": "rm -rf src/i18n-cache",
+		"clean:i18n": "rm -rf src/i18n-cache && npm run i18n:check-cache",
 		"lint": "eslint . --ext .js",
 		"lint:fix": "npm run lint -- --fix",
 		"version": "npm run bundle && git add -A bundle"


### PR DESCRIPTION
Following up https://github.com/wordpress-mobile/gutenberg-mobile/pull/4469, this PR includes the command `npm run i18n:check-cache` in i18n cache cleaning command (`npm run clean:i18n`). This way we assure that the i18n cache is always present, which is required for generating the JS bundle. 

Thanks @guarani for spotting this and suggestion the change in https://github.com/wordpress-mobile/gutenberg-mobile/pull/4469#discussion_r785089429 🙇 .

## To test
### Clean command recreates i18n cache
1. Run command `npm run clean`.
2. Observe that the folder `src/i18n-cache` is removed when the command is being executed.
3. Observe that the folder `src/i18n-cache` is created again.

### JS bundle is generated properly
1. Run command `npm run bundle`.
2. Observe that the command is executed properly without errors.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
