### PR TITLE
Add `setupFilesAfterEnv` to Jest configuration

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -26,6 +26,7 @@ module.exports = {
 	clearMocks: true,
 	preset: './gutenberg/node_modules/react-native/jest-preset.js',
 	setupFiles: [ '<rootDir>/' + configPath + '/setup.js' ],
+	setupFilesAfterEnv: [ '<rootDir>/' + configPath + '/setup-after-env.js' ],
 	testMatch: [ '<rootDir>/src/**/test/*.[jt]s?(x)' ],
 	testPathIgnorePatterns: [
 		'/node_modules/',

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -88,8 +88,6 @@ describe( 'Gutenberg Mobile initialization', () => {
 		} );
 	} );
 
-	describe( 'editor rendering', () => {} );
-
 	it( 'renders the editor', async () => {
 		// Unmock setup module to render the actual editor component.
 		jest.unmock( '@wordpress/react-native-editor/src/setup' );

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -110,7 +110,7 @@ describe( 'Gutenberg Mobile initialization', () => {
 		);
 		const blockList = screen.getByTestId( 'block-list-wrapper' );
 
-		expect( blockList ).toBeDefined();
+		expect( blockList ).toBeVisible();
 		expect( console ).toHaveLoggedWith( 'Hermes is: true' );
 		setupLocaleLogs.forEach( ( log ) =>
 			expect( console ).toHaveLoggedWith( ...log )


### PR DESCRIPTION
Following the [Jest configuration in Gutenberg](https://github.com/WordPress/gutenberg/blob/2747474eec0b0990009f12d0dc6e23d64fef7ec8/test/native/jest.config.js#L29), this PR adds the reference to the [`setup-after-env.js` file](https://github.com/WordPress/gutenberg/blob/trunk/test/native/setup-after-env.js), which allows us to use the custom matcher `toBeVisible`.

Additionally, the editor rendering test has been updated to use the custom matcher `toBeVisible`.

**To test:**
- Run the command `npm run test` and observe that all tests pass.
- Check that all PR checks pass.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
