### PR TITLE
Release 1.81.2

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,10 @@
 Unreleased
 ---
 
+1.81.2
+---
+* [**] List V2 - Prevent error when list is empty [https://github.com/WordPress/gutenberg/pull/43861]
+
 1.81.1
 ---
 * [*] List block v2: Fix text color inconsistencies with list items [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5096]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg-mobile",
-	"version": "1.81.1",
+	"version": "1.81.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg-mobile",
-	"version": "1.81.1",
+	"version": "1.81.2",
 	"private": true,
 	"config": {
 		"jsfiles": "./*.js src/*.js src/**/*.js src/**/**/*.js",


### PR DESCRIPTION
Release for Gutenberg Mobile 1.81.2

## Related PRs

- Gutenberg: https://github.com/WordPress/gutenberg/pull/43858
- WPAndroid: https://github.com/wordpress-mobile/WordPress-Android/pull/17123
- WPiOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/19286

- Aztec-iOS: N/A
- Aztec-Android: N/A

## Extra PRs that Landed After the Release Was Cut

No extra PRs yet. 🎉

## Changes

<!-- To determine the changes you can check the RELEASE-NOTES.txt and gutenberg/packages/react-native-editor/CHANGELOG.md files and cross check with the list of commits that are part of the PR -->

### List V2 - Prevent error when list is empty
- **PR:** https://github.com/WordPress/gutenberg/pull/43861
- **Issue:** https://github.com/wordpress-mobile/gutenberg-mobile/issues/5135

## Test plan

Once the installable builds of the main apps are ready, perform a quick smoke test of the editor on both iOS and Android to verify it launches without crashing. We will perform additional testing after the main apps cut their releases.

## Release Submission Checklist

- [x] Verify Items from test plan have been completed
- [x] Check if `RELEASE-NOTES.txt` is updated with all the changes that made it to the release. Replace `Unreleased` section with the release version and create a new `Unreleased` section.
- [x] Check if `gutenberg/packages/react-native-editor/CHANGELOG.md` is updated with all the changes that made it to the release. Replace `## Unreleased` with the release version and create a new `## Unreleased`.
- [x] Bundle package of the release is updated.