### PR TITLE
Improve string replacements for android lint rules in `strings2android` script

### DIFF
--- a/bin/strings2android.js
+++ b/bin/strings2android.js
@@ -73,9 +73,9 @@ function replaceHyphenInNumberRanges( XMLValue ) {
  * @param {string} XMLValue input to apply replacements.
  * @return {string} valid string passing TypographyEllipsis Android lint rule.
  */
-const ELLIPSIS_PATTERN = /(\.\.\.)/gm;
+const THREE_DOTS_PATTERN = /(\.\.\.)/gm;
 function replaceEllipsis( XMLValue ) {
-	return XMLValue.replace( ELLIPSIS_PATTERN, '…' );
+	return XMLValue.replace( THREE_DOTS_PATTERN, '…' );
 }
 
 /**

--- a/bundle/android/strings.xml
+++ b/bundle/android/strings.xml
@@ -104,7 +104,7 @@
     <string name="gutenberg_native_double_tap_and_hold_to_edit" tools:ignore="UnusedResources">Double tap and hold to edit</string>
     <string name="gutenberg_native_double_tap_to_add_a_block" tools:ignore="UnusedResources">Double tap to add a block</string>
     <string name="gutenberg_native_double_tap_to_add_a_link" tools:ignore="UnusedResources">Double tap to add a link.</string>
-    <string name="gutenberg_native_double_tap_to_change_unit" tools:ignore="UnusedResources">double–tap to change unit</string>
+    <string name="gutenberg_native_double_tap_to_change_unit" tools:ignore="UnusedResources">double-tap to change unit</string>
     <string name="gutenberg_native_double_tap_to_edit_button_text" tools:ignore="UnusedResources">Double tap to edit button text</string>
     <string name="gutenberg_native_double_tap_to_edit_label_text" tools:ignore="UnusedResources">Double tap to edit label text</string>
     <string name="gutenberg_native_double_tap_to_edit_placeholder_text" tools:ignore="UnusedResources">Double tap to edit placeholder text</string>
@@ -289,7 +289,7 @@ translators: Block name. %s: The localized block name -->
     <!-- translators: %s: social link name e.g: "Instagram". -->
     <string name="gutenberg_native_s_has_url_set" tools:ignore="UnusedResources">%s has URL set</string>
     <!-- translators: Missing block alert title. %s: The localized block name -->
-    <string name="gutenberg_native_s_is_not_fully_supported" tools:ignore="UnusedResources">\'%s\' is not fully–supported</string>
+    <string name="gutenberg_native_s_is_not_fully_supported" tools:ignore="UnusedResources">\'%s\' is not fully-supported</string>
     <!-- translators: %s: embed block variant's label e.g: "Twitter". -->
     <string name="gutenberg_native_s_link" tools:ignore="UnusedResources">%s link</string>
     <!-- translators: %s: embed block variant's label e.g: "Twitter". -->
@@ -353,8 +353,8 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="gutenberg_native_what_is_alt_text" tools:ignore="UnusedResources">What is alt text?</string>
     <string name="gutenberg_native_width_settings" tools:ignore="UnusedResources">Width Settings</string>
     <string name="gutenberg_native_wordpress_media_library" tools:ignore="UnusedResources">WordPress Media Library</string>
-    <string name="gutenberg_native_x_axis_position" tools:ignore="UnusedResources">X–Axis Position</string>
-    <string name="gutenberg_native_y_axis_position" tools:ignore="UnusedResources">Y–Axis Position</string>
+    <string name="gutenberg_native_x_axis_position" tools:ignore="UnusedResources">X-Axis Position</string>
+    <string name="gutenberg_native_y_axis_position" tools:ignore="UnusedResources">Y-Axis Position</string>
     <string name="gutenberg_native_you_can_edit_this_block_using_the_web_version_of_the_editor" tools:ignore="UnusedResources">You can edit this block using the web version of the editor.</string>
     <string name="gutenberg_native_you_can_rearrange_blocks_by_tapping_a_block_and_then_tapping_the" tools:ignore="UnusedResources">You can rearrange blocks by tapping a block and then tapping the up and down arrows that appear on the bottom left side of the block to move it above or below other blocks.</string>
 </resources>


### PR DESCRIPTION
**Related to https://github.com/wordpress-mobile/gutenberg-mobile/issues/4432.**

This PR improves the string replacements in `strings2android` script, in order to apply different logic for each one. Besides, these changes also update the specific to hyphen symbol replacement, as its original logic didn't match accurately with the Android lint rule implementation.

**To test:**
1. Create a JSON file with `test.json`.
2. Add the following code to the JSON file:
```
{
	"gutenberg": {
		"hyphen case #1": {
			"string": "hyphen case #1: 1-2",
			"platforms": ["android"]
		},
        "hyphen case #2": {
			"string": "hyphen case #2: 1 - 2",
			"platforms": ["android"]
		},
        "hyphen case #3": {
			"string": "hyphen case #3: -1-2",
			"platforms": ["android"]
		},
        "hyphen case #4": {
			"string": "hyphen case #4: -1 - 2",
			"platforms": ["android"]
		},
        "hyphen case #5": {
			"string": "hyphen case #5: 1   - 2",
			"platforms": ["android"]
		},
        "hyphen case #6": {
			"string": "hyphen case #6: 1 -      2",
			"platforms": ["android"]
		},
        "hyphen case #7 (should not replace it)": {
			"string": "hyphen case #7 (should not replace it): 1 -2",
			"platforms": ["android"]
		},
        
        "ellipsis case #1": {
			"string": "ellipsis case #1: Ellipsis...",
			"platforms": ["android"]
		}
	}
}
```
3. Run the command `bin/strings2android.js strings.xml test.json`
4. Check the content of `strings.xml` and observe that all string replacements have been properly applied.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
