### PR TITLE
Fix Custom Palette colors and support multiple origins and theme cache issues

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 Unreleased
 ---
 * [*] Fix autocorrected Headings applying bold formatting on iOS [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4557]
+* [***] Support for multiple color palettes [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4588]
 
 1.71.1
 ---


### PR DESCRIPTION
- `Gutenberg PR` -> https://github.com/WordPress/gutenberg/pull/38417

Fixes https://github.com/WordPress/gutenberg/issues/38525 and https://github.com/WordPress/gutenberg/issues/36152

This is a follow-up of https://github.com/WordPress/gutenberg/pull/38474

## Description

This PR fixes several issues, first, it fixes an ongoing issue where changing between themes would not refresh the current theme data and a restart of the editor was needed, as well as sometimes opening the editor for the first time and not seeing the theme colors.

Second, it adds support for multiple color and gradient palettes including the `Custom` ones.

To test check the Gutenberg PR description.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/RELEASE-NOTES.txt) if necessary.
