### PR TITLE
Fix metro config to resolve pnpm modules

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -21,10 +21,6 @@ const nodeModulePaths = [
 const possibleModulePath = ( name ) =>
 	nodeModulePaths.map( ( dir ) => path.join( dir, name ) );
 
-function modulePathExists( name ) {
-	return ( path ) => fs.existsSync( `${ path }/${ name }` );
-}
-
 gutenbergMetroConfigCopy.resolver.resolveRequest = (
 	context,
 	moduleName,

--- a/metro.config.js
+++ b/metro.config.js
@@ -26,7 +26,7 @@ gutenbergMetroConfigCopy.resolver.resolveRequest = (
 	moduleName,
 	platform
 ) => {
-	// If the module is not a local node module, we need to add it to the extra node modules.
+	// Add the module to the extra node modules object if the module is not on a local path.
 	if ( ! ( moduleName.startsWith( '.' ) || moduleName.startsWith( '/' ) ) ) {
 		const [ namespace, module = '' ] = moduleName.split( '/' );
 		const name = path.join( namespace, module );
@@ -57,7 +57,9 @@ gutenbergMetroConfigCopy.resolver.resolveRequest = (
 					innerNodeModules && path.join( innerNodeModules, name );
 			}
 
-			extraNodeModules[ name ] = extraNodeModulePath;
+			if ( extraNodeModulePath ) {
+				extraNodeModules[ name ] = extraNodeModulePath;
+			}
 		}
 	}
 

--- a/metro.config.js
+++ b/metro.config.js
@@ -18,7 +18,7 @@ const nodeModulePaths = [
 	'jetpack/projects/plugins/jetpack/node_modules',
 ];
 
-const possibleModulePath = ( name ) =>
+const possibleModulePaths = ( name ) =>
 	nodeModulePaths.map( ( dir ) => path.join( process.cwd(), dir, name ) );
 
 const packagedByPnpm = ( dir ) => dir && dir.includes( '.pnpm' );
@@ -35,10 +35,11 @@ gutenbergMetroConfigCopy.resolver.resolveRequest = (
 		if ( ! extraNodeModules[ name ] ) {
 			let extraNodeModulePath;
 
-			const modulePath = possibleModulePath( name ).find( fs.existsSync );
-			if ( modulePath ) {
-				extraNodeModulePath = fs.realpathSync( modulePath );
-			}
+			const modulePath = possibleModulePaths( name ).find(
+				fs.existsSync
+			);
+
+			extraNodeModulePath = modulePath && fs.realpathSync( modulePath );
 
 			if ( ! extraNodeModulePath ) {
 				// Check if package is managed by pnpm
@@ -50,9 +51,9 @@ gutenbergMetroConfigCopy.resolver.resolveRequest = (
 					/.*node_modules/
 				)?.[ 0 ];
 
-				if ( packagedByPnpm( innerNodeModules ) ) {
-					extraNodeModulePath = path.join( innerNodeModules, name );
-				}
+				extraNodeModulePath =
+					packagedByPnpm( innerNodeModules ) &&
+					path.join( innerNodeModules, name );
 			}
 
 			extraNodeModules[ name ] = extraNodeModulePath;

--- a/metro.config.js
+++ b/metro.config.js
@@ -69,4 +69,5 @@ gutenbergMetroConfigCopy.resolver.resolveRequest = (
 		platform
 	);
 };
+
 module.exports = gutenbergMetroConfigCopy;

--- a/metro.config.js
+++ b/metro.config.js
@@ -15,27 +15,47 @@ const gutenbergMetroConfigCopy = {
 
 const nodeModulePaths = [
 	'gutenberg/node_modules',
-	'./jetpack/node_modules/.pnpm/node_modules',
-].map( ( dir ) => path.join( process.cwd(), dir ) );
+	'jetpack/projects/plugins/jetpack/node_modules',
+];
 
 const possibleModulePath = ( name ) =>
-	nodeModulePaths.map( ( dir ) => path.join( dir, name ) );
+	nodeModulePaths.map( ( dir ) => path.join( process.cwd(), dir, name ) );
+
+const packagedByPnpm = ( dir ) => dir && dir.includes( '.pnpm' );
 
 gutenbergMetroConfigCopy.resolver.resolveRequest = (
 	context,
 	moduleName,
 	platform
 ) => {
-	if ( moduleName[ 0 ] !== '.' ) {
+	if ( ! ( moduleName.startsWith( '.' ) || moduleName.startsWith( '/' ) ) ) {
 		const [ namespace, module = '' ] = moduleName.split( '/' );
 		const name = path.join( namespace, module );
 
 		if ( ! extraNodeModules[ name ] ) {
-			const modulePath = possibleModulePath( name ).find( fs.existsSync );
+			let extraNodeModulePath;
 
+			const modulePath = possibleModulePath( name ).find( fs.existsSync );
 			if ( modulePath ) {
-				extraNodeModules[ name ] = fs.realpathSync( modulePath );
+				extraNodeModulePath = fs.realpathSync( modulePath );
 			}
+
+			if ( ! extraNodeModulePath ) {
+				// Check if package is managed by pnpm
+				const filePath = require.resolve( name, {
+					paths: [ path.dirname( context.originModulePath ) ],
+				} );
+
+				const innerNodeModules = filePath.match(
+					/.*node_modules/
+				)?.[ 0 ];
+
+				if ( packagedByPnpm( innerNodeModules ) ) {
+					extraNodeModulePath = path.join( innerNodeModules, name );
+				}
+			}
+
+			extraNodeModules[ name ] = extraNodeModulePath;
 		}
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8784,7 +8784,8 @@
 		"absolute-path": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/absolute-path/-/absolute-path-0.0.0.tgz",
-			"integrity": "sha1-p4di+9rftSl76ZsV01p4Wy8JW/c="
+			"integrity": "sha1-p4di+9rftSl76ZsV01p4Wy8JW/c=",
+			"dev": true
 		},
 		"accepts": {
 			"version": "1.3.7",
@@ -24691,6 +24692,7 @@
 			"version": "0.70.3",
 			"resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.70.3.tgz",
 			"integrity": "sha512-5Pc5S/Gs4RlLbziuIWtvtFd9GRoILlaRC8RZDVq5JZWcWHywKy/PjNmOBNhpyvtRlzpJfy/ssIfLhu8zINt1Mw==",
+			"dev": true,
 			"requires": {
 				"absolute-path": "^0.0.0"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7093,6 +7093,15 @@
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
 				},
+				"metro-resolver": {
+					"version": "0.66.2",
+					"resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.66.2.tgz",
+					"integrity": "sha512-pXQAJR/xauRf4kWFj2/hN5a77B4jLl0Fom5I3PHp6Arw/KxSBp0cnguXpGLwNQ6zQC0nxKCoYGL9gQpzMnN7Hw==",
+					"dev": true,
+					"requires": {
+						"absolute-path": "^0.0.0"
+					}
+				},
 				"supports-color": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -8775,8 +8784,7 @@
 		"absolute-path": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/absolute-path/-/absolute-path-0.0.0.tgz",
-			"integrity": "sha1-p4di+9rftSl76ZsV01p4Wy8JW/c=",
-			"dev": true
+			"integrity": "sha1-p4di+9rftSl76ZsV01p4Wy8JW/c="
 		},
 		"accepts": {
 			"version": "1.3.7",
@@ -24051,6 +24059,15 @@
 						"graceful-fs": "^4.1.6"
 					}
 				},
+				"metro-resolver": {
+					"version": "0.66.2",
+					"resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.66.2.tgz",
+					"integrity": "sha512-pXQAJR/xauRf4kWFj2/hN5a77B4jLl0Fom5I3PHp6Arw/KxSBp0cnguXpGLwNQ6zQC0nxKCoYGL9gQpzMnN7Hw==",
+					"dev": true,
+					"requires": {
+						"absolute-path": "^0.0.0"
+					}
+				},
 				"micromatch": {
 					"version": "4.0.4",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
@@ -24510,6 +24527,15 @@
 						"supports-color": "^7.0.0"
 					}
 				},
+				"metro-resolver": {
+					"version": "0.66.2",
+					"resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.66.2.tgz",
+					"integrity": "sha512-pXQAJR/xauRf4kWFj2/hN5a77B4jLl0Fom5I3PHp6Arw/KxSBp0cnguXpGLwNQ6zQC0nxKCoYGL9gQpzMnN7Hw==",
+					"dev": true,
+					"requires": {
+						"absolute-path": "^0.0.0"
+					}
+				},
 				"micromatch": {
 					"version": "4.0.4",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
@@ -24662,10 +24688,9 @@
 			}
 		},
 		"metro-resolver": {
-			"version": "0.66.2",
-			"resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.66.2.tgz",
-			"integrity": "sha512-pXQAJR/xauRf4kWFj2/hN5a77B4jLl0Fom5I3PHp6Arw/KxSBp0cnguXpGLwNQ6zQC0nxKCoYGL9gQpzMnN7Hw==",
-			"dev": true,
+			"version": "0.70.3",
+			"resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.70.3.tgz",
+			"integrity": "sha512-5Pc5S/Gs4RlLbziuIWtvtFd9GRoILlaRC8RZDVq5JZWcWHywKy/PjNmOBNhpyvtRlzpJfy/ssIfLhu8zINt1Mw==",
 			"requires": {
 				"absolute-path": "^0.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -94,5 +94,7 @@
 		"lint:fix": "npm run lint -- --fix",
 		"version": "npm run bundle && git add -A bundle"
 	},
-	"dependencies": {}
+	"dependencies": {
+		"metro-resolver": "^0.70.3"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -50,10 +50,11 @@
 		"rungen": "^0.3.2",
 		"sprintf-js": "^1.1.1",
 		"typescript": "4.1.3",
-		"wd": "^1.11.1"
+		"wd": "^1.11.1",
+		"metro-resolver": "^0.70.3"
 	},
 	"scripts": {
-		"postinstall": "patch-package && npm ci --prefix gutenberg && npm run i18n:check-cache && cd jetpack/projects/plugins/jetpack && npx pnpm@`npx -c 'echo \"$npm_package_engines_pnpm\"'` install",
+		"postinstall": "patch-package && npm ci --prefix gutenberg && npm run i18n:check-cache && cd jetpack/projects/plugins/jetpack && npx pnpm@`npx -c 'echo $(npx semver -c $npm_package_engines_pnpm)'` install",
 		"start": "echo \"\\x1b[33mThe start command is not available in this project. It is strongly recommended to use \\x1b[1:33mstart:reset\\x1b[0m\\x1b[33m to perform some cleanup when starting the metro bundler.\nOr you may use \\x1b[1:33mstart:quick\\x1b[0m\\x1b[33m for a quicker startup, but this may lead to unexpected javascript errors when running the app.\\x1b[0m\"",
 		"start:reset": "npm run core clean:runtime && npm run start:quick -- --reset-cache",
 		"start:quick": "react-native start --config ./metro.config.js",
@@ -93,8 +94,5 @@
 		"lint": "eslint . --ext .js",
 		"lint:fix": "npm run lint -- --fix",
 		"version": "npm run bundle && git add -A bundle"
-	},
-	"dependencies": {
-		"metro-resolver": "^0.70.3"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"wd": "^1.11.1"
 	},
 	"scripts": {
-		"postinstall": "patch-package && npm ci --prefix gutenberg && npm run i18n:check-cache && cd jetpack/projects/plugins/jetpack && npx pnpm@6 install",
+		"postinstall": "patch-package && npm ci --prefix gutenberg && npm run i18n:check-cache && cd jetpack/projects/plugins/jetpack && npx pnpm@`npx -c 'echo \"$npm_package_engines_pnpm\"'` install",
 		"start": "echo \"\\x1b[33mThe start command is not available in this project. It is strongly recommended to use \\x1b[1:33mstart:reset\\x1b[0m\\x1b[33m to perform some cleanup when starting the metro bundler.\nOr you may use \\x1b[1:33mstart:quick\\x1b[0m\\x1b[33m for a quicker startup, but this may lead to unexpected javascript errors when running the app.\\x1b[0m\"",
 		"start:reset": "npm run core clean:runtime && npm run start:quick -- --reset-cache",
 		"start:quick": "react-native start --config ./metro.config.js",


### PR DESCRIPTION
Fixes issue related to recent changes to the module hoisting in Jetpack. 
Also updates how we set the pnpm version when installing Jetpack.

To test:
- Make sure CI passes
- Checkout branch and update the Jetpack submodule 
- Remove `jetpack/node_modules` and run `npm install` to make sure the pnpm hoisting is current
- Verify that metro can resolve the Jetpack modules ( try `npm run test:e2e:bundle:ios` )

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
