### PR TITLE
Fix pnpm version issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"wd": "^1.11.1"
 	},
 	"scripts": {
-		"postinstall": "patch-package && npm ci --prefix gutenberg && npm run i18n:check-cache && cd jetpack/projects/plugins/jetpack && npx pnpm install",
+		"postinstall": "patch-package && npm ci --prefix gutenberg && npm run i18n:check-cache && cd jetpack/projects/plugins/jetpack && npx pnpm@6 install",
 		"start": "echo \"\\x1b[33mThe start command is not available in this project. It is strongly recommended to use \\x1b[1:33mstart:reset\\x1b[0m\\x1b[33m to perform some cleanup when starting the metro bundler.\nOr you may use \\x1b[1:33mstart:quick\\x1b[0m\\x1b[33m for a quicker startup, but this may lead to unexpected javascript errors when running the app.\\x1b[0m\"",
 		"start:reset": "npm run core clean:runtime && npm run start:quick -- --reset-cache",
 		"start:quick": "react-native start --config ./metro.config.js",


### PR DESCRIPTION
Fixes npm post install script by forcing `npx` to use `pnpm` at `v6`.

Jetpack currently uses `pnpm` at `^6.23.6` and `pnpm` recently released `7.0.0` which `npx` will install.  

To test:
- Verify that `npm install` succeeds
- CI "Check Correctness" step succeeds

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
