### PR TITLE
Remove WordPress.com tour banner from view in UBE

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,6 @@ Unreleased
 ---
 * [**] [Cover block] Improve color contrast between background and text [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4808]
 * [**] [Buttons block] Fix Android-only issue related to displaying formatting buttons after closing the block settings [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4814]
-
 * [*] [Unsupported Block Editor] Prevent WordPress.com tour banner from displaying. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4820]
 
 ## 1.75.0

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,8 @@
 Unreleased
 ---
 
+* [*] [Unsupported Block Editor] Prevent WordPress.com tour banner from displaying. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4820]
+
 ## 1.75.0
 ---
 * [*] [Latest Posts block] Add featured image settings [https://github.com/WordPress/gutenberg/pull/39257]

--- a/resources/unsupported-block-editor/external-style-overrides.css
+++ b/resources/unsupported-block-editor/external-style-overrides.css
@@ -4,6 +4,6 @@
 }
 
 /* Remove WordPress.com "tour" pop-up. */
-.wpcom-tour-kit .tour-kit-frame__container {
+.tour-kit-frame__container {
 	display: none;
 }

--- a/resources/unsupported-block-editor/external-style-overrides.css
+++ b/resources/unsupported-block-editor/external-style-overrides.css
@@ -2,3 +2,8 @@
 .a8c-faux-inline-help {
 	display: none;
 }
+
+/* Remove WordPress.com "tour" pop-up. */
+.wpcom-tour-kit .tour-kit-frame__container {
+	display: none;
+}


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4079

## What?

This PR removes the WordPress.com tour banner that sometimes pops up when opening the unsupported block editor (UBE).

| Before  | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/2998162/166571975-8f2df35b-0fcd-42f6-90a6-3d4e320ee970.png" width="100%"> | <img src="https://user-images.githubusercontent.com/2998162/166571113-39f9527d-5276-4b40-b87a-173df0484f35.png" width="100%"> |

_Note, the cookie banner remains as I'm assuming it'd be necessary to get the thumbs up from legal before hiding it and it's not as disruptive as the tour banner._

## Why?

The tour banner is specific to the web version of the editor, it's therefore confusing and distracting within the UBE.

## How?

Previously, as part of the changes in https://github.com/wordpress-mobile/gutenberg-mobile/pull/4352, [the `external-style-overrides.css` file](https://github.com/wordpress-mobile/gutenberg-mobile/blob/3fbea3f96c8fdf83cea89cae08c088d687ab5023/resources/unsupported-block-editor/external-style-overrides.css) was created for the purpose of "housing" CSS that didn't belong in the Gutenberg repository. It has a Gutenberg equivalent [here](https://github.com/WordPress/gutenberg/blob/da176fa9cbd19c3ed04be993563a3229063442e7/packages/react-native-bridge/common/gutenberg-web-single-block/editor-style-overrides.css).

Following the approach we've taken to hide other elements in the UBE, this PR adds CSS to the `external-style-overrides.css` that targets the tour banner and hides it from view.

## Testing Instructions

_This may be only reproducible on a new WordPress.com site, since the popup might only be shown once._

1. Locate a post that contains an unsupported block (e.g. Calendar at time of writing)
2. Open the post and expect to see the block rendered as a placeholder with the text "Unsupported"
3. Tap the (?) icon and expect the option to edit the block in a web browser to be shown
4. Tap the edit in a web browser button and expect the block to be shown, confirm that the "Welcome to WordPress!" banner is no longer visible

<hr />

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
