### PR TITLE
Track block movement actions

### DIFF
--- a/src/analytics/redux/tracked_events.js
+++ b/src/analytics/redux/tracked_events.js
@@ -64,6 +64,51 @@ function trackBlocksHandler(
 	} );
 }
 
+/**
+ * Helper function to track block movement events.
+ *
+ * @param {string[]} clientIds The client IDs of the blocks being moved
+ * @param {string}   action    Type of movement (arrows/drag & drop)
+ * @return {void}
+ */
+function trackBlockMoved( clientIds, action ) {
+	const block = select( 'core/block-editor' ).getBlock( clientIds?.[ 0 ] );
+
+	if ( block ) {
+		const eventProperties = {
+			action_source: action,
+			inner_block: !! block.innerBlocks.length,
+			block_name: block.name,
+		};
+
+		sendEventToHost( 'editor_block_moved', eventProperties );
+	}
+}
+
+/**
+ * Helper function to handle when a block is moved by an index position
+ *
+ * @param {string[]} clientIds The client IDs of the blocks being moved
+ * @param {number}   toIndex   Index of the new position of the block
+ * @return {void}
+ */
+function handleBlockMovedByPosition( clientIds, toIndex ) {
+	const lastBlockIndex = select( 'core/block-editor' ).getBlockCount() - 1;
+	const currentBlockIndex = select( 'core/block-editor' ).getBlockIndex(
+		clientIds?.[ 0 ]
+	);
+
+	if ( currentBlockIndex >= 0 ) {
+		if ( toIndex > currentBlockIndex && toIndex === lastBlockIndex ) {
+			// The block was moved to the bottom of the editor
+			trackBlockMoved( clientIds, 'move_arrows_to_bottom' );
+		} else if ( toIndex < currentBlockIndex && toIndex === 0 ) {
+			// The block was moved to the top of the editor
+			trackBlockMoved( clientIds, 'move_arrows_to_top' );
+		}
+	}
+}
+
 export const trackedEvents = {
 	'core/block-editor': {
 		insertBlock( blocks ) {
@@ -79,6 +124,28 @@ export const trackedEvents = {
 				'editor_block_inserted',
 				( { name } ) => ( { block_name: name } )
 			);
+		},
+		moveBlocksUp( clientIds ) {
+			trackBlockMoved( clientIds, 'move_arrows_up' );
+		},
+		moveBlocksDown( clientIds ) {
+			trackBlockMoved( clientIds, 'move_arrows_down' );
+		},
+		moveBlocksToPosition(
+			clientIds,
+			_fromRootClientId,
+			_toRootClientId,
+			toIndex
+		) {
+			const isDraggingBlock = select(
+				'core/block-editor'
+			).isDraggingBlocks();
+
+			if ( isDraggingBlock ) {
+				trackBlockMoved( clientIds, 'drag_and_drop' );
+			} else {
+				handleBlockMovedByPosition( clientIds, toIndex );
+			}
 		},
 	},
 };


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4831

- `WordPress iOS PR` -> https://github.com/wordpress-mobile/WordPress-iOS/pull/18530
- `WordPress Android PR` -> https://github.com/wordpress-mobile/WordPress-Android/pull/16485

**Note**: The bundle and Gutenberg reference changes are included to be able to test the drag & drop event, those will not be included once this is approved and ready to be merged.

This PR adds a new event `editor_block_moved` that is triggered when a block is moved by either:
- Tapping on the up/down arrow button in the block toolbar.
- Long-pressing on the up/down arrow button and moving a block to the top or bottom.
- Drag & drop

The event has the following properties:
- `action_source` which can be:
  - `move_arrows_up` when a block is moved using the up arrow button.
  - `move_arrows_down` when a block is moved using the down arrow button.
  - `move_arrows_to_top` when a block is moved to the top by long-pressing on the up arrow button.
  - `move_arrows_to_bottom` when a block is moved to the bottom by long-pressing on the down arrow button.
  - `drag_and_drop` when a block is moved using the drag & drop blocks feature.
- `block_name` name of the block that is being moved.
- `inner_block` if it has inner blocks or not.

Once this is merged, it will only track when a block is moved using the up/down arrow buttons, since the drag & drop blocks feature is not merged yet.

## To test

**Builds**:
- [iOS](https://github.com/wordpress-mobile/WordPress-iOS/pull/18530#issuecomment-1119701117)
- [Android](https://github.com/wordpress-mobile/WordPress-Android/pull/16485#issuecomment-1119691299)

### Move a block by tapping on the up/down arrow buttons

- Open the app using the builds linked above.
- Create a new post/page
- Add some blocks
- Select a block and tap the up/down arrow buttons within the block toolbar.
- Using the live event page, **expect** the event `wp(ios|android)_editor_block_moved` to arrive successfully with the properties `action_source` containing: `move_arrows_(up|down)`, `inner_block` and, `block_name`.

### Move a block by long-pressing on the up/down arrow buttons

- Open the app using the builds linked above.
- Create a new post/page
- Add some blocks
- Select a block and long-press on the up/down arrow buttons within the block toolbar.
- Select either `Move to the top` or `Move to the bottom`.
- Using the live event page, **expect** the event `wp(ios|android)_editor_block_moved` to arrive successfully with the properties `action_source` containing: `move_arrows_to_(top|bottom)`, `inner_block` and, `block_name`.

### Move a block using the drag & drop blocks feature

- Open the app using the builds linked above.
- Create a new post/page
- Add some blocks
- Drag & drop a block
- Using the live event page, **expect** the event `wp(ios|android)_editor_block_moved` to arrive successfully with the properties `action_source` containing: `drag_and_drop, `inner_block` and, `block_name`.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
