### PR TITLE
Assure destination directory presence for localization strings files output

### DIFF
--- a/bin/strings2android.js
+++ b/bin/strings2android.js
@@ -188,6 +188,13 @@ if ( require.main === module ) {
 	}
 
 	const xmlOutput = strings2Android( onlyNativeStrings );
+
+	// Assure that the destination directory exists
+	const destinationDir = path.dirname( destination );
+	if ( ! fs.existsSync( destinationDir ) ) {
+		fs.mkdirSync( destinationDir, { recursive: true } );
+	}
+
 	fs.writeFileSync( destination, xmlOutput );
 }
 

--- a/bin/strings2swift.js
+++ b/bin/strings2swift.js
@@ -67,6 +67,13 @@ if ( require.main === module ) {
 	}
 
 	const swiftOutput = strings2Swift( onlyNativeStrings );
+
+	// Assure that the destination directory exists
+	const destinationDir = path.dirname( destination );
+	if ( ! fs.existsSync( destinationDir ) ) {
+		fs.mkdirSync( destinationDir, { recursive: true } );
+	}
+
 	fs.writeFileSync( destination, swiftOutput );
 }
 


### PR DESCRIPTION
This PR adds logic to both scripts in charge of generating the localization strings files (`strings2android` and `strings2swift`), in order to assure that the destination directory provided to the script is always present.

To test:
1. Run command `rm -rf bundle && npm run bundle`.
2. Observe that no errors are thrown and that bundles are generated.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
