### PR TITLE
jetpack pointed to shared extension folder migration branch for CI test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -61,7 +61,7 @@ module.exports = {
 		// See: https://github.com/wordpress-mobile/gutenberg-mobile/pull/257#discussion_r234978268
 		// There is no overloading in jest so we need to rewrite the config from react-native-jest-preset:
 		// https://github.com/facebook/react-native/blob/master/jest-preset.json#L20
-		'node_modules/(?!(simple-html-tokenizer|@react-native-community|(jest-)?react-native|@react-native|react-clone-referenced-element|@automattic/jetpack-shared-extension-utils))',
+		'node_modules/(?!(simple-html-tokenizer|@react-native-community|(jest-)?react-native|@react-native|react-clone-referenced-element|jetpack-shared-extension-utils))',
 	],
 	reporters: [ 'default', 'jest-junit' ],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -58,7 +58,7 @@ module.exports = {
 	},
 	transform: {
 		'^.+\\.(js|jsx|ts|tsx)$': 'babel-jest',
-	  },
+	},
 	transformIgnorePatterns: [
 		// This is required for now to have jest transform some of our modules
 		// See: https://github.com/wordpress-mobile/gutenberg-mobile/pull/257#discussion_r234978268

--- a/jest.config.js
+++ b/jest.config.js
@@ -57,7 +57,7 @@ module.exports = {
 		platforms: [ 'android', 'ios', 'native' ],
 	},
 	transform: {
-		'^.+\\.(js|jsx|ts|tsx)$': 'babel-jest'
+		'^.+\\.(js|jsx|ts|tsx)$': 'babel-jest',
 	  },
 	transformIgnorePatterns: [
 		// This is required for now to have jest transform some of our modules

--- a/jest.config.js
+++ b/jest.config.js
@@ -56,12 +56,15 @@ module.exports = {
 		defaultPlatform: rnPlatform,
 		platforms: [ 'android', 'ios', 'native' ],
 	},
+	transform: {
+		'^.+\\.(js|jsx|ts|tsx)$': 'babel-jest'
+	  },
 	transformIgnorePatterns: [
 		// This is required for now to have jest transform some of our modules
 		// See: https://github.com/wordpress-mobile/gutenberg-mobile/pull/257#discussion_r234978268
 		// There is no overloading in jest so we need to rewrite the config from react-native-jest-preset:
 		// https://github.com/facebook/react-native/blob/master/jest-preset.json#L20
-		'node_modules/(?!(simple-html-tokenizer|@react-native-community|(jest-)?react-native|@react-native|react-clone-referenced-element|jetpack-shared-extension-utils))',
+		'node_modules/(?!(simple-html-tokenizer|@react-native-community|(jest-)?react-native|@react-native|react-clone-referenced-element))',
 	],
 	reporters: [ 'default', 'jest-junit' ],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -61,7 +61,7 @@ module.exports = {
 		// See: https://github.com/wordpress-mobile/gutenberg-mobile/pull/257#discussion_r234978268
 		// There is no overloading in jest so we need to rewrite the config from react-native-jest-preset:
 		// https://github.com/facebook/react-native/blob/master/jest-preset.json#L20
-		'node_modules/(?!(simple-html-tokenizer|@react-native-community|(jest-)?react-native|@react-native|react-clone-referenced-element))',
+		'node_modules/(?!(simple-html-tokenizer|@react-native-community|(jest-)?react-native|@react-native|react-clone-referenced-element|@automattic/jetpack-shared-extension-utils))',
 	],
 	reporters: [ 'default', 'jest-junit' ],
 };

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,8 +1,13 @@
 const path = require( 'path' );
 const fs = require( 'fs' );
 
+const gutenbergMetroConfig = require( './gutenberg/packages/react-native-editor/metro.config.js' );
 const gutenbergMetroConfigCopy = {
-	...require( './gutenberg/packages/react-native-editor/metro.config.js' ),
+	...gutenbergMetroConfig,
+	resolver: {
+		...gutenbergMetroConfig.resolver,
+		sourceExts: [ 'js', 'jsx', 'json', 'scss', 'sass', 'ts', 'tsx' ],
+	},
 };
 
 gutenbergMetroConfigCopy.resolver.extraNodeModules = new Proxy(


### PR DESCRIPTION
Fixes #
This PR was created for testing [migration](https://github.com/Automattic/jetpack/pull/22758) of with-has-warning-is-interactive-class-names folder. This led to a couple of issues. Jest was not transpiling shared-extension-utils folder properly as it had .jsx file and metro bundler was not resolving index.jsx as it was only looking for .js|.ts|.tsx files.

Relevant discussions: p1645194383560999-slack-C02HQGKMFJ8
p1645014582668279-slack-C6UJ0KRKQ

NOTE: Need to revert jetpack submodule branch changes before merge

To test:
Make sure the CI gods are happy :)

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.