### PR TITLE
Release 1.75.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,8 +1,6 @@
 Unreleased
 ---
 
-## Unreleased
-
 ## 1.75.0
 ---
 * [*] [Latest Posts block] Add featured image settings [https://github.com/WordPress/gutenberg/pull/39257]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,19 @@
 Unreleased
 ---
 
+## Unreleased
+
+## 1.75.0
+---
+* [*] [Latest Posts block] Add featured image settings [https://github.com/WordPress/gutenberg/pull/39257]
+* [*] Prevent incorrect notices displaying when switching between HTML-Visual mode quickly [https://github.com/WordPress/gutenberg/pull/40415]
+* [*] [Embed block] Fix inline preview cut-off when editing URL [https://github.com/WordPress/gutenberg/pull/35326]
+* [*] [iOS] Prevent gaps shown around floating toolbar when using external keyboard [https://github.com/WordPress/gutenberg/pull/40266]
+
+## 1.74.1
+---
+* [**] RichText - Set a default value for selection values [https://github.com/WordPress/gutenberg/pull/40581]
+
 ## 1.74.0
 ---
 * [**] [Quote block] Adds support for V2 behind a feature flag [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4744]

--- a/bundle/android/strings.xml
+++ b/bundle/android/strings.xml
@@ -13,8 +13,7 @@
     <string name="gutenberg_native_add_block_after" tools:ignore="UnusedResources">Add Block After</string>
     <string name="gutenberg_native_add_block_before" tools:ignore="UnusedResources">Add Block Before</string>
     <string name="gutenberg_native_add_block_here" tools:ignore="UnusedResources">ADD BLOCK HERE</string>
-    <string name="gutenberg_native_add_blocks" tools:ignore="UnusedResources">Add Blocks</string>
-    <string name="gutenberg_native_add_blocks_11d0841f" tools:ignore="UnusedResources">Add blocks</string>
+    <string name="gutenberg_native_add_blocks" tools:ignore="UnusedResources">Add blocks</string>
     <string name="gutenberg_native_add_button_text" tools:ignore="UnusedResources">Add button text</string>
     <string name="gutenberg_native_add_image" tools:ignore="UnusedResources">ADD IMAGE</string>
     <string name="gutenberg_native_add_image_or_video" tools:ignore="UnusedResources">ADD IMAGE OR VIDEO</string>

--- a/bundle/ios/GutenbergNativeTranslations.swift
+++ b/bundle/ios/GutenbergNativeTranslations.swift
@@ -24,7 +24,6 @@ private func dummy() {
     _ = NSLocalizedString("Add Block Before", comment: "")
     _ = NSLocalizedString("ADD BLOCK HERE", comment: "")
     _ = NSLocalizedString("Add blocks", comment: "")
-    _ = NSLocalizedString("Add Blocks", comment: "")
     _ = NSLocalizedString("Add button text", comment: "")
     _ = NSLocalizedString("ADD IMAGE", comment: "")
     _ = NSLocalizedString("Add image or video", comment: "")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg-mobile",
-	"version": "1.74.0",
+	"version": "1.75.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg-mobile",
-	"version": "1.74.0",
+	"version": "1.75.0",
 	"private": true,
 	"config": {
 		"jsfiles": "./*.js src/*.js src/**/*.js src/**/**/*.js",


### PR DESCRIPTION
Release for Gutenberg Mobile 1.75.0

## Related PRs

- Gutenberg: https://github.com/WordPress/gutenberg/pull/40630
- WPAndroid: https://github.com/wordpress-mobile/WordPress-Android/pull/16410
- WPiOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/18451

## Extra PRs that Landed After the Release Was Cut

No extra PRs yet. 🎉

## Changes

<!-- To determine the changes you can check the RELEASE-NOTES.txt and gutenberg/packages/react-native-editor/CHANGELOG.md files and cross check with the list of commits that are part of the PR -->

### User-facing changes 

#### Change 1 - KeyboardAvoidingView - Set a background color for the toolbar container
- **PR:** https://github.com/WordPress/gutenberg/pull/40266
- **Issue:** https://github.com/wordpress-mobile/gutenberg-mobile/issues/4370

Fixes an issue that could be seen on iPads, where the floating toolbar that's used when an external keyboard is in use left a gap at the bottom of the screen. The floating toolbar now has a set background colour.

#### Change 2 - Embed block - Fix inline preview cut-off when editing URL
- **PR:** https://github.com/WordPress/gutenberg/pull/35326
- **Issue:** https://github.com/wordpress-mobile/gutenberg-mobile/issues/4059

#### Change 3 - Notice list - Code improvements and bug fixes
- **PR:** https://github.com/WordPress/gutenberg/pull/40415
- **Issue:** https://github.com/wordpress-mobile/WordPress-iOS/issues/18036 and https://github.com/wordpress-mobile/WordPress-Android/issues/15643

#### Change 4 - Add featured image settings to the Latest Posts block
- **PR:** https://github.com/WordPress/gutenberg/pull/39257
- **Issue:** https://github.com/wordpress-mobile/gutenberg-mobile/issues/4034

#### Change 5 - HTML View - Add a top margin for the title
- **PR:** https://github.com/WordPress/gutenberg/pull/40312
- **Issue:** https://github.com/wordpress-mobile/gutenberg-mobile/issues/4351

### Internal-only and code improvements

#### Change 6 - Add constants file to Spacer block
- **PR:** https://github.com/WordPress/gutenberg/pull/40446
- **Issue:** A follow up to this comment: https://github.com/WordPress/gutenberg/pull/40053#discussion_r851230469

#### Change 7 - Set "expanded" version of inserter's "add blocks" text to title case
- **PR:** https://github.com/WordPress/gutenberg/pull/40550
- **Issue:** N/A

#### Change 8 - RichText - Set a default value for selection values
- **PR:** https://github.com/WordPress/gutenberg/pull/40581
- **Issue:** https://github.com/WordPress/gutenberg/issues/40545

#### Change 9 - Upgrade to AztecAndroid 1.5.7
- **PR:** https://github.com/WordPress/gutenberg/pull/40099
- **Issue:** N/A

#### Change 10 - Prevent unnecessary re-renders of RichText component due to color palettes prop
- **PR:** https://github.com/WordPress/gutenberg/pull/40615
- **Issue:** https://github.com/WordPress/gutenberg/issues/39955

#### Change 11 -
- **PR:** https://github.com/WordPress/gutenberg/pull/40404
- **Issue:** N/A

## Test plan

Once the installable builds of the main apps are ready, perform a quick smoke test of the editor on both iOS and Android to verify it launches without crashing. We will perform additional testing after the main apps cut their releases.

## Release Submission Checklist

- [ ] Verify Items from test plan have been completed
- [ ] Check if `RELEASE-NOTES.txt` is updated with all the changes that made it to the release. Replace `Unreleased` section with the release version and create a new `Unreleased` section.
- [ ] Check if `gutenberg/packages/react-native-editor/CHANGELOG.md` is updated with all the changes that made it to the release. Replace `## Unreleased` with the release version and create a new `## Unreleased`.
- [ ] Bundle package of the release is updated.