### PR TITLE
Set branch to `trunk` in Jetpack submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,6 +3,7 @@
 	url = ../../WordPress/gutenberg.git
 	shallow = true
 [submodule "jetpack"]
+	branch = trunk
 	path = jetpack
 	url = ../../Automattic/jetpack.git
 	shallow = true


### PR DESCRIPTION
Fixes #

To test:

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
