### PR TITLE
Note to run the full local testsuite at least once

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ and for Android:
 
 `npm run test:e2e:android:local`
 
+**Note:** Make sure you've run the above commands at least once, so the demo app binaries are built before running individual tests below.
+
 To run a single test instead of the entire suite, use `npm run device-tests:local`. Here's an example that runs only `gutenberg-editor-paragraph.test`:
 
 `TEST_RN_PLATFORM=ios npm run device-tests:local gutenberg-editor-paragraph.test`


### PR DESCRIPTION
If one tries to run specific Appium tests locally without having run the full testsuite first, the app binary is not built and the run fails with:

```
An unknown server-side error occurred while processing the command. Original error: Bad app: .../gutenberg/packages/react-native-editor/ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app. App paths need to be absolute or an URL to a compressed app file: The application at '.../gutenberg/packages/react-native-editor/ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app' does not exist or is not accessible
```

This PR adds a small note to the README to nudge to run the full testsuite first since those npm scripts will also build the app first.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
