### PR TITLE
Fix act warnings triggered after test finishes

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -25,7 +25,13 @@ module.exports = {
 	// Automatically clear mock calls and instances between every test
 	clearMocks: true,
 	preset: './gutenberg/node_modules/react-native/jest-preset.js',
-	setupFiles: [ '<rootDir>/' + configPath + '/setup.js' ],
+	setupFiles: [
+		'<rootDir>/' + configPath + '/setup.js',
+		// Disable React Native Testing Library auto-cleanup to provide our own implementation.
+		// Reference: https://callstack.github.io/react-native-testing-library/docs/migration-v2#auto-cleanup
+		'<rootDir>/gutenberg/node_modules/@testing-library/react-native/dont-cleanup-after-each.js',
+	],
+	setupFilesAfterEnv: [ '<rootDir>/' + configPath + '/setup-after-env.js' ],
 	testMatch: [ '<rootDir>/src/**/test/*.[jt]s?(x)' ],
 	testPathIgnorePatterns: [
 		'/node_modules/',


### PR DESCRIPTION
**Gutenberg PR:** https://github.com/WordPress/gutenberg/pull/38336

This PR updates the Jest configuration to match the same one that is provided to Gutenberg via https://github.com/WordPress/gutenberg/pull/38336 ([reference](https://github.com/WordPress/gutenberg/blob/f9bb733c366687b8df27b20a7b419ec24244d928/test/native/jest.config.js#L28-L34)).

**To test:**
1. Run `npm run test`.
2. Observe that all tests pass.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
