### PR TITLE
Prevent bold headings after autocorrection

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,10 +1,10 @@
 Unreleased
 ---
+* [*] Fix autocorrected Headings applying bold formatting on iOS [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4557]
 
 1.71.1
 ---
 * [*] Highlight text: Check if style attribute value is defined during filtering [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4562]
-* [*] Fix autocorrected Headings applying bold formatting on iOS [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4557]
 
 1.71.0
 ---

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@ Unreleased
 1.71.1
 ---
 * [*] Highlight text: Check if style attribute value is defined during filtering [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4562]
+* [*] Fix autocorrected Headings applying bold formatting on iOS [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4557]
 
 1.71.0
 ---

--- a/RNTAztecView.podspec
+++ b/RNTAztecView.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.xcconfig         = {'OTHER_LDFLAGS' => '-lxml2',
                         'HEADER_SEARCH_PATHS' => '/usr/include/libxml2'}
   s.dependency         'React-Core'
-  s.dependency         'WordPress-Aztec-iOS', '~> 1.19.7'
+  s.dependency         'WordPress-Aztec-iOS', '~> 1.19.8'
 
 end


### PR DESCRIPTION
Fixes #4063

## Related PRs:
- https://github.com/WordPress/gutenberg/pull/38633
- https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1334
- https://github.com/wordpress-mobile/WordPress-iOS/pull/17844
- https://github.com/wordpress-mobile/test-cases/pull/111

## To test:

### Heading with no formatting

1. In the demo app, add a new heading. Ensure no formatting is applied (the default settings).
2. Type a sentence that will be autocorrected, such as: "Hello i'm testing"

**Expectations:**
-  The sentence is autocorrected (e.g. "Hello I'm testing").
- The autocorrected word (e.g. "I'm") does not have bold formatting enabled (the B in the formatting toolbar is not depressed).
- When placing the cursor inside the autocorrected word it does not have bold formatting enabled.
- In HTML mode the autocorrected word is not wrapped in `<strong>` tags:

```
<!-- wp:heading -->
<h2>Hello I’m testing</h2>
<!-- /wp:heading -->
```

### Heading with bold formatting

1. In the demo app, add a new heading and apply bold formatting by pressing the **B** on the formatting toolbar.
2. Type a sentence that will be autocorrected, such as: "Hello i'm testing"

**Expectations:**
-  The sentence is autocorrected (e.g. "Hello I'm testing").
- The autocorrected word (e.g. "I'm") has bold formatting enabled (the B in the formatting toolbar is depressed).
- When placing the cursor inside the autocorrected word it has bold formatting enabled.
- In HTML mode the heading's text content is wrapped in `<strong>` tags:

```
<!-- wp:heading -->
<h2><strong>Hello I’m testing a heading</strong></h2>
<!-- /wp:heading -->
```

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
