### PR TITLE
feat: Support alternative version managers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+install-jetpack.sh.local
 
 npm-debug.log*
 yarn-debug.log*

--- a/bin/install-jetpack.sh
+++ b/bin/install-jetpack.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -Eeuo pipefail
 
+if [ -e ./bin/install-jetpack.sh.local ]
+then
+  source ./bin/install-jetpack.sh.local
+  exit 0
+fi
+
 # Check if nvm is installed
 [ -z "$NVM_DIR" ] && NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"


### PR DESCRIPTION
Conditionally sourcing a Jetpack install script allows both default support for nvm and the option to use alternatives, e.g. [asdf-vm](https://asdf-vm.com).

<details><summary>For additional context, click to see example asdf-vm-based Jetpack install script</summary>

```shell
#!/bin/bash
set -Eeuo pipefail

pushd jetpack

# Set up required pnpm version
listed_pnpm_version=$(npx -c 'echo $npm_package_engines_pnpm')
pnpm_version=$(npx semver -c "$listed_pnpm_version")

cd projects/plugins/jetpack

# npx might prompt to install pnpm at the requested version. Let's just agree and carry on.
( yes || true ) | asdf exec npx --cache /tmp/empty-cache pnpm@"$pnpm_version" install

popd

```

</details>


To test:

<details><summary>Leverage nvm default</summary>

1. Clone this branch.
1. `npm install`
1. Verify installation succeeds without error. (Presuming you have `nvm` installed.)

</details>

<details><summary>Leverage local script</summary>

1. Clone this branch.
1. `echo 'echo ">>> Local Test"' > ./bin/install-jetpack.sh.local`
1. `npm install`
1. Verify `>>> Local Test` is displayed at the end of the console logs and `nvm install`/`pnpm install` is not run (as the script exits early when locating/sourcing a local script). 

</details>

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
