### PR TITLE
Address failing mobile tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@automattic/jetpack-base-styles": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@automattic/jetpack-base-styles/-/jetpack-base-styles-0.3.0.tgz",
+			"integrity": "sha512-pvHY3G2rMjIChA1+AybDnGrclr32Jbj1TOinuvEzronwsTbFYXNX4p5pkoc0x7c6Kui8Nzs00oH1msReQqDDFQ=="
+		},
 		"@babel/code-frame": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,12 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@automattic/jetpack-base-styles": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@automattic/jetpack-base-styles/-/jetpack-base-styles-0.3.0.tgz",
-			"integrity": "sha512-pvHY3G2rMjIChA1+AybDnGrclr32Jbj1TOinuvEzronwsTbFYXNX4p5pkoc0x7c6Kui8Nzs00oH1msReQqDDFQ==",
-			"dev": true
-		},
 		"@babel/code-frame": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
 		"@automattic/jetpack-base-styles": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/@automattic/jetpack-base-styles/-/jetpack-base-styles-0.3.0.tgz",
-			"integrity": "sha512-pvHY3G2rMjIChA1+AybDnGrclr32Jbj1TOinuvEzronwsTbFYXNX4p5pkoc0x7c6Kui8Nzs00oH1msReQqDDFQ=="
+			"integrity": "sha512-pvHY3G2rMjIChA1+AybDnGrclr32Jbj1TOinuvEzronwsTbFYXNX4p5pkoc0x7c6Kui8Nzs00oH1msReQqDDFQ==",
+			"dev": true
 		},
 		"@babel/code-frame": {
 			"version": "7.8.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
 		"npm": ">=6.9.0 <7"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-base-styles": "^0.3.0",
 		"@babel/core": "^7.14.3",
 		"@babel/runtime": "^7.14.0",
 		"@react-native-community/cli": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -94,5 +94,6 @@
 		"lint": "eslint . --ext .js",
 		"lint:fix": "npm run lint -- --fix",
 		"version": "npm run bundle && git add -A bundle"
-	}
+	},
+	"dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"npm": ">=6.9.0 <7"
 	},
 	"devDependencies": {
+		"@automattic/jetpack-base-styles": "^0.3.0",
 		"@babel/core": "^7.14.3",
 		"@babel/runtime": "^7.14.0",
 		"@react-native-community/cli": "^6.0.0",
@@ -93,8 +94,5 @@
 		"lint": "eslint . --ext .js",
 		"lint:fix": "npm run lint -- --fix",
 		"version": "npm run bundle && git add -A bundle"
-	},
-	"dependencies": {
-		"@automattic/jetpack-base-styles": "^0.3.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -94,5 +94,7 @@
 		"lint:fix": "npm run lint -- --fix",
 		"version": "npm run bundle && git add -A bundle"
 	},
-	"dependencies": {}
+	"dependencies": {
+		"@automattic/jetpack-base-styles": "^0.3.0"
+	}
 }


### PR DESCRIPTION
Fixes a recent breakage in the native build, which can be viewed here: https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/17096/workflows/37583660-a955-4550-ac07-9fdab16dd5b8/jobs/93001

<details>
<summary>The error logs associated with this breakage can be viewed here, and is related to files that were moved in #23817. ⤵︎</summary>

```
error jetpack/projects/plugins/jetpack/extensions/shared/icons.scss: @**********/jetpack-base-styles/gutenberg-base-styles could not be resolved in /home/circleci/project/jetpack/projects/plugins/jetpack/extensions/shared/@**********/jetpack-base-styles,/home/circleci/project,jetpack/projects/plugins/jetpack/extensions/shared,/home/circleci/project/gutenberg/packages/react-native-editor/src,/home/circleci/project/gutenberg/packages/base-styles
  ╷
9 │ @import '@**********/jetpack-base-styles/gutenberg-base-styles';
  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ╵
  stdin 9:9  root stylesheet.
Error: @**********/jetpack-base-styles/gutenberg-base-styles could not be resolved in /home/circleci/project/jetpack/projects/plugins/jetpack/extensions/shared/@**********/jetpack-base-styles,/home/circleci/project,jetpack/projects/plugins/jetpack/extensions/shared,/home/circleci/project/gutenberg/packages/react-native-editor/src,/home/circleci/project/gutenberg/packages/base-styles
  ╷
9 │ @import '@**********/jetpack-base-styles/gutenberg-base-styles';
  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ╵
  stdin 9:9  root stylesheet

```
</details>

### Related PRs

* `Jetpack:` https://github.com/Automattic/jetpack/pull/24020

### Testing

Please refer to [the Jetpack PR](https://github.com/Automattic/jetpack/pull/24020) for the most up-to-date description and testing instructions.

<hr />

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
