### PR TITLE
Update CI to Xcode 13.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,7 +263,7 @@ jobs:
         type: string
         default: ""
     macos:
-      xcode: "12.0.0"
+      xcode: "13.4.1"
     steps:
     - checkout-shallow
     - checkout-submodules


### PR DESCRIPTION
**Related PRs:**
- `Gutenberg` -> https://github.com/WordPress/gutenberg/pull/42532

This PR updates the Xcode version to `13.4.1` due to CircleCI's image [deprecations](https://circleci.com/docs/xcode-policy). The following versions will not be available after August 2nd 2022:

* Xcode 12.0.1
* Xcode 12.1.1
* Xcode 12.2.0
* Xcode 12.3.0
* Xcode 12.4.0

We are currently using Xcode 12, so we need to upgrade it.

To test all checks in this PR should pass.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
