### PR TITLE
Point VSCode launch config to react-native-editor root

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
     "configurations": [
         {
             "name": "Attach to packager",
-            "cwd": "${workspaceFolder}",
+            "cwd": "${workspaceFolder}/gutenberg/packages/react-native-editor",
             "type": "reactnative",
             "request": "attach"
         },


### PR DESCRIPTION
Currently, trying to start (attach) the debugger provided by the `vscode-react-native` extension ends up in error because the extension doesn't detect the gutenberg-mobile root as the RN app root. Error:

```
An error occurred while attaching debugger to the application. Seems to be that you are trying to debug from within directory that is not a React Native project root. 
 If so, please, follow these instructions: [https://github.com/microsoft/vscode-react-native#customization]() (error code 604) (error code 1410)
```

<img width="296" alt="Screenshot 2022-02-11 at 15 43 13" src="https://user-images.githubusercontent.com/1032913/153602549-e53b3c13-01ec-4e8b-93bf-9bb6684e5f12.png">

This PR updates the launch configuration to point to the react-native-editor package root, making the extension happy.

### To test:

0. In a terminal, start Metro (`npm ci` followed by `npm run start:reset`), and possibly the demo app as well (`npm run core android`)
1. Open VSCode from the root of the gutenberg-mobile checkout
2. Git the F5 key or use the "Run > Start Debugging" menu action to attach the debugger.
3. No error should be presented by VSCode, and a `Established a connection with the Proxy (Packager) to the React Native application` message should be visible in the "DEBUG CONSOLE" pane in VSCode
4. If you want to test further, place a breakpoint in https://github.com/wordpress-mobile/gutenberg-mobile/blob/9e667f925fc1f133b608496994412b2f66932c2e/src/index.js#L28
5. In the demo app, open the debug menu and hit "Debug"
6. Some moments later, debugger should break at the line above.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
