### PR TITLE
Renames hideBlockByCapability for clarity

### DIFF
--- a/src/jetpack-editor-setup.js
+++ b/src/jetpack-editor-setup.js
@@ -47,7 +47,7 @@ const setJetpackData = ( {
 	return jetpackEditorInitialState;
 };
 
-const hideBlockByCapability = ( capability, blockName ) => {
+const showBlockByCapability = ( capability, blockName ) => {
 	if ( capability !== true ) {
 		dispatch( editPostStore ).hideBlockTypes( [ blockName ] );
 	} else {
@@ -68,11 +68,11 @@ export function registerJetpackBlocks( { capabilities } ) {
 		return;
 	}
 
-	hideBlockByCapability(
+	showBlockByCapability(
 		capabilities.mediaFilesCollectionBlock,
 		'jetpack/story'
 	);
-	hideBlockByCapability(
+	showBlockByCapability(
 		capabilities.contactInfoBlock,
 		'jetpack/contact-info'
 	);


### PR DESCRIPTION
This PR renames `hideBlockByCapability` to `showBlockByCapability` since, if a block is passed into this method along with a `true` argument, the function's logic is to display the block (not hide it).

To test:

Run locally and verify if Jetpack blocks are still shown correctly according to [their availability](https://github.com/wordpress-mobile/gutenberg-mobile/blob/f63c4a115d6d9e97e7a44c65c45f4e9aa99f6c31/src/jetpack-editor-setup.js#L21-L28) and [their corresponding editor capability's value](https://github.com/wordpress-mobile/gutenberg-mobile/blob/f63c4a115d6d9e97e7a44c65c45f4e9aa99f6c31/src/jetpack-editor-setup.js#L71-L78).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
