### PR TITLE
Release 1.75.1

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,10 @@
 Unreleased
 ---
 
+## 1.75.1
+---
+* [*] Track block movement actions [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4833]
+
 ## 1.75.0
 ---
 * [*] [Latest Posts block] Add featured image settings [https://github.com/WordPress/gutenberg/pull/39257]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg-mobile",
-	"version": "1.75.0",
+	"version": "1.75.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg-mobile",
-	"version": "1.75.0",
+	"version": "1.75.1",
 	"private": true,
 	"config": {
 		"jsfiles": "./*.js src/*.js src/**/*.js src/**/**/*.js",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"wd": "^1.11.1"
 	},
 	"scripts": {
-		"postinstall": "patch-package && npm ci --prefix gutenberg && npm run i18n:check-cache && cd jetpack/projects/plugins/jetpack && npx pnpm install",
+		"postinstall": "patch-package && npm ci --prefix gutenberg && npm run i18n:check-cache && cd jetpack/projects/plugins/jetpack && npx pnpm@6 install",
 		"start": "echo \"\\x1b[33mThe start command is not available in this project. It is strongly recommended to use \\x1b[1:33mstart:reset\\x1b[0m\\x1b[33m to perform some cleanup when starting the metro bundler.\nOr you may use \\x1b[1:33mstart:quick\\x1b[0m\\x1b[33m for a quicker startup, but this may lead to unexpected javascript errors when running the app.\\x1b[0m\"",
 		"start:reset": "npm run core clean:runtime && npm run start:quick -- --reset-cache",
 		"start:quick": "react-native start --config ./metro.config.js",

--- a/src/analytics/redux/tracked_events.js
+++ b/src/analytics/redux/tracked_events.js
@@ -64,6 +64,51 @@ function trackBlocksHandler(
 	} );
 }
 
+/**
+ * Helper function to track block movement events.
+ *
+ * @param {string[]} clientIds The client IDs of the blocks being moved
+ * @param {string}   action    Type of movement (arrows/drag & drop)
+ * @return {void}
+ */
+function trackBlockMoved( clientIds, action ) {
+	const block = select( 'core/block-editor' ).getBlock( clientIds?.[ 0 ] );
+
+	if ( block ) {
+		const eventProperties = {
+			action_source: action,
+			inner_block: !! block.innerBlocks.length,
+			block_name: block.name,
+		};
+
+		sendEventToHost( 'editor_block_moved', eventProperties );
+	}
+}
+
+/**
+ * Helper function to handle when a block is moved by an index position
+ *
+ * @param {string[]} clientIds The client IDs of the blocks being moved
+ * @param {number}   toIndex   Index of the new position of the block
+ * @return {void}
+ */
+function handleBlockMovedByPosition( clientIds, toIndex ) {
+	const lastBlockIndex = select( 'core/block-editor' ).getBlockCount() - 1;
+	const currentBlockIndex = select( 'core/block-editor' ).getBlockIndex(
+		clientIds?.[ 0 ]
+	);
+
+	if ( currentBlockIndex >= 0 ) {
+		if ( toIndex > currentBlockIndex && toIndex === lastBlockIndex ) {
+			// The block was moved to the bottom of the editor
+			trackBlockMoved( clientIds, 'move_arrows_to_bottom' );
+		} else if ( toIndex < currentBlockIndex && toIndex === 0 ) {
+			// The block was moved to the top of the editor
+			trackBlockMoved( clientIds, 'move_arrows_to_top' );
+		}
+	}
+}
+
 export const trackedEvents = {
 	'core/block-editor': {
 		insertBlock( blocks ) {
@@ -79,6 +124,28 @@ export const trackedEvents = {
 				'editor_block_inserted',
 				( { name } ) => ( { block_name: name } )
 			);
+		},
+		moveBlocksUp( clientIds ) {
+			trackBlockMoved( clientIds, 'move_arrows_up' );
+		},
+		moveBlocksDown( clientIds ) {
+			trackBlockMoved( clientIds, 'move_arrows_down' );
+		},
+		moveBlocksToPosition(
+			clientIds,
+			_fromRootClientId,
+			_toRootClientId,
+			toIndex
+		) {
+			const isDraggingBlock = select(
+				'core/block-editor'
+			).isDraggingBlocks();
+
+			if ( isDraggingBlock ) {
+				trackBlockMoved( clientIds, 'drag_and_drop' );
+			} else {
+				handleBlockMovedByPosition( clientIds, toIndex );
+			}
 		},
 	},
 };


### PR DESCRIPTION
Release for Gutenberg Mobile 1.75.1

## Related PRs

- Gutenberg: https://github.com/WordPress/gutenberg/pull/40974 there are no Gutenberg changes but to keep versions consistent, this PR will only update the version to `1.75.1`.
- WPAndroid: https://github.com/wordpress-mobile/WordPress-Android/pull/16515
- WPiOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/18553

- Aztec-iOS: N/A
- Aztec-Android: N/A

## Extra PRs that Landed After the Release Was Cut

No extra PRs yet. 🎉

## Changes

<!-- To determine the changes you can check the RELEASE-NOTES.txt and gutenberg/packages/react-native-editor/CHANGELOG.md files and cross check with the list of commits that are part of the PR -->

### Track block movement actions
- **PR:** https://github.com/wordpress-mobile/gutenberg-mobile/pull/4833
- **Issue:** https://github.com/wordpress-mobile/gutenberg-mobile/issues/4831

## Test plan

Once the installable builds of the main apps are ready, perform a quick smoke test of the editor on both iOS and Android to verify it launches without crashing. We will perform additional testing after the main apps cut their releases.

## Release Submission Checklist

- [x] Verify Items from test plan have been completed
- [x] Check if `RELEASE-NOTES.txt` is updated with all the changes that made it to the release. Replace `Unreleased` section with the release version and create a new `Unreleased` section.
- [x] Check if `gutenberg/packages/react-native-editor/CHANGELOG.md` is updated with all the changes that made it to the release. Replace `## Unreleased` with the release version and create a new `## Unreleased`.
- [x] Bundle package of the release is updated.