### PR TITLE
Update Appium to `1.22.3`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8949,9 +8949,9 @@
 			"dev": true
 		},
 		"appium": {
-			"version": "1.20.2",
-			"resolved": "https://registry.npmjs.org/appium/-/appium-1.20.2.tgz",
-			"integrity": "sha512-4uQ47RmQn01L1X1rjCUcs6KHL0nWuOpTZ4v5roeHZfj5mRo29w8nUD9TKKh7yuu1uNsuQaWbjOlIuzjo6TtiOQ==",
+			"version": "1.22.3",
+			"resolved": "https://registry.npmjs.org/appium/-/appium-1.22.3.tgz",
+			"integrity": "sha512-0/SkcOdC8h79Z5TgCeWbeGEbAQzLzwR3h2jYL5EI6zPIrbqZczGv7S8HgmFQPQ98La2wmf26dpPvL8Vw4r/WXw==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.6.0",
@@ -8959,22 +8959,22 @@
 				"appium-base-driver": "^7.0.0",
 				"appium-espresso-driver": "^1.0.0",
 				"appium-fake-driver": "^1.x",
-				"appium-flutter-driver": "^0",
-				"appium-geckodriver": "^0.3.0",
+				"appium-flutter-driver": "^0.x",
+				"appium-geckodriver": "^0.x",
 				"appium-ios-driver": "4.x",
 				"appium-mac-driver": "1.x",
-				"appium-mac2-driver": "^0",
+				"appium-mac2-driver": "^0.x",
 				"appium-safari-driver": "^2.1.0",
 				"appium-support": "2.x",
 				"appium-tizen-driver": "^1.1.1-beta.4",
-				"appium-uiautomator2-driver": "^1.61.2",
+				"appium-uiautomator2-driver": "^1.37.1",
 				"appium-windows-driver": "1.x",
-				"appium-xcuitest-driver": "^3.33.1",
-				"appium-youiengine-driver": "^1.2.0",
+				"appium-xcuitest-driver": "^3.59.0",
+				"appium-youiengine-driver": "^1.2.8",
 				"argparse": "^2.0.1",
 				"async-lock": "^1.0.0",
 				"asyncbox": "2.x",
-				"axios": "^0.21.0",
+				"axios": "^0.x",
 				"bluebird": "3.x",
 				"continuation-local-storage": "3.x",
 				"find-root": "^1.1.0",
@@ -8982,7 +8982,7 @@
 				"longjohn": "^0.2.12",
 				"npmlog": "4.x",
 				"semver": "^7.0.0",
-				"source-map-support": "0.x",
+				"source-map-support": "^0.x",
 				"teen_process": "1.x",
 				"winston": "3.x",
 				"word-wrap": "^1.2.3"
@@ -9010,9 +9010,9 @@
 					}
 				},
 				"@babel/runtime": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-					"integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+					"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
 					"dev": true,
 					"requires": {
 						"regenerator-runtime": "^0.13.4"
@@ -9030,24 +9030,24 @@
 					}
 				},
 				"@jimp/bmp": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.14.0.tgz",
-					"integrity": "sha512-5RkX6tSS7K3K3xNEb2ygPuvyL9whjanhoaB/WmmXlJS6ub4DjTqrapu8j4qnIWmO4YYtFeTbDTXV6v9P1yMA5A==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.16.1.tgz",
+					"integrity": "sha512-iwyNYQeBawrdg/f24x3pQ5rEx+/GwjZcCXd3Kgc+ZUd+Ivia7sIqBsOnDaMZdKCBPlfW364ekexnlOqyVa0NWg==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0",
+						"@jimp/utils": "^0.16.1",
 						"bmp-js": "^0.1.0"
 					}
 				},
 				"@jimp/core": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.14.0.tgz",
-					"integrity": "sha512-S62FcKdtLtj3yWsGfJRdFXSutjvHg7aQNiFogMbwq19RP4XJWqS2nOphu7ScB8KrSlyy5nPF2hkWNhLRLyD82w==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.16.1.tgz",
+					"integrity": "sha512-la7kQia31V6kQ4q1kI/uLimu8FXx7imWVajDGtwUG8fzePLWDFJyZl0fdIXVCL1JW2nBcRHidUot6jvlRDi2+g==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0",
+						"@jimp/utils": "^0.16.1",
 						"any-base": "^1.1.0",
 						"buffer": "^5.2.0",
 						"exif-parser": "^0.1.12",
@@ -9071,289 +9071,289 @@
 					}
 				},
 				"@jimp/custom": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.14.0.tgz",
-					"integrity": "sha512-kQJMeH87+kWJdVw8F9GQhtsageqqxrvzg7yyOw3Tx/s7v5RToe8RnKyMM+kVtBJtNAG+Xyv/z01uYQ2jiZ3GwA==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.16.1.tgz",
+					"integrity": "sha512-DNUAHNSiUI/j9hmbatD6WN/EBIyeq4AO0frl5ETtt51VN1SvE4t4v83ZA/V6ikxEf3hxLju4tQ5Pc3zmZkN/3A==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/core": "^0.14.0"
+						"@jimp/core": "^0.16.1"
 					}
 				},
 				"@jimp/gif": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.14.0.tgz",
-					"integrity": "sha512-DHjoOSfCaCz72+oGGEh8qH0zE6pUBaBxPxxmpYJjkNyDZP7RkbBkZJScIYeQ7BmJxmGN4/dZn+MxamoQlr+UYg==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.16.1.tgz",
+					"integrity": "sha512-r/1+GzIW1D5zrP4tNrfW+3y4vqD935WBXSc8X/wm23QTY9aJO9Lw6PEdzpYCEY+SOklIFKaJYUAq/Nvgm/9ryw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0",
+						"@jimp/utils": "^0.16.1",
 						"gifwrap": "^0.9.2",
 						"omggif": "^1.0.9"
 					}
 				},
 				"@jimp/jpeg": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.14.0.tgz",
-					"integrity": "sha512-561neGbr+87S/YVQYnZSTyjWTHBm9F6F1obYHiyU3wVmF+1CLbxY3FQzt4YolwyQHIBv36Bo0PY2KkkU8BEeeQ==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.16.1.tgz",
+					"integrity": "sha512-8352zrdlCCLFdZ/J+JjBslDvml+fS3Z8gttdml0We759PnnZGqrnPRhkOEOJbNUlE+dD4ckLeIe6NPxlS/7U+w==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0",
-						"jpeg-js": "^0.4.0"
+						"@jimp/utils": "^0.16.1",
+						"jpeg-js": "0.4.2"
 					}
 				},
 				"@jimp/plugin-blit": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.14.0.tgz",
-					"integrity": "sha512-YoYOrnVHeX3InfgbJawAU601iTZMwEBZkyqcP1V/S33Qnz9uzH1Uj1NtC6fNgWzvX6I4XbCWwtr4RrGFb5CFrw==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.16.1.tgz",
+					"integrity": "sha512-fKFNARm32RoLSokJ8WZXHHH2CGzz6ire2n1Jh6u+XQLhk9TweT1DcLHIXwQMh8oR12KgjbgsMGvrMVlVknmOAg==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0"
+						"@jimp/utils": "^0.16.1"
 					}
 				},
 				"@jimp/plugin-blur": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.14.0.tgz",
-					"integrity": "sha512-9WhZcofLrT0hgI7t0chf7iBQZib//0gJh9WcQMUt5+Q1Bk04dWs8vTgLNj61GBqZXgHSPzE4OpCrrLDBG8zlhQ==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.16.1.tgz",
+					"integrity": "sha512-1WhuLGGj9MypFKRcPvmW45ht7nXkOKu+lg3n2VBzIB7r4kKNVchuI59bXaCYQumOLEqVK7JdB4glaDAbCQCLyw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0"
+						"@jimp/utils": "^0.16.1"
 					}
 				},
 				"@jimp/plugin-circle": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.14.0.tgz",
-					"integrity": "sha512-o5L+wf6QA44tvTum5HeLyLSc5eVfIUd5ZDVi5iRfO4o6GT/zux9AxuTSkKwnjhsG8bn1dDmywAOQGAx7BjrQVA==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.16.1.tgz",
+					"integrity": "sha512-JK7yi1CIU7/XL8hdahjcbGA3V7c+F+Iw+mhMQhLEi7Q0tCnZ69YJBTamMiNg3fWPVfMuvWJJKOBRVpwNTuaZRg==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0"
+						"@jimp/utils": "^0.16.1"
 					}
 				},
 				"@jimp/plugin-color": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.14.0.tgz",
-					"integrity": "sha512-JJz512SAILYV0M5LzBb9sbOm/XEj2fGElMiHAxb7aLI6jx+n0agxtHpfpV/AePTLm1vzzDxx6AJxXbKv355hBQ==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.16.1.tgz",
+					"integrity": "sha512-9yQttBAO5SEFj7S6nJK54f+1BnuBG4c28q+iyzm1JjtnehjqMg6Ljw4gCSDCvoCQ3jBSYHN66pmwTV74SU1B7A==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0",
+						"@jimp/utils": "^0.16.1",
 						"tinycolor2": "^1.4.1"
 					}
 				},
 				"@jimp/plugin-contain": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.14.0.tgz",
-					"integrity": "sha512-RX2q233lGyaxiMY6kAgnm9ScmEkNSof0hdlaJAVDS1OgXphGAYAeSIAwzESZN4x3ORaWvkFefeVH9O9/698Evg==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.16.1.tgz",
+					"integrity": "sha512-44F3dUIjBDHN+Ym/vEfg+jtjMjAqd2uw9nssN67/n4FdpuZUVs7E7wadKY1RRNuJO+WgcD5aDQcsvurXMETQTg==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0"
+						"@jimp/utils": "^0.16.1"
 					}
 				},
 				"@jimp/plugin-cover": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.14.0.tgz",
-					"integrity": "sha512-0P/5XhzWES4uMdvbi3beUgfvhn4YuQ/ny8ijs5kkYIw6K8mHcl820HahuGpwWMx56DJLHRl1hFhJwo9CeTRJtQ==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.16.1.tgz",
+					"integrity": "sha512-YztWCIldBAVo0zxcQXR+a/uk3/TtYnpKU2CanOPJ7baIuDlWPsG+YE4xTsswZZc12H9Kl7CiziEbDtvF9kwA/Q==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0"
+						"@jimp/utils": "^0.16.1"
 					}
 				},
 				"@jimp/plugin-crop": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.14.0.tgz",
-					"integrity": "sha512-Ojtih+XIe6/XSGtpWtbAXBozhCdsDMmy+THUJAGu2x7ZgKrMS0JotN+vN2YC3nwDpYkM+yOJImQeptSfZb2Sug==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.16.1.tgz",
+					"integrity": "sha512-UQdva9oQzCVadkyo3T5Tv2CUZbf0klm2cD4cWMlASuTOYgaGaFHhT9st+kmfvXjKL8q3STkBu/zUPV6PbuV3ew==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0"
+						"@jimp/utils": "^0.16.1"
 					}
 				},
 				"@jimp/plugin-displace": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.14.0.tgz",
-					"integrity": "sha512-c75uQUzMgrHa8vegkgUvgRL/PRvD7paFbFJvzW0Ugs8Wl+CDMGIPYQ3j7IVaQkIS+cAxv+NJ3TIRBQyBrfVEOg==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.16.1.tgz",
+					"integrity": "sha512-iVAWuz2+G6Heu8gVZksUz+4hQYpR4R0R/RtBzpWEl8ItBe7O6QjORAkhxzg+WdYLL2A/Yd4ekTpvK0/qW8hTVw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0"
+						"@jimp/utils": "^0.16.1"
 					}
 				},
 				"@jimp/plugin-dither": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.14.0.tgz",
-					"integrity": "sha512-g8SJqFLyYexXQQsoh4dc1VP87TwyOgeTElBcxSXX2LaaMZezypmxQfLTzOFzZoK8m39NuaoH21Ou1Ftsq7LzVQ==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.16.1.tgz",
+					"integrity": "sha512-tADKVd+HDC9EhJRUDwMvzBXPz4GLoU6s5P7xkVq46tskExYSptgj5713J5Thj3NMgH9Rsqu22jNg1H/7tr3V9Q==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0"
+						"@jimp/utils": "^0.16.1"
 					}
 				},
 				"@jimp/plugin-fisheye": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.14.0.tgz",
-					"integrity": "sha512-BFfUZ64EikCaABhCA6mR3bsltWhPpS321jpeIQfJyrILdpFsZ/OccNwCgpW1XlbldDHIoNtXTDGn3E+vCE7vDg==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.16.1.tgz",
+					"integrity": "sha512-BWHnc5hVobviTyIRHhIy9VxI1ACf4CeSuCfURB6JZm87YuyvgQh5aX5UDKtOz/3haMHXBLP61ZBxlNpMD8CG4A==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0"
+						"@jimp/utils": "^0.16.1"
 					}
 				},
 				"@jimp/plugin-flip": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.14.0.tgz",
-					"integrity": "sha512-WtL1hj6ryqHhApih+9qZQYA6Ye8a4HAmdTzLbYdTMrrrSUgIzFdiZsD0WeDHpgS/+QMsWwF+NFmTZmxNWqKfXw==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.16.1.tgz",
+					"integrity": "sha512-KdxTf0zErfZ8DyHkImDTnQBuHby+a5YFdoKI/G3GpBl3qxLBvC+PWkS2F/iN3H7wszP7/TKxTEvWL927pypT0w==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0"
+						"@jimp/utils": "^0.16.1"
 					}
 				},
 				"@jimp/plugin-gaussian": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.14.0.tgz",
-					"integrity": "sha512-uaLwQ0XAQoydDlF9tlfc7iD9drYPriFe+jgYnWm8fbw5cN+eOIcnneEX9XCOOzwgLPkNCxGox6Kxjn8zY6GxtQ==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.16.1.tgz",
+					"integrity": "sha512-u9n4wjskh3N1mSqketbL6tVcLU2S5TEaFPR40K6TDv4phPLZALi1Of7reUmYpVm8mBDHt1I6kGhuCJiWvzfGyg==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0"
+						"@jimp/utils": "^0.16.1"
 					}
 				},
 				"@jimp/plugin-invert": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.14.0.tgz",
-					"integrity": "sha512-UaQW9X9vx8orQXYSjT5VcITkJPwDaHwrBbxxPoDG+F/Zgv4oV9fP+udDD6qmkgI9taU+44Fy+zm/J/gGcMWrdg==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.16.1.tgz",
+					"integrity": "sha512-2DKuyVXANH8WDpW9NG+PYFbehzJfweZszFYyxcaewaPLN0GxvxVLOGOPP1NuUTcHkOdMFbE0nHDuB7f+sYF/2w==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0"
+						"@jimp/utils": "^0.16.1"
 					}
 				},
 				"@jimp/plugin-mask": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.14.0.tgz",
-					"integrity": "sha512-tdiGM69OBaKtSPfYSQeflzFhEpoRZ+BvKfDEoivyTjauynbjpRiwB1CaiS8En1INTDwzLXTT0Be9SpI3LkJoEA==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.16.1.tgz",
+					"integrity": "sha512-snfiqHlVuj4bSFS0v96vo2PpqCDMe4JB+O++sMo5jF5mvGcGL6AIeLo8cYqPNpdO6BZpBJ8MY5El0Veckhr39Q==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0"
+						"@jimp/utils": "^0.16.1"
 					}
 				},
 				"@jimp/plugin-normalize": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.14.0.tgz",
-					"integrity": "sha512-AfY8sqlsbbdVwFGcyIPy5JH/7fnBzlmuweb+Qtx2vn29okq6+HelLjw2b+VT2btgGUmWWHGEHd86oRGSoWGyEQ==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.16.1.tgz",
+					"integrity": "sha512-dOQfIOvGLKDKXPU8xXWzaUeB0nvkosHw6Xg1WhS1Z5Q0PazByhaxOQkSKgUryNN/H+X7UdbDvlyh/yHf3ITRaw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0"
+						"@jimp/utils": "^0.16.1"
 					}
 				},
 				"@jimp/plugin-print": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.14.0.tgz",
-					"integrity": "sha512-MwP3sH+VS5AhhSTXk7pui+tEJFsxnTKFY3TraFJb8WFbA2Vo2qsRCZseEGwpTLhENB7p/JSsLvWoSSbpmxhFAQ==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.16.1.tgz",
+					"integrity": "sha512-ceWgYN40jbN4cWRxixym+csyVymvrryuKBQ+zoIvN5iE6OyS+2d7Mn4zlNgumSczb9GGyZZESIgVcBDA1ezq0Q==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0",
+						"@jimp/utils": "^0.16.1",
 						"load-bmfont": "^1.4.0"
 					}
 				},
 				"@jimp/plugin-resize": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.14.0.tgz",
-					"integrity": "sha512-qFeMOyXE/Bk6QXN0GQo89+CB2dQcXqoxUcDb2Ah8wdYlKqpi53skABkgVy5pW3EpiprDnzNDboMltdvDslNgLQ==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.16.1.tgz",
+					"integrity": "sha512-u4JBLdRI7dargC04p2Ha24kofQBk3vhaf0q8FwSYgnCRwxfvh2RxvhJZk9H7Q91JZp6wgjz/SjvEAYjGCEgAwQ==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0"
+						"@jimp/utils": "^0.16.1"
 					}
 				},
 				"@jimp/plugin-rotate": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.14.0.tgz",
-					"integrity": "sha512-aGaicts44bvpTcq5Dtf93/8TZFu5pMo/61lWWnYmwJJU1RqtQlxbCLEQpMyRhKDNSfPbuP8nyGmaqXlM/82J0Q==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.16.1.tgz",
+					"integrity": "sha512-ZUU415gDQ0VjYutmVgAYYxC9Og9ixu2jAGMCU54mSMfuIlmohYfwARQmI7h4QB84M76c9hVLdONWjuo+rip/zg==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0"
+						"@jimp/utils": "^0.16.1"
 					}
 				},
 				"@jimp/plugin-scale": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.14.0.tgz",
-					"integrity": "sha512-ZcJk0hxY5ZKZDDwflqQNHEGRblgaR+piePZm7dPwPUOSeYEH31P0AwZ1ziceR74zd8N80M0TMft+e3Td6KGBHw==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.16.1.tgz",
+					"integrity": "sha512-jM2QlgThIDIc4rcyughD5O7sOYezxdafg/2Xtd1csfK3z6fba3asxDwthqPZAgitrLgiKBDp6XfzC07Y/CefUw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0"
+						"@jimp/utils": "^0.16.1"
 					}
 				},
 				"@jimp/plugin-shadow": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.14.0.tgz",
-					"integrity": "sha512-p2igcEr/iGrLiTu0YePNHyby0WYAXM14c5cECZIVnq/UTOOIQ7xIcWZJ1lRbAEPxVVXPN1UibhZAbr3HAb5BjQ==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.16.1.tgz",
+					"integrity": "sha512-MeD2Is17oKzXLnsphAa1sDstTu6nxscugxAEk3ji0GV1FohCvpHBcec0nAq6/czg4WzqfDts+fcPfC79qWmqrA==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0"
+						"@jimp/utils": "^0.16.1"
 					}
 				},
 				"@jimp/plugin-threshold": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.14.0.tgz",
-					"integrity": "sha512-N4BlDgm/FoOMV/DQM2rSpzsgqAzkP0DXkWZoqaQrlRxQBo4zizQLzhEL00T/YCCMKnddzgEhnByaocgaaa0fKw==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.16.1.tgz",
+					"integrity": "sha512-iGW8U/wiCSR0+6syrPioVGoSzQFt4Z91SsCRbgNKTAk7D+XQv6OI78jvvYg4o0c2FOlwGhqz147HZV5utoSLxA==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0"
+						"@jimp/utils": "^0.16.1"
 					}
 				},
 				"@jimp/plugins": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.14.0.tgz",
-					"integrity": "sha512-vDO3XT/YQlFlFLq5TqNjQkISqjBHT8VMhpWhAfJVwuXIpilxz5Glu4IDLK6jp4IjPR6Yg2WO8TmRY/HI8vLrOw==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.16.1.tgz",
+					"integrity": "sha512-c+lCqa25b+4q6mJZSetlxhMoYuiltyS+ValLzdwK/47+aYsq+kcJNl+TuxIEKf59yr9+5rkbpsPkZHLF/V7FFA==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/plugin-blit": "^0.14.0",
-						"@jimp/plugin-blur": "^0.14.0",
-						"@jimp/plugin-circle": "^0.14.0",
-						"@jimp/plugin-color": "^0.14.0",
-						"@jimp/plugin-contain": "^0.14.0",
-						"@jimp/plugin-cover": "^0.14.0",
-						"@jimp/plugin-crop": "^0.14.0",
-						"@jimp/plugin-displace": "^0.14.0",
-						"@jimp/plugin-dither": "^0.14.0",
-						"@jimp/plugin-fisheye": "^0.14.0",
-						"@jimp/plugin-flip": "^0.14.0",
-						"@jimp/plugin-gaussian": "^0.14.0",
-						"@jimp/plugin-invert": "^0.14.0",
-						"@jimp/plugin-mask": "^0.14.0",
-						"@jimp/plugin-normalize": "^0.14.0",
-						"@jimp/plugin-print": "^0.14.0",
-						"@jimp/plugin-resize": "^0.14.0",
-						"@jimp/plugin-rotate": "^0.14.0",
-						"@jimp/plugin-scale": "^0.14.0",
-						"@jimp/plugin-shadow": "^0.14.0",
-						"@jimp/plugin-threshold": "^0.14.0",
+						"@jimp/plugin-blit": "^0.16.1",
+						"@jimp/plugin-blur": "^0.16.1",
+						"@jimp/plugin-circle": "^0.16.1",
+						"@jimp/plugin-color": "^0.16.1",
+						"@jimp/plugin-contain": "^0.16.1",
+						"@jimp/plugin-cover": "^0.16.1",
+						"@jimp/plugin-crop": "^0.16.1",
+						"@jimp/plugin-displace": "^0.16.1",
+						"@jimp/plugin-dither": "^0.16.1",
+						"@jimp/plugin-fisheye": "^0.16.1",
+						"@jimp/plugin-flip": "^0.16.1",
+						"@jimp/plugin-gaussian": "^0.16.1",
+						"@jimp/plugin-invert": "^0.16.1",
+						"@jimp/plugin-mask": "^0.16.1",
+						"@jimp/plugin-normalize": "^0.16.1",
+						"@jimp/plugin-print": "^0.16.1",
+						"@jimp/plugin-resize": "^0.16.1",
+						"@jimp/plugin-rotate": "^0.16.1",
+						"@jimp/plugin-scale": "^0.16.1",
+						"@jimp/plugin-shadow": "^0.16.1",
+						"@jimp/plugin-threshold": "^0.16.1",
 						"timm": "^1.6.1"
 					}
 				},
 				"@jimp/png": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.14.0.tgz",
-					"integrity": "sha512-0RV/mEIDOrPCcNfXSPmPBqqSZYwGADNRVUTyMt47RuZh7sugbYdv/uvKmQSiqRdR0L1sfbCBMWUEa5G/8MSbdA==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.16.1.tgz",
+					"integrity": "sha512-iyWoCxEBTW0OUWWn6SveD4LePW89kO7ZOy5sCfYeDM/oTPLpR8iMIGvZpZUz1b8kvzFr27vPst4E5rJhGjwsdw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/utils": "^0.14.0",
+						"@jimp/utils": "^0.16.1",
 						"pngjs": "^3.3.3"
 					},
 					"dependencies": {
@@ -9366,9 +9366,9 @@
 					}
 				},
 				"@jimp/tiff": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.14.0.tgz",
-					"integrity": "sha512-zBYDTlutc7j88G/7FBCn3kmQwWr0rmm1e0FKB4C3uJ5oYfT8645lftUsvosKVUEfkdmOaMAnhrf4ekaHcb5gQw==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.16.1.tgz",
+					"integrity": "sha512-3K3+xpJS79RmSkAvFMgqY5dhSB+/sxhwTFA9f4AVHUK0oKW+u6r52Z1L0tMXHnpbAdR9EJ+xaAl2D4x19XShkQ==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
@@ -9376,24 +9376,24 @@
 					}
 				},
 				"@jimp/types": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.14.0.tgz",
-					"integrity": "sha512-hx3cXAW1KZm+b+XCrY3LXtdWy2U+hNtq0rPyJ7NuXCjU7lZR3vIkpz1DLJ3yDdS70hTi5QDXY3Cd9kd6DtloHQ==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.16.1.tgz",
+					"integrity": "sha512-g1w/+NfWqiVW4CaXSJyD28JQqZtm2eyKMWPhBBDCJN9nLCN12/Az0WFF3JUAktzdsEC2KRN2AqB1a2oMZBNgSQ==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
-						"@jimp/bmp": "^0.14.0",
-						"@jimp/gif": "^0.14.0",
-						"@jimp/jpeg": "^0.14.0",
-						"@jimp/png": "^0.14.0",
-						"@jimp/tiff": "^0.14.0",
+						"@jimp/bmp": "^0.16.1",
+						"@jimp/gif": "^0.16.1",
+						"@jimp/jpeg": "^0.16.1",
+						"@jimp/png": "^0.16.1",
+						"@jimp/tiff": "^0.16.1",
 						"timm": "^1.6.1"
 					}
 				},
 				"@jimp/utils": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
-					"integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.16.1.tgz",
+					"integrity": "sha512-8fULQjB0x4LzUSiSYG6ZtQl355sZjxbv8r9PPAuYHzS9sGiSHJQavNqK/nKnpDsVkU88/vRGcE7t3nMU0dEnVw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
@@ -9401,39 +9401,24 @@
 					}
 				},
 				"@sindresorhus/is": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.0.tgz",
-					"integrity": "sha512-FyD2meJpDPjyNQejSjvnhpgI/azsQkA4lGbuu5BQZfjvJ9cbRZXzeWL2HceCekW4lixO9JPesIIQkSoLjeJHNQ==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.0.tgz",
+					"integrity": "sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw==",
 					"dev": true
 				},
 				"@szmarczak/http-timer": {
-					"version": "4.0.5",
-					"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
-					"integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
+					"version": "4.0.6",
+					"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+					"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
 					"dev": true,
 					"requires": {
 						"defer-to-connect": "^2.0.0"
 					}
 				},
-				"@types/archiver": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-5.1.0.tgz",
-					"integrity": "sha512-baFOhanb/hxmcOd1Uey2TfFg43kTSmM6py1Eo7Rjbv/ivcl7PXLhY0QgXGf50Hx/eskGCFqPfhs/7IZLb15C5g==",
-					"dev": true,
-					"requires": {
-						"@types/glob": "*"
-					}
-				},
-				"@types/atob": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/@types/atob/-/atob-2.1.2.tgz",
-					"integrity": "sha512-8GAYQ1jDRUQkSpHzJUqXwAkYFOxuWAOGLhIR4aPd/Y/yL12Q/9m7LsKpHKlfKdNE/362Hc9wPI1Yh6opDfxVJg==",
-					"dev": true
-				},
 				"@types/cacheable-request": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
-					"integrity": "sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==",
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
+					"integrity": "sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==",
 					"dev": true,
 					"requires": {
 						"@types/http-cache-semantics": "*",
@@ -9448,125 +9433,49 @@
 					"integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
 					"dev": true
 				},
-				"@types/fs-extra": {
-					"version": "9.0.6",
-					"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.6.tgz",
-					"integrity": "sha512-ecNRHw4clCkowNOBJH1e77nvbPxHYnWIXMv1IAoG/9+MYGkgoyr3Ppxr7XYFNL41V422EDhyV4/4SSK8L2mlig==",
-					"dev": true,
-					"requires": {
-						"@types/node": "*"
-					}
-				},
-				"@types/glob": {
-					"version": "7.1.3",
-					"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
-					"integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
-					"dev": true,
-					"requires": {
-						"@types/minimatch": "*",
-						"@types/node": "*"
-					}
-				},
 				"@types/http-cache-semantics": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
-					"integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==",
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+					"integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==",
 					"dev": true
 				},
 				"@types/keyv": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
-					"integrity": "sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==",
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.3.tgz",
+					"integrity": "sha512-FXCJgyyN3ivVgRoml4h94G/p3kY+u/B86La+QptcqJaWtBWtmc6TtkNfS40n9bIvyLteHh7zXOtgbobORKPbDg==",
 					"dev": true,
 					"requires": {
 						"@types/node": "*"
 					}
 				},
-				"@types/lodash": {
-					"version": "4.14.166",
-					"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.166.tgz",
-					"integrity": "sha512-A3YT/c1oTlyvvW/GQqG86EyqWNrT/tisOIh2mW3YCgcx71TNjiTZA3zYZWA5BCmtsOTXjhliy4c4yEkErw6njA==",
-					"dev": true
-				},
-				"@types/lodash.clonedeep": {
-					"version": "4.5.6",
-					"resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
-					"integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
-					"dev": true,
-					"requires": {
-						"@types/lodash": "*"
-					}
-				},
-				"@types/lodash.isobject": {
-					"version": "3.0.6",
-					"resolved": "https://registry.npmjs.org/@types/lodash.isobject/-/lodash.isobject-3.0.6.tgz",
-					"integrity": "sha512-2lwGbaIXMR5hjO56nCvI7W6bmY3Y3uJvbHWqO9MtOE1StyhZ1VtLINQ0MLC87rrB3zHHp+u4DHeal70rx1kvjw==",
-					"dev": true,
-					"requires": {
-						"@types/lodash": "*"
-					}
-				},
-				"@types/lodash.isplainobject": {
-					"version": "4.0.6",
-					"resolved": "https://registry.npmjs.org/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-					"integrity": "sha512-8G41YFhmOl8Ck6NrwLK5hhnbz6ADfuDJP+zusDnX3PoYhfC60+H/rQE6zmdO4yFzPCPJPY4oGZK2spbXm6gYEA==",
-					"dev": true,
-					"requires": {
-						"@types/lodash": "*"
-					}
-				},
-				"@types/lodash.merge": {
-					"version": "4.6.6",
-					"resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.6.tgz",
-					"integrity": "sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==",
-					"dev": true,
-					"requires": {
-						"@types/lodash": "*"
-					}
-				},
-				"@types/lodash.zip": {
-					"version": "4.2.6",
-					"resolved": "https://registry.npmjs.org/@types/lodash.zip/-/lodash.zip-4.2.6.tgz",
-					"integrity": "sha512-mKAcnkyFaihVR1oK83ZBQqSSQ1hpAY+uD5QaDkf//xtvr4NlNwqJEDg/oQoqLJg5YdSEwVWlQq0Aq4oLvD3zuw==",
-					"dev": true,
-					"requires": {
-						"@types/lodash": "*"
-					}
-				},
-				"@types/minimatch": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-					"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-					"dev": true
-				},
 				"@types/node": {
-					"version": "14.14.17",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.17.tgz",
-					"integrity": "sha512-G0lD1/7qD60TJ/mZmhog76k7NcpLWkPVGgzkRy3CTlnFu4LUQh5v2Wa661z6vnXmD8EQrnALUyf0VRtrACYztw==",
+					"version": "16.3.3",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.3.tgz",
+					"integrity": "sha512-8h7k1YgQKxKXWckzFCMfsIwn0Y61UK6tlD6y2lOb3hTOIMlK3t9/QwHOhc81TwU+RMf0As5fj7NPjroERCnejQ==",
 					"dev": true
 				},
 				"@types/puppeteer": {
-					"version": "2.1.5",
-					"resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-2.1.5.tgz",
-					"integrity": "sha512-ZZKAcX5XVEtSK+CLxz6FhofPt8y1D3yDtjGZHDFBZ4bGe8v2aaS6qBDHY4crruvpb4jsO7HKrPEx39IIqsZAUg==",
+					"version": "5.4.4",
+					"resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.4.tgz",
+					"integrity": "sha512-3Nau+qi69CN55VwZb0ATtdUAlYlqOOQ3OfQfq0Hqgc4JMFXiQT/XInlwQ9g6LbicDslE6loIFsXFklGh5XmI6Q==",
 					"dev": true,
 					"requires": {
 						"@types/node": "*"
 					}
 				},
 				"@types/puppeteer-core": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/@types/puppeteer-core/-/puppeteer-core-2.1.0.tgz",
-					"integrity": "sha512-q1s+x/3HuXQN1Xo9eVhCfRJ2SNfHA/a641iSZQRNnRH55t4jX7TsNWxQN0drLqwbz/Kp8nodJ5rTNYEIKX//gg==",
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/@types/puppeteer-core/-/puppeteer-core-5.4.0.tgz",
+					"integrity": "sha512-yqRPuv4EFcSkTyin6Yy17pN6Qz2vwVwTCJIDYMXbE3j8vTPhv0nCQlZOl5xfi0WHUkqvQsjAR8hAfjeMCoetwg==",
 					"dev": true,
 					"requires": {
-						"@types/puppeteer": "^2"
+						"@types/puppeteer": "*"
 					}
 				},
 				"@types/request": {
-					"version": "2.48.5",
-					"resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
-					"integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
+					"version": "2.48.6",
+					"resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.6.tgz",
+					"integrity": "sha512-vrZaV3Ij7j/l/3hz6OttZFtpRCu7zlq7XgkYHJP6FwVEAZkGQ095WqyJV08/GlW9eyXKVcp/xmtruHm8eHpw1g==",
 					"dev": true,
 					"requires": {
 						"@types/caseless": "*",
@@ -9598,27 +9507,21 @@
 					}
 				},
 				"@types/tough-cookie": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
-					"integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.1.tgz",
+					"integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==",
 					"dev": true
 				},
-				"@types/ua-parser-js": {
-					"version": "0.7.35",
-					"resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
-					"integrity": "sha512-PsPx0RLbo2Un8+ff2buzYJnZjzwhD3jQHPOG2PtVIeOhkRDddMcKU8vJtHpzzfLB95dkUi0qAkfLg2l2Fd0yrQ==",
-					"dev": true
-				},
-				"@types/uuid": {
-					"version": "8.3.0",
-					"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
-					"integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
+				"@types/which": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/@types/which/-/which-1.3.2.tgz",
+					"integrity": "sha512-8oDqyLC7eD4HM307boe2QWKyuzdzWBj56xI/imSl2cpL+U3tCMaTAkMJ4ee5JBZ/FsOJlvRGeIShiZDAl1qERA==",
 					"dev": true
 				},
 				"@types/yauzl": {
-					"version": "2.9.1",
-					"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
-					"integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+					"version": "2.9.2",
+					"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
+					"integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -9626,9 +9529,9 @@
 					}
 				},
 				"@wdio/config": {
-					"version": "6.10.11",
-					"resolved": "https://registry.npmjs.org/@wdio/config/-/config-6.10.11.tgz",
-					"integrity": "sha512-yyv1UhJtASykXO6/q6JHmmySMa4NUQirOUVQZSG+viHdTIt/noMXmqD3BKFvev10ZG/k0DnxhXTnU+2aT/7BTA==",
+					"version": "6.12.1",
+					"resolved": "https://registry.npmjs.org/@wdio/config/-/config-6.12.1.tgz",
+					"integrity": "sha512-V5hTIW5FNlZ1W33smHF4Rd5BKjGW2KeYhyXDQfXHjqLCeRiirZ9fABCo9plaVQDnwWSUMWYaAaIAifV82/oJCQ==",
 					"dev": true,
 					"requires": {
 						"@wdio/logger": "6.10.10",
@@ -9649,45 +9552,51 @@
 					},
 					"dependencies": {
 						"ansi-regex": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-							"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+							"version": "5.0.1",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+							"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 							"dev": true
 						},
 						"strip-ansi": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+							"version": "6.0.1",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+							"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 							"dev": true,
 							"requires": {
-								"ansi-regex": "^5.0.0"
+								"ansi-regex": "^5.0.1"
 							}
 						}
 					}
 				},
 				"@wdio/protocols": {
-					"version": "6.10.6",
-					"resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-6.10.6.tgz",
-					"integrity": "sha512-CLLVdc82S+Zij7f9djL90JC1bE5gtaOn+EF2pY4n8XdypqPUa1orQip8stQtX/wXEX0Ak45MEcSU9nCY+CzNnQ==",
+					"version": "6.12.0",
+					"resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-6.12.0.tgz",
+					"integrity": "sha512-UhTBZxClCsM3VjaiDp4DoSCnsa7D1QNmI2kqEBfIpyNkT3GcZhJb7L+nL0fTkzCwi7+/uLastb3/aOwH99gt0A==",
 					"dev": true
 				},
 				"@wdio/repl": {
-					"version": "6.10.11",
-					"resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-6.10.11.tgz",
-					"integrity": "sha512-Ig3WLUi7anpEd8bvRnunZ9PHbVXtkvUQH2wPbEuDcJ3kPwPkKWQl9IK7AyDrIl81RX2S++iBBa4r27IREXWNOQ==",
+					"version": "6.11.0",
+					"resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-6.11.0.tgz",
+					"integrity": "sha512-FxrFKiTkFyELNGGVEH1uijyvNY7lUpmff6x+FGskFGZB4uSRs0rxkOMaEjxnxw7QP1zgQKr2xC7GyO03gIGRGg==",
 					"dev": true,
 					"requires": {
-						"@wdio/utils": "6.10.11"
+						"@wdio/utils": "6.11.0"
 					}
 				},
 				"@wdio/utils": {
-					"version": "6.10.11",
-					"resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-6.10.11.tgz",
-					"integrity": "sha512-x4yc08UWPvP1j7sPKt4Wwyd+z85pVaSYZ+6iyodbXpflCo9uxnQgSmLdDnGDxksREeBVkndsBqhdJHsuI8eWsw==",
+					"version": "6.11.0",
+					"resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-6.11.0.tgz",
+					"integrity": "sha512-vf0sOQzd28WbI26d6/ORrQ4XKWTzSlWLm9W/K/eJO0NASKPEzR+E+Q2kaa+MJ4FKXUpjbt+Lxfo+C26TzBk7tg==",
 					"dev": true,
 					"requires": {
 						"@wdio/logger": "6.10.10"
 					}
+				},
+				"@xmldom/xmldom": {
+					"version": "0.7.5",
+					"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
+					"integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==",
+					"dev": true
 				},
 				"accepts": {
 					"version": "1.3.7",
@@ -9773,9 +9682,9 @@
 					"dev": true
 				},
 				"appium-adb": {
-					"version": "8.9.2",
-					"resolved": "https://registry.npmjs.org/appium-adb/-/appium-adb-8.9.2.tgz",
-					"integrity": "sha512-yp2260MwbYcyfCYwD+oeIKdPm3xQvrA1qq4z0RUf492FJiDycf2tNQyO/R3rUY51vV+CASNI9tgzXBY689aFBw==",
+					"version": "8.16.2",
+					"resolved": "https://registry.npmjs.org/appium-adb/-/appium-adb-8.16.2.tgz",
+					"integrity": "sha512-mWPPY0Z10Q3HiHsiKD5+PJelpU/AtG1Hxr18S2KKM/sRPIFIo05iyboXsGYYg0cx0u3Mtwdq7LEhWRlSWbrr3A==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0",
@@ -9784,31 +9693,30 @@
 						"async-lock": "^1.0.0",
 						"asyncbox": "^2.6.0",
 						"bluebird": "^3.4.7",
-						"ini": "^1.3.5",
+						"ini": "^2.0.0",
 						"lodash": "^4.0.0",
 						"lru-cache": "^6.0.0",
 						"semver": "^7.0.0",
-						"source-map-support": "^0.5.5",
+						"source-map-support": "^0.x",
 						"teen_process": "^1.11.0",
 						"utf7": "^1.0.2"
 					}
 				},
 				"appium-android-driver": {
-					"version": "4.41.1",
-					"resolved": "https://registry.npmjs.org/appium-android-driver/-/appium-android-driver-4.41.1.tgz",
-					"integrity": "sha512-Tg79UXlGAO/YGvksM+8OQrlMYByHXpnc83IpKAiJfMKhEi/DmwiZLk2kOy0QVqrvlJVdBtEoUjo2bfQ52H+ZRw==",
+					"version": "4.51.0",
+					"resolved": "https://registry.npmjs.org/appium-android-driver/-/appium-android-driver-4.51.0.tgz",
+					"integrity": "sha512-OghdG1BdmF6MZiHnulqo+6khxPKKE5Bb4JaGMND/7NG8CFuztAFA3vf4X5g3p3zs5e9a2XoSFUqC5iEoE4zvcQ==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0",
-						"appium-adb": "^8.8.0",
+						"appium-adb": "^8.16.0",
 						"appium-base-driver": "^7.0.0",
 						"appium-chromedriver": "^4.13.0",
 						"appium-support": "^2.47.1",
-						"async-lock": "^1.2.2",
 						"asyncbox": "^2.8.0",
-						"axios": "^0.20.0",
+						"axios": "^0.x",
 						"bluebird": "^3.4.7",
-						"io.appium.settings": "^3.1.0",
+						"io.appium.settings": "^3.3.0",
 						"jimp": "^0.16.1",
 						"lodash": "^4.17.4",
 						"lru-cache": "^6.0.0",
@@ -9820,32 +9728,28 @@
 						"shared-preferences-builder": "^0.0.4",
 						"source-map-support": "^0.5.5",
 						"teen_process": "^1.9.0",
-						"ws": "^7.0.0",
-						"yargs": "^16.0.0"
+						"ws": "^8.0.0"
 					},
 					"dependencies": {
-						"axios": {
-							"version": "0.20.0",
-							"resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-							"integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
-							"dev": true,
-							"requires": {
-								"follow-redirects": "^1.10.0"
-							}
+						"ws": {
+							"version": "8.2.3",
+							"resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+							"integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+							"dev": true
 						}
 					}
 				},
 				"appium-base-driver": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/appium-base-driver/-/appium-base-driver-7.4.0.tgz",
-					"integrity": "sha512-+gh03W6XUsKSprw+8O7uG1i07NI7tpoPHMHM57T2oR05KygxqvrLaQrxej50AtKPWmHHiMaMV4lxxf/YKtKp6g==",
+					"version": "7.11.0",
+					"resolved": "https://registry.npmjs.org/appium-base-driver/-/appium-base-driver-7.11.0.tgz",
+					"integrity": "sha512-EXdLWbj3adRMKgopeaUXeQsoMu8ttVPqYZXPoSjG82IiyaccpnZmAjSkmCwvhlIyW9lw8xM+cwdaF6ZRYMZLLg==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0",
-						"appium-support": "^2.48.0",
+						"appium-support": "^2.54.1",
 						"async-lock": "^1.0.0",
-						"asyncbox": "^2.3.1",
-						"axios": "^0.21.0",
+						"asyncbox": "^2.9.1",
+						"axios": "^0.x",
 						"bluebird": "^3.5.3",
 						"body-parser": "^1.18.2",
 						"colors": "^1.1.2",
@@ -9857,51 +9761,51 @@
 						"method-override": "^3.0.0",
 						"morgan": "^1.9.0",
 						"serve-favicon": "^2.4.5",
-						"source-map-support": "^0.5.5",
+						"source-map-support": "^0.x",
 						"validate.js": "^0.13.0",
 						"webdriverio": "^6.0.2",
-						"ws": "^7.0.0"
+						"ws": "^8.0.0"
+					},
+					"dependencies": {
+						"ws": {
+							"version": "8.2.3",
+							"resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+							"integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+							"dev": true
+						}
 					}
 				},
 				"appium-chromedriver": {
-					"version": "4.26.2",
-					"resolved": "https://registry.npmjs.org/appium-chromedriver/-/appium-chromedriver-4.26.2.tgz",
-					"integrity": "sha512-flBp6H4Ed+YTzk7Bm4lVDS7eeRqMmz7D3xcfZYQhNwaTPgK4Vdde2F/7vU6c2A2Z73UcX3plgNWz4JJ3KtII7w==",
+					"version": "4.27.3",
+					"resolved": "https://registry.npmjs.org/appium-chromedriver/-/appium-chromedriver-4.27.3.tgz",
+					"integrity": "sha512-6yonhwM+DJ7fOJlu/q+UNtSwQ6SiTs6T8XTwP5ce1kEQAdANknOqkLVseqlvDyb1ICgcb2kUHRwtAYdnQZoqeQ==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0",
 						"appium-base-driver": "^7.1.0",
 						"appium-support": "^2.46.0",
 						"asyncbox": "^2.0.2",
-						"axios": "^0.21.0",
+						"axios": "^0.x",
 						"bluebird": "^3.5.1",
 						"compare-versions": "^3.4.0",
 						"fancy-log": "^1.3.2",
 						"lodash": "^4.17.4",
 						"semver": "^7.0.0",
-						"source-map-support": "^0.5.5",
+						"source-map-support": "^0.x",
 						"teen_process": "^1.15.0",
-						"xmldom": "^0.4.0",
-						"xpath": "^0.0.32"
-					},
-					"dependencies": {
-						"xmldom": {
-							"version": "0.4.0",
-							"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.4.0.tgz",
-							"integrity": "sha512-2E93k08T30Ugs+34HBSTQLVtpi6mCddaY8uO+pMNk1pqSjV5vElzn4mmh6KLxN3hki8rNcHSYzILoh3TEWORvA==",
-							"dev": true
-						}
+						"xmldom": "^0.x",
+						"xpath": "^0.x"
 					}
 				},
 				"appium-espresso-driver": {
-					"version": "1.41.0",
-					"resolved": "https://registry.npmjs.org/appium-espresso-driver/-/appium-espresso-driver-1.41.0.tgz",
-					"integrity": "sha512-EJU2NepjadwDPXQbHRyy4ydE5d7CuR+15a68tJHGI6olfTjcXm5fNyAd2JI4rCQMwGW4bsa1IXGuNG0QrS5TWg==",
+					"version": "1.45.3",
+					"resolved": "https://registry.npmjs.org/appium-espresso-driver/-/appium-espresso-driver-1.45.3.tgz",
+					"integrity": "sha512-CzWOsCD4z/67XmIfZzptiWYfHjGwjSOiltXwgTEi6WAL4WzBtz0tORu4+oYXNssen8EZ/ljgckcIA8GPB+5aKA==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.4.3",
 						"appium-adb": "^8.9.0",
-						"appium-android-driver": "^4.40.0",
+						"appium-android-driver": "^4.45.0",
 						"appium-base-driver": "^7.0.0",
 						"appium-support": "^2.46.0",
 						"asyncbox": "^2.3.1",
@@ -9909,14 +9813,13 @@
 						"lodash": "^4.17.11",
 						"portscanner": "^2.1.1",
 						"source-map-support": "^0.5.8",
-						"validate.js": "^0.13.0",
-						"yargs": "^16.0.2"
+						"validate.js": "^0.x"
 					}
 				},
 				"appium-fake-driver": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/appium-fake-driver/-/appium-fake-driver-1.0.1.tgz",
-					"integrity": "sha512-gbDPWleCCOixH2ImlvS6CsEKEuePpSFFdbMkDA2Ie2H5EEdAAMUZEtI9DwlcTTKNcrwM58SNdPraQTnopFlHrQ==",
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/appium-fake-driver/-/appium-fake-driver-1.0.2.tgz",
+					"integrity": "sha512-mPyAbhoSupDMHrqq3gKdt4W8Boa349O2p/oirsNCyzNAJrHBlpFrLajRhjhLhPS5k0Snasas7l+jYkzZKqAt9Q==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0",
@@ -9925,217 +9828,33 @@
 						"asyncbox": "^2.3.2",
 						"bluebird": "^3.5.1",
 						"lodash": "^4.17.4",
-						"source-map-support": "^0.5.5",
-						"xmldom": "^0.3.0",
-						"xpath": "0.0.27",
-						"yargs": "^15.0.1"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-							"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-							"dev": true
-						},
-						"cliui": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-							"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-							"dev": true,
-							"requires": {
-								"string-width": "^4.2.0",
-								"strip-ansi": "^6.0.0",
-								"wrap-ansi": "^6.2.0"
-							}
-						},
-						"is-fullwidth-code-point": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-							"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-							"dev": true
-						},
-						"string-width": {
-							"version": "4.2.0",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-							"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-							"dev": true,
-							"requires": {
-								"emoji-regex": "^8.0.0",
-								"is-fullwidth-code-point": "^3.0.0",
-								"strip-ansi": "^6.0.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^5.0.0"
-							}
-						},
-						"wrap-ansi": {
-							"version": "6.2.0",
-							"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-							"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.0.0",
-								"string-width": "^4.1.0",
-								"strip-ansi": "^6.0.0"
-							}
-						},
-						"xmldom": {
-							"version": "0.3.0",
-							"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.3.0.tgz",
-							"integrity": "sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g==",
-							"dev": true
-						},
-						"xpath": {
-							"version": "0.0.27",
-							"resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.27.tgz",
-							"integrity": "sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ==",
-							"dev": true
-						},
-						"y18n": {
-							"version": "4.0.1",
-							"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-							"integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
-							"dev": true
-						},
-						"yargs": {
-							"version": "15.4.1",
-							"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-							"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-							"dev": true,
-							"requires": {
-								"cliui": "^6.0.0",
-								"decamelize": "^1.2.0",
-								"find-up": "^4.1.0",
-								"get-caller-file": "^2.0.1",
-								"require-directory": "^2.1.1",
-								"require-main-filename": "^2.0.0",
-								"set-blocking": "^2.0.0",
-								"string-width": "^4.2.0",
-								"which-module": "^2.0.0",
-								"y18n": "^4.0.0",
-								"yargs-parser": "^18.1.2"
-							}
-						},
-						"yargs-parser": {
-							"version": "18.1.3",
-							"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-							"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-							"dev": true,
-							"requires": {
-								"camelcase": "^5.0.0",
-								"decamelize": "^1.2.0"
-							}
-						}
+						"source-map-support": "^0.x",
+						"xmldom": "^0.x",
+						"xpath": "^0.x"
 					}
 				},
 				"appium-flutter-driver": {
-					"version": "0.0.25",
-					"resolved": "https://registry.npmjs.org/appium-flutter-driver/-/appium-flutter-driver-0.0.25.tgz",
-					"integrity": "sha512-ZM8y1XuuNb7P9FqvDlL7iFAWmVXhgb8IAGUlcUdi/N+5/tpT5CueE6uq8IJpfpGQKAVoOzbUT34Ie1YXvHL/sQ==",
+					"version": "0.0.32",
+					"resolved": "https://registry.npmjs.org/appium-flutter-driver/-/appium-flutter-driver-0.0.32.tgz",
+					"integrity": "sha512-Hl00luaY9duDQbg/LSXxJDYX/CXL+ZZxtiQ7Ms1F4GEt6SF6v9J4yd3vo6MWR8/nJmksP0XbyqaGRdrUOlMu8g==",
 					"dev": true,
 					"requires": {
-						"appium-base-driver": "^5.0.0",
+						"appium-adb": "^8.8.0",
+						"appium-base-driver": "^7.4.1",
+						"appium-ios-device": "^1.7.1",
+						"appium-support": "^2.47.1",
 						"appium-uiautomator2-driver": "^1.35.1",
 						"appium-xcuitest-driver": "^3.17.0",
+						"asyncbox": "^2.3.1",
+						"bluebird": "^3.1.1",
+						"portscanner": "2.2.0",
 						"rpc-websockets": "^5.1.1"
-					},
-					"dependencies": {
-						"appium-base-driver": {
-							"version": "5.8.1",
-							"resolved": "https://registry.npmjs.org/appium-base-driver/-/appium-base-driver-5.8.1.tgz",
-							"integrity": "sha512-k5ybExgP0kJx7vsR0Y8GeEay+Vr0yCs0muzYtdrIDbqOCz5bFX0skyZubSSsm/lOE4KvgHhm4cRwWJM0DlHvRA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.0.0",
-								"appium-support": "^2.46.0",
-								"async-lock": "^1.0.0",
-								"asyncbox": "^2.3.1",
-								"axios": "^0.19.2",
-								"bluebird": "^3.5.3",
-								"body-parser": "^1.18.2",
-								"colors": "^1.1.2",
-								"es6-error": "^4.1.1",
-								"express": "^4.16.2",
-								"http-status-codes": "^1.3.0",
-								"lodash": "^4.0.0",
-								"lru-cache": "^5.0.0",
-								"method-override": "^3.0.0",
-								"morgan": "^1.9.0",
-								"request": "^2.88.2",
-								"request-promise": "^4.2.5",
-								"serve-favicon": "^2.4.5",
-								"source-map-support": "^0.5.5",
-								"validate.js": "^0.13.0",
-								"webdriverio": "^6.0.2",
-								"ws": "^7.0.0"
-							}
-						},
-						"axios": {
-							"version": "0.19.2",
-							"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-							"integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-							"dev": true,
-							"requires": {
-								"follow-redirects": "1.5.10"
-							}
-						},
-						"debug": {
-							"version": "3.1.0",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-							"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-							"dev": true,
-							"requires": {
-								"ms": "2.0.0"
-							}
-						},
-						"follow-redirects": {
-							"version": "1.5.10",
-							"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-							"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-							"dev": true,
-							"requires": {
-								"debug": "=3.1.0"
-							}
-						},
-						"http-status-codes": {
-							"version": "1.4.0",
-							"resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-1.4.0.tgz",
-							"integrity": "sha512-JrT3ua+WgH8zBD3HEJYbeEgnuQaAnUeRRko/YojPAJjGmIfGD3KPU/asLdsLwKjfxOmQe5nXMQ0pt/7MyapVbQ==",
-							"dev": true
-						},
-						"lru-cache": {
-							"version": "5.1.1",
-							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-							"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-							"dev": true,
-							"requires": {
-								"yallist": "^3.0.2"
-							}
-						},
-						"ms": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-							"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-							"dev": true
-						},
-						"yallist": {
-							"version": "3.1.1",
-							"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-							"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-							"dev": true
-						}
 					}
 				},
 				"appium-geckodriver": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/appium-geckodriver/-/appium-geckodriver-0.3.2.tgz",
-					"integrity": "sha512-2yQ6al64mU6PEfDBvMxe8gM+kcT9Y7+uT2jlgD1Z74r0qRItPQRn+TixMO0HSxv3+RLoXBP3/WhMQO+IO+gDeA==",
+					"version": "0.3.3",
+					"resolved": "https://registry.npmjs.org/appium-geckodriver/-/appium-geckodriver-0.3.3.tgz",
+					"integrity": "sha512-bPv3a+2nl73kUSaOFKdFfoSTgUyF+XE8dn43fv9gpvNne4MbIGKfdGJFQ23xQ9bc4kr9qvVeIwVwJGcYXsgqoQ==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0",
@@ -10146,14 +9865,13 @@
 						"lodash": "^4.17.4",
 						"portscanner": "2.2.0",
 						"source-map-support": "^0.5.5",
-						"teen_process": "^1.15.0",
-						"yargs": "^16.1.0"
+						"teen_process": "^1.15.0"
 					}
 				},
 				"appium-idb": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/appium-idb/-/appium-idb-0.5.0.tgz",
-					"integrity": "sha512-6IayLxBbN/2fOzbxjpOt/ntoFlFfcyZbURKyeH9XJyAjjN5iIG+i8EWGof6tMM5BHDC1mOJcPZkFaQtYi/Y5Iw==",
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/appium-idb/-/appium-idb-0.5.1.tgz",
+					"integrity": "sha512-xijrqWSxJtKtWvXPVVR/FkVJtfQ5DwVCCA5R0nV0jMOtET55CoKKx0TO7KIiuZaHfQv/dbBCR8u7SEe3MF5Q9Q==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0",
@@ -10166,9 +9884,9 @@
 					}
 				},
 				"appium-ios-device": {
-					"version": "1.7.1",
-					"resolved": "https://registry.npmjs.org/appium-ios-device/-/appium-ios-device-1.7.1.tgz",
-					"integrity": "sha512-kMsj/jjYqNRNgKpl7waXzWv9ydioMmGy1hGvdbhLHFI8oNMw71KJlK0rQtJ2Abw1H2zf92bpjpmoCBmO+UyICQ==",
+					"version": "1.8.0",
+					"resolved": "https://registry.npmjs.org/appium-ios-device/-/appium-ios-device-1.8.0.tgz",
+					"integrity": "sha512-l4PVO0RSCsgd9wLiHhpBOlCP2wM0ND3+9+UMKP72c3qaaC2JxEqiKNIoc0r/jW7D5/Aoh/MtTT2yFHvqtZ0r/Q==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0",
@@ -10180,9 +9898,9 @@
 					}
 				},
 				"appium-ios-driver": {
-					"version": "4.8.0",
-					"resolved": "https://registry.npmjs.org/appium-ios-driver/-/appium-ios-driver-4.8.0.tgz",
-					"integrity": "sha512-jjZWJ5DR0x8J9HCCf4EDihwJmd+BV0SEIUOQyVLQj1FZq99DWIIBnpTDbu1LaU9WIMNC2a8JqvKp/T/6XnzQGg==",
+					"version": "4.8.3",
+					"resolved": "https://registry.npmjs.org/appium-ios-driver/-/appium-ios-driver-4.8.3.tgz",
+					"integrity": "sha512-eC7dsZGHBkyHxsNGtX3eHl4BmQGEwcUKwddfAXig01EkWx7CkJ7rI+3L2H2IW9wt8yo8QZFuNTIw2HDLwKT3Kw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0",
@@ -10192,23 +9910,22 @@
 						"appium-support": "^2.41.0",
 						"appium-xcode": "^3.1.0",
 						"asyncbox": "^2.3.1",
-						"axios": "^0.20.0",
+						"axios": "^0.x",
 						"bluebird": "^3.5.1",
 						"colors": "^1.1.2",
 						"js2xmlparser2": "^0.2.0",
 						"lodash": "^4.13.1",
 						"moment": "^2.24.0",
-						"moment-timezone": "^0.5.26",
+						"moment-timezone": "^0.x",
 						"node-idevice": "^0.1.6",
 						"pem": "^1.8.3",
 						"portfinder": "^1.0.13",
 						"safari-launcher": "^2.0.5",
-						"source-map-support": "^0.5.5",
+						"source-map-support": "^0.x",
 						"teen_process": "^1.6.0",
 						"through": "^2.3.8",
-						"xmldom": "^0.3.0",
-						"xpath": "^0.0.24",
-						"yargs": "^16.0.0"
+						"xmldom": "^0.x",
+						"xpath": "^0.x"
 					},
 					"dependencies": {
 						"@wdio/config": {
@@ -10351,15 +10068,6 @@
 								"lodash": "^4.17.14"
 							}
 						},
-						"axios": {
-							"version": "0.20.0",
-							"resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-							"integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
-							"dev": true,
-							"requires": {
-								"follow-redirects": "^1.10.0"
-							}
-						},
 						"chalk": {
 							"version": "3.0.0",
 							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
@@ -10498,18 +10206,6 @@
 								"webdriver": "5.23.0"
 							}
 						},
-						"xmldom": {
-							"version": "0.3.0",
-							"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.3.0.tgz",
-							"integrity": "sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g==",
-							"dev": true
-						},
-						"xpath": {
-							"version": "0.0.24",
-							"resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.24.tgz",
-							"integrity": "sha1-Gt4WLhzFI8jTn8fQavwW6iFvKfs=",
-							"dev": true
-						},
 						"yallist": {
 							"version": "3.1.1",
 							"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -10530,37 +10226,121 @@
 					}
 				},
 				"appium-ios-simulator": {
-					"version": "3.27.0",
-					"resolved": "https://registry.npmjs.org/appium-ios-simulator/-/appium-ios-simulator-3.27.0.tgz",
-					"integrity": "sha512-JCg1Q98QSLZOpghLPeQ6jhvJg4PCJ6pQm94iDV7n9L8Gq5YP7teLCZTKoTtPHKC5mC5LbOq/JPL3zuAl+/LpkA==",
+					"version": "3.29.0",
+					"resolved": "https://registry.npmjs.org/appium-ios-simulator/-/appium-ios-simulator-3.29.0.tgz",
+					"integrity": "sha512-7Y6KJJI3K4V35xbJeEwyedPg0DACYmv7cyyyoMbyz7PcLmoaKcufziNYwhlIiiKJIlPc+U/MJfeWUBSQ6W5/Vg==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0",
+						"@xmldom/xmldom": "^0.x",
 						"appium-support": "^2.44.0",
 						"appium-xcode": "^3.1.0",
 						"async-lock": "^1.0.0",
 						"asyncbox": "^2.3.1",
 						"bluebird": "^3.5.1",
 						"lodash": "^4.2.1",
-						"node-simctl": "^6.4.0",
+						"node-simctl": "^6.6.0",
 						"semver": "^7.0.0",
 						"source-map-support": "^0.5.3",
-						"teen_process": "^1.3.0",
-						"xmldom": "^0.4.0"
+						"teen_process": "^1.3.0"
 					},
 					"dependencies": {
-						"xmldom": {
-							"version": "0.4.0",
-							"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.4.0.tgz",
-							"integrity": "sha512-2E93k08T30Ugs+34HBSTQLVtpi6mCddaY8uO+pMNk1pqSjV5vElzn4mmh6KLxN3hki8rNcHSYzILoh3TEWORvA==",
+						"ansi-regex": {
+							"version": "5.0.1",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+							"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 							"dev": true
+						},
+						"are-we-there-yet": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+							"integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+							"dev": true,
+							"requires": {
+								"delegates": "^1.0.0",
+								"readable-stream": "^3.6.0"
+							}
+						},
+						"gauge": {
+							"version": "3.0.2",
+							"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+							"integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+							"dev": true,
+							"requires": {
+								"aproba": "^1.0.3 || ^2.0.0",
+								"color-support": "^1.1.2",
+								"console-control-strings": "^1.0.0",
+								"has-unicode": "^2.0.1",
+								"object-assign": "^4.1.1",
+								"signal-exit": "^3.0.0",
+								"string-width": "^4.2.3",
+								"strip-ansi": "^6.0.1",
+								"wide-align": "^1.1.2"
+							}
+						},
+						"is-fullwidth-code-point": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+							"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+							"dev": true
+						},
+						"node-simctl": {
+							"version": "6.6.0",
+							"resolved": "https://registry.npmjs.org/node-simctl/-/node-simctl-6.6.0.tgz",
+							"integrity": "sha512-157a3XqQFatcPT8BijH3IQml/GW8qByVjhe04reG86SawyJGfosM3s+qugd1kaar3nsKo+ad6KSS4GB7e9fxig==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.0.0",
+								"asyncbox": "^2.3.1",
+								"bluebird": "^3.5.1",
+								"lodash": "^4.2.1",
+								"npmlog": "^5.0.0",
+								"rimraf": "^3.0.0",
+								"semver": "^7.0.0",
+								"source-map-support": "^0.5.5",
+								"teen_process": "^1.5.1",
+								"uuid": "^8.0.0",
+								"which": "^2.0.0"
+							}
+						},
+						"npmlog": {
+							"version": "5.0.1",
+							"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+							"integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+							"dev": true,
+							"requires": {
+								"are-we-there-yet": "^2.0.0",
+								"console-control-strings": "^1.1.0",
+								"gauge": "^3.0.0",
+								"set-blocking": "^2.0.0"
+							}
+						},
+						"string-width": {
+							"version": "4.2.3",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+							"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+							"dev": true,
+							"requires": {
+								"emoji-regex": "^8.0.0",
+								"is-fullwidth-code-point": "^3.0.0",
+								"strip-ansi": "^6.0.1"
+							}
+						},
+						"strip-ansi": {
+							"version": "6.0.1",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+							"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^5.0.1"
+							}
 						}
 					}
 				},
 				"appium-mac-driver": {
-					"version": "1.10.1",
-					"resolved": "https://registry.npmjs.org/appium-mac-driver/-/appium-mac-driver-1.10.1.tgz",
-					"integrity": "sha512-EEl9iKgL7HUI6Tc8iyOLPOxHeKf1NKgekNGVR6TTQkiyV6zzYFsdutRZBvB7KfYVuRCtvAvgP5TE3K3Y0kU7SA==",
+					"version": "1.10.2",
+					"resolved": "https://registry.npmjs.org/appium-mac-driver/-/appium-mac-driver-1.10.2.tgz",
+					"integrity": "sha512-gsCcFvh7yWvCWpW1Zrmb8jMXLdJ6T1F5oJBkX6uh+qW354nKD/45Pm0skuWNSObXIc4VN9xCBc7CLsOBVMoX7Q==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0",
@@ -10570,26 +10350,25 @@
 						"bluebird": "^3.5.1",
 						"lodash": "^4.17.4",
 						"source-map-support": "^0.5.5",
-						"teen_process": "^1.15.0",
-						"yargs": "^16.0.3"
+						"teen_process": "^1.15.0"
 					}
 				},
 				"appium-mac2-driver": {
-					"version": "0.8.1",
-					"resolved": "https://registry.npmjs.org/appium-mac2-driver/-/appium-mac2-driver-0.8.1.tgz",
-					"integrity": "sha512-uqd+uxO3DrNb22hJTME/zgm/f4IJjRPvlcp5W3zdcMYmcZmeE4H9NaemPAl29l2NLEgrrMgMzCYuJiwnMX3ifA==",
+					"version": "0.14.1",
+					"resolved": "https://registry.npmjs.org/appium-mac2-driver/-/appium-mac2-driver-0.14.1.tgz",
+					"integrity": "sha512-gq7A0Q2w7cUF3ZTC+jWSSGEjRhF2ifFr/3IcOMxLwXY6LmgD7eavPdVYZ+DYw8a7dRkUZdnSWuWcyfSCCxplQQ==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0",
 						"appium-base-driver": "^7.1.0",
 						"appium-support": "^2.46.0",
 						"asyncbox": "^2.0.2",
+						"axios": "^0.x",
 						"bluebird": "^3.5.1",
 						"lodash": "^4.17.4",
 						"portscanner": "2.2.0",
 						"source-map-support": "^0.5.5",
-						"teen_process": "^1.15.0",
-						"yargs": "^16.1.0"
+						"teen_process": "^1.15.0"
 					}
 				},
 				"appium-remote-debugger": {
@@ -10610,9 +10389,9 @@
 					}
 				},
 				"appium-safari-driver": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/appium-safari-driver/-/appium-safari-driver-2.2.0.tgz",
-					"integrity": "sha512-QD1xIVEnzoeCCATHdUhqAGBPJjPUXnIgNMUDishj3gCsIApdvBFsY0kIJGhJ27aWEUPMx/TzrM3n9JYXJc9JwQ==",
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/appium-safari-driver/-/appium-safari-driver-2.2.1.tgz",
+					"integrity": "sha512-aOE4TWs6945e4uYzo45JN6idQn8m5E7Pl2y3M5wCB5qjIocTqY43Oq9zPgORFZEmaOON7n0Y4d4mCLsptNrwxA==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0",
@@ -10621,10 +10400,10 @@
 						"asyncbox": "^2.0.2",
 						"bluebird": "^3.5.1",
 						"lodash": "^4.17.4",
+						"node-simctl": "^6.4.0",
 						"portscanner": "2.2.0",
 						"source-map-support": "^0.5.5",
-						"teen_process": "^1.15.0",
-						"yargs": "^16.1.0"
+						"teen_process": "^1.15.0"
 					}
 				},
 				"appium-sdb": {
@@ -10642,35 +10421,34 @@
 					}
 				},
 				"appium-support": {
-					"version": "2.49.0",
-					"resolved": "https://registry.npmjs.org/appium-support/-/appium-support-2.49.0.tgz",
-					"integrity": "sha512-PtUsfpCjdGqZTTuRyH5U9iOGq9SpEVHg0H6/2HrazkX6ZvSQ+kIVYHTAGIXVeBJecfN9/syqgMmEekVgD15BGA==",
+					"version": "2.54.1",
+					"resolved": "https://registry.npmjs.org/appium-support/-/appium-support-2.54.1.tgz",
+					"integrity": "sha512-Nhbduhtj9CwDAhOH77Ux5nyXpccIw9kz2WW0eLwIn2BoEEIcRjEcAdIvXQ2qTqURhVAHd4VyATllf1oAVYFbkQ==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0",
 						"archiver": "^5.0.0",
-						"axios": "^0.20.0",
+						"axios": "^0.x",
 						"base64-stream": "^1.0.0",
 						"bluebird": "^3.5.1",
 						"bplist-creator": "^0",
-						"bplist-parser": "^0.2",
-						"form-data": "^3.0.0",
+						"bplist-parser": "^0.x",
+						"form-data": "^4.0.0",
 						"get-stream": "^6.0.0",
 						"glob": "^7.1.2",
-						"jimp": "^0.14.0",
+						"jimp": "^0.x",
 						"jsftp": "^2.1.2",
 						"klaw": "^3.0.0",
 						"lockfile": "^1.0.4",
 						"lodash": "^4.2.1",
-						"mjpeg-server": "^0.3.0",
 						"mkdirp": "^1.0.0",
 						"moment": "^2.24.0",
 						"mv": "^2.1.1",
 						"ncp": "^2.0.0",
-						"npmlog": "^4.1.2",
+						"npmlog": "^5.0.0",
 						"plist": "^3.0.1",
 						"pluralize": "^8.0.0",
-						"pngjs": "^5.0.0",
+						"pngjs": "^6.0.0",
 						"rimraf": "^3.0.0",
 						"sanitize-filename": "^1.6.1",
 						"semver": "^7.0.0",
@@ -10682,26 +10460,33 @@
 						"yauzl": "^2.7.0"
 					},
 					"dependencies": {
-						"axios": {
-							"version": "0.20.0",
-							"resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-							"integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+						"gauge": {
+							"version": "3.0.1",
+							"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.1.tgz",
+							"integrity": "sha512-6STz6KdQgxO4S/ko+AbjlFGGdGcknluoqU+79GOFCDqqyYj5OanQf9AjxwN0jCidtT+ziPMmPSt9E4hfQ0CwIQ==",
 							"dev": true,
 							"requires": {
-								"follow-redirects": "^1.10.0"
+								"aproba": "^1.0.3 || ^2.0.0",
+								"color-support": "^1.1.2",
+								"console-control-strings": "^1.0.0",
+								"has-unicode": "^2.0.1",
+								"object-assign": "^4.1.1",
+								"signal-exit": "^3.0.0",
+								"string-width": "^1.0.1 || ^2.0.0",
+								"strip-ansi": "^3.0.1 || ^4.0.0",
+								"wide-align": "^1.1.2"
 							}
 						},
-						"jimp": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/jimp/-/jimp-0.14.0.tgz",
-							"integrity": "sha512-8BXU+J8+SPmwwyq9ELihpSV4dWPTiOKBWCEgtkbnxxAVMjXdf3yGmyaLSshBfXc8sP/JQ9OZj5R8nZzz2wPXgA==",
+						"npmlog": {
+							"version": "5.0.0",
+							"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.0.tgz",
+							"integrity": "sha512-ftpIiLjerL2tUg3dCqN8pOSoB90gqZlzv/gaZoxHaKjeLClrfJIEQ1Pdxi6qSzflz916Bljdy8dTWQ4J7hAFSQ==",
 							"dev": true,
 							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/custom": "^0.14.0",
-								"@jimp/plugins": "^0.14.0",
-								"@jimp/types": "^0.14.0",
-								"regenerator-runtime": "^0.13.3"
+								"are-we-there-yet": "^1.1.5",
+								"console-control-strings": "^1.1.0",
+								"gauge": "^3.0.0",
+								"set-blocking": "^2.0.0"
 							}
 						}
 					}
@@ -11151,34 +10936,6 @@
 								"supports-color": "^7.1.0"
 							}
 						},
-						"cliui": {
-							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-							"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-							"dev": true,
-							"requires": {
-								"string-width": "^2.1.1",
-								"strip-ansi": "^4.0.0",
-								"wrap-ansi": "^2.0.0"
-							},
-							"dependencies": {
-								"ansi-regex": {
-									"version": "3.0.0",
-									"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-									"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-									"dev": true
-								},
-								"strip-ansi": {
-									"version": "4.0.0",
-									"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-									"integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
-									"dev": true,
-									"requires": {
-										"ansi-regex": "^3.0.0"
-									}
-								}
-							}
-						},
 						"compress-commons": {
 							"version": "2.1.1",
 							"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
@@ -11218,31 +10975,10 @@
 								"readable-stream": "^3.4.0"
 							}
 						},
-						"find-up": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-							"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-							"dev": true,
-							"requires": {
-								"locate-path": "^3.0.0"
-							}
-						},
-						"get-caller-file": {
-							"version": "1.0.3",
-							"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-							"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-							"dev": true
-						},
 						"http-status-codes": {
 							"version": "1.4.0",
 							"resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-1.4.0.tgz",
 							"integrity": "sha512-JrT3ua+WgH8zBD3HEJYbeEgnuQaAnUeRRko/YojPAJjGmIfGD3KPU/asLdsLwKjfxOmQe5nXMQ0pt/7MyapVbQ==",
-							"dev": true
-						},
-						"is-fullwidth-code-point": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-							"integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
 							"dev": true
 						},
 						"jimp": {
@@ -11263,16 +10999,6 @@
 							"resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.7.tgz",
 							"integrity": "sha512-9IXdWudL61npZjvLuVe/ktHiA41iE8qFyLB+4VDTblEsWBzeg8WQTlktdUK4CdncUqtUgUg0bbOmTE2bKBKaBQ==",
 							"dev": true
-						},
-						"locate-path": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-							"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-							"dev": true,
-							"requires": {
-								"p-locate": "^3.0.0",
-								"path-exists": "^3.0.0"
-							}
 						},
 						"lru-cache": {
 							"version": "5.1.1",
@@ -11298,31 +11024,10 @@
 								"minimist": "0.0.8"
 							}
 						},
-						"p-locate": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-							"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-							"dev": true,
-							"requires": {
-								"p-limit": "^2.0.0"
-							}
-						},
-						"path-exists": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-							"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-							"dev": true
-						},
 						"pngjs": {
 							"version": "3.4.0",
 							"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
 							"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
-							"dev": true
-						},
-						"require-main-filename": {
-							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-							"integrity": "sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug==",
 							"dev": true
 						},
 						"rgb2hex": {
@@ -11338,33 +11043,6 @@
 							"dev": true,
 							"requires": {
 								"type-fest": "^0.8.0"
-							}
-						},
-						"string-width": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-							"dev": true,
-							"requires": {
-								"is-fullwidth-code-point": "^2.0.0",
-								"strip-ansi": "^4.0.0"
-							},
-							"dependencies": {
-								"ansi-regex": {
-									"version": "3.0.0",
-									"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-									"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-									"dev": true
-								},
-								"strip-ansi": {
-									"version": "4.0.0",
-									"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-									"integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
-									"dev": true,
-									"requires": {
-										"ansi-regex": "^3.0.0"
-									}
-								}
 							}
 						},
 						"strip-ansi": {
@@ -11420,94 +11098,11 @@
 								"webdriver": "5.23.0"
 							}
 						},
-						"wrap-ansi": {
-							"version": "2.1.0",
-							"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-							"integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
-							"dev": true,
-							"requires": {
-								"string-width": "^1.0.1",
-								"strip-ansi": "^3.0.1"
-							},
-							"dependencies": {
-								"ansi-regex": {
-									"version": "2.1.1",
-									"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-									"integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-									"dev": true
-								},
-								"is-fullwidth-code-point": {
-									"version": "1.0.0",
-									"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-									"integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
-									"dev": true,
-									"requires": {
-										"number-is-nan": "^1.0.0"
-									}
-								},
-								"string-width": {
-									"version": "1.0.2",
-									"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-									"integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
-									"dev": true,
-									"requires": {
-										"code-point-at": "^1.0.0",
-										"is-fullwidth-code-point": "^1.0.0",
-										"strip-ansi": "^3.0.0"
-									}
-								},
-								"strip-ansi": {
-									"version": "3.0.1",
-									"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-									"integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-									"dev": true,
-									"requires": {
-										"ansi-regex": "^2.0.0"
-									}
-								}
-							}
-						},
-						"y18n": {
-							"version": "4.0.1",
-							"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-							"integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
-							"dev": true
-						},
 						"yallist": {
 							"version": "3.1.1",
 							"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
 							"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 							"dev": true
-						},
-						"yargs": {
-							"version": "12.0.5",
-							"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-							"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
-							"dev": true,
-							"requires": {
-								"cliui": "^4.0.0",
-								"decamelize": "^1.2.0",
-								"find-up": "^3.0.0",
-								"get-caller-file": "^1.0.1",
-								"os-locale": "^3.0.0",
-								"require-directory": "^2.1.1",
-								"require-main-filename": "^1.0.1",
-								"set-blocking": "^2.0.0",
-								"string-width": "^2.0.0",
-								"which-module": "^2.0.0",
-								"y18n": "^3.2.1 || ^4.0.0",
-								"yargs-parser": "^11.1.1"
-							}
-						},
-						"yargs-parser": {
-							"version": "11.1.1",
-							"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-							"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-							"dev": true,
-							"requires": {
-								"camelcase": "^5.0.0",
-								"decamelize": "^1.2.0"
-							}
 						},
 						"zip-stream": {
 							"version": "2.1.3",
@@ -11523,39 +11118,38 @@
 					}
 				},
 				"appium-uiautomator2-driver": {
-					"version": "1.61.2",
-					"resolved": "https://registry.npmjs.org/appium-uiautomator2-driver/-/appium-uiautomator2-driver-1.61.2.tgz",
-					"integrity": "sha512-BPR4R898h7+XUiZDVQTZWpLSNmiX1+xL33m1MZV0pFxt4Uy1VFWWgOTcF49MTDKEiePZoWwfZtRYRsgvdBAybQ==",
+					"version": "1.70.1",
+					"resolved": "https://registry.npmjs.org/appium-uiautomator2-driver/-/appium-uiautomator2-driver-1.70.1.tgz",
+					"integrity": "sha512-KMCjO4QBcBy+vqWDx0mIhP90vr/1dMDqE0m6LR4MlHCREeJn2BhzRaepTLJCYvDDOtItI2gkgrjkCp9sbKuLzg==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0",
-						"appium-adb": "^8.9.0",
-						"appium-android-driver": "^4.40.0",
+						"appium-adb": "^8.10.0",
+						"appium-android-driver": "^4.50.0",
 						"appium-base-driver": "^7.0.0",
 						"appium-chromedriver": "^4.23.1",
 						"appium-support": "^2.49.0",
-						"appium-uiautomator2-server": "^4.17.4",
+						"appium-uiautomator2-server": "^4.26.0",
 						"asyncbox": "^2.3.1",
-						"axios": "^0.21.0",
+						"axios": "^0.x",
 						"bluebird": "^3.5.1",
 						"css-selector-parser": "^1.4.1",
 						"lodash": "^4.17.4",
 						"portscanner": "2.2.0",
 						"source-map-support": "^0.5.5",
-						"teen_process": "^1.3.1",
-						"yargs": "^16.0.0"
+						"teen_process": "^1.3.1"
 					}
 				},
 				"appium-uiautomator2-server": {
-					"version": "4.17.4",
-					"resolved": "https://registry.npmjs.org/appium-uiautomator2-server/-/appium-uiautomator2-server-4.17.4.tgz",
-					"integrity": "sha512-x4FqjU6usdLHtOfjbwS6MM55tYYb4IfqojGe5olC5Hw6umQ57rK6LEnnUwFcUd7NrBcTfsklMANJV6s89S4nfQ==",
+					"version": "4.27.0",
+					"resolved": "https://registry.npmjs.org/appium-uiautomator2-server/-/appium-uiautomator2-server-4.27.0.tgz",
+					"integrity": "sha512-R7cX/9UGUuUheFBnDMI6lQezQJKUfHdnZRKoXNtqxyAlzpgAhJNoG62LHEL3e5nygq1Qt2DQmbFB5xgNXUvomg==",
 					"dev": true
 				},
 				"appium-webdriveragent": {
-					"version": "2.32.2",
-					"resolved": "https://registry.npmjs.org/appium-webdriveragent/-/appium-webdriveragent-2.32.2.tgz",
-					"integrity": "sha512-ia1bjyswSJiTaW2CKUAKIOMHqZA1NtGUu5ltEnRmSu+NhKCixVqWGKCOiJyic/vh0OtxI74DMs0V3AWGGxFlmw==",
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/appium-webdriveragent/-/appium-webdriveragent-3.17.0.tgz",
+					"integrity": "sha512-gHtx1uPCQlJn4k2cnMyyOPf4dCaNy0eFt6Oc1bPXkxrYm0X04ZVLFUSIdqBL9n5YKv8Igg3/mkqt4TzWyZxrFw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0",
@@ -11564,7 +11158,7 @@
 						"appium-support": "^2.46.0",
 						"async-lock": "^1.0.0",
 						"asyncbox": "^2.5.3",
-						"axios": "^0.21.0",
+						"axios": "^0.x",
 						"bluebird": "^3.5.5",
 						"lodash": "^4.17.11",
 						"node-simctl": "^6.0.2",
@@ -11573,9 +11167,9 @@
 					}
 				},
 				"appium-windows-driver": {
-					"version": "1.17.0",
-					"resolved": "https://registry.npmjs.org/appium-windows-driver/-/appium-windows-driver-1.17.0.tgz",
-					"integrity": "sha512-Wz7LzPhxZN8C1qiuQnf4kZ6SuTqkEla6i0hp77W7bCCgI2anXoJ+kAEbO0Ue/ueEOIE6bQXxhz90B2Wdl0r4Vw==",
+					"version": "1.19.1",
+					"resolved": "https://registry.npmjs.org/appium-windows-driver/-/appium-windows-driver-1.19.1.tgz",
+					"integrity": "sha512-iZW51z88VQKPA851IshZaWyogfoI05QKqH9ltzuKHkHgdvWm/DLnAXmeQHfJi+nUaBy+D92PLiyHnAvJJTRB/Q==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0",
@@ -11583,17 +11177,17 @@
 						"appium-support": "^2.49.0",
 						"asyncbox": "^2.3.1",
 						"bluebird": "^3.5.1",
+						"es6-error": "^4.1.1",
 						"lodash": "^4.6.1",
 						"portscanner": "2.2.0",
 						"source-map-support": "^0.5.5",
-						"teen_process": "^1.7.0",
-						"yargs": "^16.0.2"
+						"teen_process": "^1.7.0"
 					}
 				},
 				"appium-xcode": {
-					"version": "3.10.0",
-					"resolved": "https://registry.npmjs.org/appium-xcode/-/appium-xcode-3.10.0.tgz",
-					"integrity": "sha512-6Db49w2UjcdMn96nUMS/EGKE/6r/sgIPcw8mr9+e4Oeb5rvROAm/VeIWmwnov3uk2JG3SGkLTQRB9tROKKRDgw==",
+					"version": "3.11.0",
+					"resolved": "https://registry.npmjs.org/appium-xcode/-/appium-xcode-3.11.0.tgz",
+					"integrity": "sha512-kT1du+HYBrd8X+cLfpp0mLCbqv7tgPRI9lCmrSeL2t9cIGdb+p9m4MOlfaKxrsqFurQlmMVUHmKDZLU4kvZWBg==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0",
@@ -11607,50 +11201,50 @@
 					}
 				},
 				"appium-xcuitest-driver": {
-					"version": "3.33.1",
-					"resolved": "https://registry.npmjs.org/appium-xcuitest-driver/-/appium-xcuitest-driver-3.33.1.tgz",
-					"integrity": "sha512-9HK5nxyrM5bOqwKNFv2J5pHkTIROaWwYwX0w/6odoREkr8x4B99Q0l86bjCE72xXAlLbBfdjukVu2nLGSlOcdA==",
+					"version": "3.59.0",
+					"resolved": "https://registry.npmjs.org/appium-xcuitest-driver/-/appium-xcuitest-driver-3.59.0.tgz",
+					"integrity": "sha512-SG3ylxzzbIDg8P4zx9S6vSBIcT4TGnvVcolENC/pYJBO/8g3ru4z8+lcHZNdVzNZ6fpORdTROcEk2Zfu8WEAnw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0",
+						"@xmldom/xmldom": "^0.x",
 						"appium-base-driver": "^7.0.0",
-						"appium-idb": "^0.5.0",
-						"appium-ios-device": "^1.5.0",
-						"appium-ios-driver": "^4.8.0",
-						"appium-ios-simulator": "^3.25.1",
+						"appium-idb": "^0.x",
+						"appium-ios-device": "^1.8.0",
+						"appium-ios-simulator": "^3.28.0",
 						"appium-remote-debugger": "^8.13.2",
 						"appium-support": "^2.47.1",
-						"appium-webdriveragent": "^2.32.2",
+						"appium-webdriveragent": "^3.16.0",
 						"appium-xcode": "^3.8.0",
 						"async-lock": "^1.0.0",
 						"asyncbox": "^2.3.1",
-						"bluebird": "^3.1.1",
-						"js2xmlparser2": "^0.2.0",
+						"bluebird": "^3.5.1",
+						"css-selector-parser": "^1.4.1",
+						"js2xmlparser2": "^0.x",
 						"lodash": "^4.17.10",
+						"lru-cache": "^6.0.0",
 						"moment": "^2.24.0",
-						"moment-timezone": "0.5.32",
+						"moment-timezone": "^0.x",
 						"node-simctl": "^6.4.0",
 						"portscanner": "2.2.0",
 						"semver": "^7.0.0",
-						"source-map-support": "^0.5.5",
+						"source-map-support": "^0.x",
 						"teen_process": "^1.14.0",
-						"ws": "^7.0.0",
-						"xmldom": "^0.4.0",
-						"yargs": "^16.0.3"
+						"ws": "^8.0.0"
 					},
 					"dependencies": {
-						"xmldom": {
-							"version": "0.4.0",
-							"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.4.0.tgz",
-							"integrity": "sha512-2E93k08T30Ugs+34HBSTQLVtpi6mCddaY8uO+pMNk1pqSjV5vElzn4mmh6KLxN3hki8rNcHSYzILoh3TEWORvA==",
+						"ws": {
+							"version": "8.3.0",
+							"resolved": "https://registry.npmjs.org/ws/-/ws-8.3.0.tgz",
+							"integrity": "sha512-Gs5EZtpqZzLvmIM59w4igITU57lrtYVFneaa434VROv4thzJyV6UjIL3D42lslWlI+D4KzLYnxSwtfuiO79sNw==",
 							"dev": true
 						}
 					}
 				},
 				"appium-youiengine-driver": {
-					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/appium-youiengine-driver/-/appium-youiengine-driver-1.2.7.tgz",
-					"integrity": "sha512-JFpqWvdNg7c9DT7G1vErQZv8u0/SHO/4r44YhiqoEdU66WqQ872EjxxtnIZq/o3pPQ1H28k1qdb8NKrdp5XCng==",
+					"version": "1.2.9",
+					"resolved": "https://registry.npmjs.org/appium-youiengine-driver/-/appium-youiengine-driver-1.2.9.tgz",
+					"integrity": "sha512-Xq3sttITAJi+fF42BepuyT82YwMWQCFpH21/fZuNwUv8Ry6jercFoNa0wz6SIXyXOMgmoHsf+uW7sinrcq/9tA==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.11.2",
@@ -11677,9 +11271,9 @@
 					"dev": true
 				},
 				"archiver": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/archiver/-/archiver-5.1.0.tgz",
-					"integrity": "sha512-iKuQUP1nuKzBC2PFlGet5twENzCfyODmvkxwDV0cEFXavwcLrIW5ssTuHi9dyTPvpWr6Faweo2eQaQiLIwyXTA==",
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.0.tgz",
+					"integrity": "sha512-iUw+oDwK0fgNpvveEsdQ0Ase6IIKztBJU2U0E9MzszMfmVVUyv1QJhS2ITW9ZCqx8dktAxVAjWWkKehuZE8OPg==",
 					"dev": true,
 					"requires": {
 						"archiver-utils": "^2.1.0",
@@ -11687,8 +11281,8 @@
 						"buffer-crc32": "^0.2.1",
 						"readable-stream": "^3.6.0",
 						"readdir-glob": "^1.0.0",
-						"tar-stream": "^2.1.4",
-						"zip-stream": "^4.0.4"
+						"tar-stream": "^2.2.0",
+						"zip-stream": "^4.1.0"
 					}
 				},
 				"archiver-utils": {
@@ -11842,15 +11436,15 @@
 					}
 				},
 				"async-lock": {
-					"version": "1.2.6",
-					"resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.2.6.tgz",
-					"integrity": "sha512-gobUp/bRWL/uJsxi4ZK7NM770s5d2Tx5Hl7uxFIcN6yTz1Kvy2RCSKEvzhLsjAAnYaNa8lDvcjy9ybM6lXFjIg==",
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.3.0.tgz",
+					"integrity": "sha512-8A7SkiisnEgME2zEedtDYPxUPzdv3x//E7n5IFktPAtMYSEAV7eNJF0rMwrVyUFj6d/8rgajLantbjcNRQYXIg==",
 					"dev": true
 				},
 				"asyncbox": {
-					"version": "2.8.0",
-					"resolved": "https://registry.npmjs.org/asyncbox/-/asyncbox-2.8.0.tgz",
-					"integrity": "sha512-wutDUrsVaCOjNNEDskVnLAcu8nQRHRNtI/gz1LtR4GNYMF+yMiWe5YvFMOOeGlavbEmkwrTalftIaTwwCiMtog==",
+					"version": "2.9.2",
+					"resolved": "https://registry.npmjs.org/asyncbox/-/asyncbox-2.9.2.tgz",
+					"integrity": "sha512-VSon1vGccTPcseugq0hl1ImUReW2+Z0GrDpeNHrxuZIKIUf5+gaeXtEFqESFJzSlF3y1UHC8Pkc6AhX/mTiBLA==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0",
@@ -11918,9 +11512,9 @@
 					}
 				},
 				"balanced-match": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+					"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 					"dev": true
 				},
 				"base64-js": {
@@ -11960,9 +11554,9 @@
 					"dev": true
 				},
 				"bl": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-					"integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+					"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
 					"dev": true,
 					"requires": {
 						"buffer": "^5.5.0",
@@ -12018,21 +11612,21 @@
 					}
 				},
 				"bplist-creator": {
-					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.8.tgz",
-					"integrity": "sha512-Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==",
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.1.0.tgz",
+					"integrity": "sha512-sXaHZicyEEmY86WyueLTQesbeoH/mquvarJaQNbjuOQO+7gbFcDEWqKmcWA4cOTLzFlfgvkiVxolk1k5bBIpmg==",
 					"dev": true,
 					"requires": {
-						"stream-buffers": "~2.2.0"
+						"stream-buffers": "2.2.x"
 					}
 				},
 				"bplist-parser": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
-					"integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.0.tgz",
+					"integrity": "sha512-zgmaRvT6AN1JpPPV+S0a1/FAtoxSreYDccZGIqEMSvZl9DMe70mJ7MFzpxa1X+gHVdkToE2haRUHHMiW1OdejA==",
 					"dev": true,
 					"requires": {
-						"big-integer": "^1.6.44"
+						"big-integer": "1.6.x"
 					}
 				},
 				"brace-expansion": {
@@ -12086,9 +11680,9 @@
 					"dev": true
 				},
 				"cacheable-request": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
-					"integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
+					"version": "7.0.2",
+					"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
+					"integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
 					"dev": true,
 					"requires": {
 						"clone-response": "^1.0.2",
@@ -12096,7 +11690,7 @@
 						"http-cache-semantics": "^4.0.0",
 						"keyv": "^4.0.0",
 						"lowercase-keys": "^2.0.0",
-						"normalize-url": "^4.1.0",
+						"normalize-url": "^6.0.1",
 						"responselike": "^2.0.0"
 					},
 					"dependencies": {
@@ -12124,9 +11718,9 @@
 					"dev": true
 				},
 				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+					"integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -12177,46 +11771,45 @@
 					"dev": true
 				},
 				"cliui": {
-					"version": "7.0.4",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-					"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"dev": true,
 					"requires": {
-						"string-width": "^4.2.0",
-						"strip-ansi": "^6.0.0",
-						"wrap-ansi": "^7.0.0"
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
 					},
 					"dependencies": {
 						"ansi-regex": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-							"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 							"dev": true
 						},
 						"is-fullwidth-code-point": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-							"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 							"dev": true
 						},
 						"string-width": {
-							"version": "4.2.0",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-							"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 							"dev": true,
 							"requires": {
-								"emoji-regex": "^8.0.0",
-								"is-fullwidth-code-point": "^3.0.0",
-								"strip-ansi": "^6.0.0"
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^4.0.0"
 							}
 						},
 						"strip-ansi": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 							"dev": true,
 							"requires": {
-								"ansi-regex": "^5.0.0"
+								"ansi-regex": "^3.0.0"
 							}
 						}
 					}
@@ -12285,9 +11878,9 @@
 					"dev": true
 				},
 				"color-string": {
-					"version": "1.5.4",
-					"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
-					"integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
+					"integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
 					"dev": true,
 					"requires": {
 						"color-name": "^1.0.0",
@@ -12338,13 +11931,13 @@
 					"dev": true
 				},
 				"compress-commons": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.2.tgz",
-					"integrity": "sha512-qhd32a9xgzmpfoga1VQEiLEwdKZ6Plnpx5UCgIsf89FSolyJ7WnifY4Gtjgv5WR6hWAyRaHxC5MiEhU/38U70A==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.1.tgz",
+					"integrity": "sha512-QLdDLCKNV2dtoTorqgxngQCMA+gWXkM/Nwu7FpeBhk/RdkzimqC3jueb/FDmaZeXh+uby1jkBqE3xArsLBE5wQ==",
 					"dev": true,
 					"requires": {
 						"buffer-crc32": "^0.2.13",
-						"crc32-stream": "^4.0.1",
+						"crc32-stream": "^4.0.2",
 						"normalize-path": "^3.0.0",
 						"readable-stream": "^3.6.0"
 					}
@@ -12430,9 +12023,9 @@
 					}
 				},
 				"crc32-stream": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.1.tgz",
-					"integrity": "sha512-FN5V+weeO/8JaXsamelVYO1PHyeCsuL3HcG4cqsj0ceARcocxalaShCsohZMSAF+db7UYFwBy1rARK/0oFItUw==",
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.2.tgz",
+					"integrity": "sha512-DxFZ/Hk473b/muq1VJ///PMNLj0ZMnzye9thBpmjpJKCc5eMgB95aK8zCGrGfQ90cWo561Te6HK9D+j4KPdM6w==",
 					"dev": true,
 					"requires": {
 						"crc-32": "^1.2.0",
@@ -12550,9 +12143,9 @@
 					"dev": true
 				},
 				"defer-to-connect": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
-					"integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==",
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+					"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
 					"dev": true
 				},
 				"delayed-stream": {
@@ -12580,18 +12173,15 @@
 					"dev": true
 				},
 				"devtools": {
-					"version": "6.10.11",
-					"resolved": "https://registry.npmjs.org/devtools/-/devtools-6.10.11.tgz",
-					"integrity": "sha512-PjsxgEb4RPp3bJwq1zqcM3JNaXo9QhGiVnOsNkGzftCFr4OOKrvtdOCCST+xpQvE+5F/jNc2qWKI1WXGCBNRew==",
+					"version": "6.12.1",
+					"resolved": "https://registry.npmjs.org/devtools/-/devtools-6.12.1.tgz",
+					"integrity": "sha512-JyG46suEiZmld7/UVeogkCWM0zYGt+2ML/TI+SkEp+bTv9cs46cDb0pKF3glYZJA7wVVL2gC07Ic0iCxyJEnCQ==",
 					"dev": true,
 					"requires": {
-						"@types/puppeteer-core": "^2.0.0",
-						"@types/ua-parser-js": "^0.7.33",
-						"@types/uuid": "^8.3.0",
-						"@wdio/config": "6.10.11",
+						"@wdio/config": "6.12.1",
 						"@wdio/logger": "6.10.10",
-						"@wdio/protocols": "6.10.6",
-						"@wdio/utils": "6.10.11",
+						"@wdio/protocols": "6.12.0",
+						"@wdio/utils": "6.11.0",
 						"chrome-launcher": "^0.13.1",
 						"edge-paths": "^2.1.0",
 						"puppeteer-core": "^5.1.0",
@@ -12628,10 +12218,14 @@
 					}
 				},
 				"edge-paths": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/edge-paths/-/edge-paths-2.1.0.tgz",
-					"integrity": "sha512-ZpIN1Vm5hlo9dkkST/1s8QqPNne2uwk3Plf6HcVUhnpfal0WnDRLdNj/wdQo3xRc+wnN3C25wPpPlV2E6aOunQ==",
-					"dev": true
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/edge-paths/-/edge-paths-2.2.1.tgz",
+					"integrity": "sha512-AI5fC7dfDmCdKo3m5y7PkYE8m6bMqR6pvVpgtrZkkhcJXFLelUgkjrhk3kXXx8Kbw2cRaTT4LkOR7hqf39KJdw==",
+					"dev": true,
+					"requires": {
+						"@types/which": "^1.3.2",
+						"which": "^2.0.2"
+					}
 				},
 				"ee-first": {
 					"version": "1.1.1",
@@ -12694,12 +12288,6 @@
 					"version": "6.1.1",
 					"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.1.1.tgz",
 					"integrity": "sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg==",
-					"dev": true
-				},
-				"escalade": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-					"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
 					"dev": true
 				},
 				"escape-html": {
@@ -12879,9 +12467,9 @@
 					"dev": true
 				},
 				"fast-safe-stringify": {
-					"version": "2.0.7",
-					"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-					"integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
+					"version": "2.0.8",
+					"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz",
+					"integrity": "sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag==",
 					"dev": true
 				},
 				"fd-slicer": {
@@ -12894,9 +12482,9 @@
 					}
 				},
 				"fecha": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
-					"integrity": "sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg==",
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
+					"integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==",
 					"dev": true
 				},
 				"file-type": {
@@ -12960,9 +12548,9 @@
 					"dev": true
 				},
 				"follow-redirects": {
-					"version": "1.13.1",
-					"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-					"integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+					"integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
 					"dev": true
 				},
 				"forever-agent": {
@@ -12972,9 +12560,9 @@
 					"dev": true
 				},
 				"form-data": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-					"integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+					"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
 					"dev": true,
 					"requires": {
 						"asynckit": "^0.4.0",
@@ -12983,9 +12571,9 @@
 					}
 				},
 				"forwarded": {
-					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-					"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+					"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
 					"dev": true
 				},
 				"fresh": {
@@ -13001,15 +12589,15 @@
 					"dev": true
 				},
 				"fs-extra": {
-					"version": "9.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-					"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+					"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
 					"dev": true,
 					"requires": {
 						"at-least-node": "^1.0.0",
 						"graceful-fs": "^4.2.0",
 						"jsonfile": "^6.0.1",
-						"universalify": "^1.0.0"
+						"universalify": "^2.0.0"
 					}
 				},
 				"fs.realpath": {
@@ -13076,9 +12664,9 @@
 					}
 				},
 				"get-caller-file": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+					"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
 					"dev": true
 				},
 				"get-port": {
@@ -13094,9 +12682,9 @@
 					"dev": true
 				},
 				"get-stream": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
-					"integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+					"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
 					"dev": true
 				},
 				"getpass": {
@@ -13119,9 +12707,9 @@
 					}
 				},
 				"glob": {
-					"version": "7.1.6",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+					"version": "7.1.7",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+					"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
 					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
@@ -13143,9 +12731,9 @@
 					}
 				},
 				"got": {
-					"version": "11.8.1",
-					"resolved": "https://registry.npmjs.org/got/-/got-11.8.1.tgz",
-					"integrity": "sha512-9aYdZL+6nHmvJwHALLwKSUZ0hMwGaJGYv3hoPLPgnT8BoBXm1SjnZeky+91tfwJaDzun2s4RsBRy48IEYv2q2Q==",
+					"version": "11.8.2",
+					"resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
+					"integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
 					"dev": true,
 					"requires": {
 						"@sindresorhus/is": "^4.0.0",
@@ -13162,9 +12750,9 @@
 					}
 				},
 				"graceful-fs": {
-					"version": "4.2.4",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"version": "4.2.6",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+					"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
 					"dev": true
 				},
 				"grapheme-splitter": {
@@ -13255,9 +12843,9 @@
 					"dev": true
 				},
 				"http2-wrapper": {
-					"version": "1.0.0-beta.5.2",
-					"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.0-beta.5.2.tgz",
-					"integrity": "sha512-xYz9goEyBnC8XwXDTuC/MZ6t+MrKVQZOk4s7+PaDkwIsQd8IwqvM+0M6bA/2lvG8GHXcPdf+MejTUeO2LCPCeQ==",
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+					"integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
 					"dev": true,
 					"requires": {
 						"quick-lru": "^5.1.1",
@@ -13318,9 +12906,9 @@
 					"dev": true
 				},
 				"ini": {
-					"version": "1.3.8",
-					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-					"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+					"integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
 					"dev": true
 				},
 				"interpret": {
@@ -13336,9 +12924,9 @@
 					"dev": true
 				},
 				"io.appium.settings": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/io.appium.settings/-/io.appium.settings-3.2.1.tgz",
-					"integrity": "sha512-tAk+rdk0cUTrYYwubWfSV6ovBMs/m2fnqdXWDo9DgJvHR7jes8TsDD0h0VB9tBr6iONmRxJuMfIwmO20ZqXSGg==",
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/io.appium.settings/-/io.appium.settings-3.4.0.tgz",
+					"integrity": "sha512-7up+8dJr2RXXZhXNVUq9rdtZbGRTytSJ1rax4qm16534zPcBwXeWin0hC9qsIjDtqXXEEUOHdybeqTD1X8ZlMQ==",
 					"dev": true
 				},
 				"ipaddr.js": {
@@ -13372,18 +12960,18 @@
 					"dev": true
 				},
 				"is-core-module": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-					"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
+					"integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
 					"dev": true,
 					"requires": {
 						"has": "^1.0.3"
 					}
 				},
 				"is-docker": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
-					"integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+					"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
 					"dev": true
 				},
 				"is-fullwidth-code-point": {
@@ -13460,375 +13048,6 @@
 						"@jimp/plugins": "^0.16.1",
 						"@jimp/types": "^0.16.1",
 						"regenerator-runtime": "^0.13.3"
-					},
-					"dependencies": {
-						"@jimp/bmp": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.16.1.tgz",
-							"integrity": "sha512-iwyNYQeBawrdg/f24x3pQ5rEx+/GwjZcCXd3Kgc+ZUd+Ivia7sIqBsOnDaMZdKCBPlfW364ekexnlOqyVa0NWg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1",
-								"bmp-js": "^0.1.0"
-							}
-						},
-						"@jimp/core": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.16.1.tgz",
-							"integrity": "sha512-la7kQia31V6kQ4q1kI/uLimu8FXx7imWVajDGtwUG8fzePLWDFJyZl0fdIXVCL1JW2nBcRHidUot6jvlRDi2+g==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1",
-								"any-base": "^1.1.0",
-								"buffer": "^5.2.0",
-								"exif-parser": "^0.1.12",
-								"file-type": "^9.0.0",
-								"load-bmfont": "^1.3.1",
-								"mkdirp": "^0.5.1",
-								"phin": "^2.9.1",
-								"pixelmatch": "^4.0.2",
-								"tinycolor2": "^1.4.1"
-							}
-						},
-						"@jimp/custom": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.16.1.tgz",
-							"integrity": "sha512-DNUAHNSiUI/j9hmbatD6WN/EBIyeq4AO0frl5ETtt51VN1SvE4t4v83ZA/V6ikxEf3hxLju4tQ5Pc3zmZkN/3A==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/core": "^0.16.1"
-							}
-						},
-						"@jimp/gif": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.16.1.tgz",
-							"integrity": "sha512-r/1+GzIW1D5zrP4tNrfW+3y4vqD935WBXSc8X/wm23QTY9aJO9Lw6PEdzpYCEY+SOklIFKaJYUAq/Nvgm/9ryw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1",
-								"gifwrap": "^0.9.2",
-								"omggif": "^1.0.9"
-							}
-						},
-						"@jimp/jpeg": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.16.1.tgz",
-							"integrity": "sha512-8352zrdlCCLFdZ/J+JjBslDvml+fS3Z8gttdml0We759PnnZGqrnPRhkOEOJbNUlE+dD4ckLeIe6NPxlS/7U+w==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1",
-								"jpeg-js": "0.4.2"
-							}
-						},
-						"@jimp/plugin-blit": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.16.1.tgz",
-							"integrity": "sha512-fKFNARm32RoLSokJ8WZXHHH2CGzz6ire2n1Jh6u+XQLhk9TweT1DcLHIXwQMh8oR12KgjbgsMGvrMVlVknmOAg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-blur": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.16.1.tgz",
-							"integrity": "sha512-1WhuLGGj9MypFKRcPvmW45ht7nXkOKu+lg3n2VBzIB7r4kKNVchuI59bXaCYQumOLEqVK7JdB4glaDAbCQCLyw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-circle": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.16.1.tgz",
-							"integrity": "sha512-JK7yi1CIU7/XL8hdahjcbGA3V7c+F+Iw+mhMQhLEi7Q0tCnZ69YJBTamMiNg3fWPVfMuvWJJKOBRVpwNTuaZRg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-color": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.16.1.tgz",
-							"integrity": "sha512-9yQttBAO5SEFj7S6nJK54f+1BnuBG4c28q+iyzm1JjtnehjqMg6Ljw4gCSDCvoCQ3jBSYHN66pmwTV74SU1B7A==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1",
-								"tinycolor2": "^1.4.1"
-							}
-						},
-						"@jimp/plugin-contain": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.16.1.tgz",
-							"integrity": "sha512-44F3dUIjBDHN+Ym/vEfg+jtjMjAqd2uw9nssN67/n4FdpuZUVs7E7wadKY1RRNuJO+WgcD5aDQcsvurXMETQTg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-cover": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.16.1.tgz",
-							"integrity": "sha512-YztWCIldBAVo0zxcQXR+a/uk3/TtYnpKU2CanOPJ7baIuDlWPsG+YE4xTsswZZc12H9Kl7CiziEbDtvF9kwA/Q==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-crop": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.16.1.tgz",
-							"integrity": "sha512-UQdva9oQzCVadkyo3T5Tv2CUZbf0klm2cD4cWMlASuTOYgaGaFHhT9st+kmfvXjKL8q3STkBu/zUPV6PbuV3ew==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-displace": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.16.1.tgz",
-							"integrity": "sha512-iVAWuz2+G6Heu8gVZksUz+4hQYpR4R0R/RtBzpWEl8ItBe7O6QjORAkhxzg+WdYLL2A/Yd4ekTpvK0/qW8hTVw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-dither": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.16.1.tgz",
-							"integrity": "sha512-tADKVd+HDC9EhJRUDwMvzBXPz4GLoU6s5P7xkVq46tskExYSptgj5713J5Thj3NMgH9Rsqu22jNg1H/7tr3V9Q==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-fisheye": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.16.1.tgz",
-							"integrity": "sha512-BWHnc5hVobviTyIRHhIy9VxI1ACf4CeSuCfURB6JZm87YuyvgQh5aX5UDKtOz/3haMHXBLP61ZBxlNpMD8CG4A==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-flip": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.16.1.tgz",
-							"integrity": "sha512-KdxTf0zErfZ8DyHkImDTnQBuHby+a5YFdoKI/G3GpBl3qxLBvC+PWkS2F/iN3H7wszP7/TKxTEvWL927pypT0w==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-gaussian": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.16.1.tgz",
-							"integrity": "sha512-u9n4wjskh3N1mSqketbL6tVcLU2S5TEaFPR40K6TDv4phPLZALi1Of7reUmYpVm8mBDHt1I6kGhuCJiWvzfGyg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-invert": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.16.1.tgz",
-							"integrity": "sha512-2DKuyVXANH8WDpW9NG+PYFbehzJfweZszFYyxcaewaPLN0GxvxVLOGOPP1NuUTcHkOdMFbE0nHDuB7f+sYF/2w==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-mask": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.16.1.tgz",
-							"integrity": "sha512-snfiqHlVuj4bSFS0v96vo2PpqCDMe4JB+O++sMo5jF5mvGcGL6AIeLo8cYqPNpdO6BZpBJ8MY5El0Veckhr39Q==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-normalize": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.16.1.tgz",
-							"integrity": "sha512-dOQfIOvGLKDKXPU8xXWzaUeB0nvkosHw6Xg1WhS1Z5Q0PazByhaxOQkSKgUryNN/H+X7UdbDvlyh/yHf3ITRaw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-print": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.16.1.tgz",
-							"integrity": "sha512-ceWgYN40jbN4cWRxixym+csyVymvrryuKBQ+zoIvN5iE6OyS+2d7Mn4zlNgumSczb9GGyZZESIgVcBDA1ezq0Q==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1",
-								"load-bmfont": "^1.4.0"
-							}
-						},
-						"@jimp/plugin-resize": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.16.1.tgz",
-							"integrity": "sha512-u4JBLdRI7dargC04p2Ha24kofQBk3vhaf0q8FwSYgnCRwxfvh2RxvhJZk9H7Q91JZp6wgjz/SjvEAYjGCEgAwQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-rotate": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.16.1.tgz",
-							"integrity": "sha512-ZUU415gDQ0VjYutmVgAYYxC9Og9ixu2jAGMCU54mSMfuIlmohYfwARQmI7h4QB84M76c9hVLdONWjuo+rip/zg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-scale": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.16.1.tgz",
-							"integrity": "sha512-jM2QlgThIDIc4rcyughD5O7sOYezxdafg/2Xtd1csfK3z6fba3asxDwthqPZAgitrLgiKBDp6XfzC07Y/CefUw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-shadow": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.16.1.tgz",
-							"integrity": "sha512-MeD2Is17oKzXLnsphAa1sDstTu6nxscugxAEk3ji0GV1FohCvpHBcec0nAq6/czg4WzqfDts+fcPfC79qWmqrA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-threshold": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.16.1.tgz",
-							"integrity": "sha512-iGW8U/wiCSR0+6syrPioVGoSzQFt4Z91SsCRbgNKTAk7D+XQv6OI78jvvYg4o0c2FOlwGhqz147HZV5utoSLxA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugins": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.16.1.tgz",
-							"integrity": "sha512-c+lCqa25b+4q6mJZSetlxhMoYuiltyS+ValLzdwK/47+aYsq+kcJNl+TuxIEKf59yr9+5rkbpsPkZHLF/V7FFA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/plugin-blit": "^0.16.1",
-								"@jimp/plugin-blur": "^0.16.1",
-								"@jimp/plugin-circle": "^0.16.1",
-								"@jimp/plugin-color": "^0.16.1",
-								"@jimp/plugin-contain": "^0.16.1",
-								"@jimp/plugin-cover": "^0.16.1",
-								"@jimp/plugin-crop": "^0.16.1",
-								"@jimp/plugin-displace": "^0.16.1",
-								"@jimp/plugin-dither": "^0.16.1",
-								"@jimp/plugin-fisheye": "^0.16.1",
-								"@jimp/plugin-flip": "^0.16.1",
-								"@jimp/plugin-gaussian": "^0.16.1",
-								"@jimp/plugin-invert": "^0.16.1",
-								"@jimp/plugin-mask": "^0.16.1",
-								"@jimp/plugin-normalize": "^0.16.1",
-								"@jimp/plugin-print": "^0.16.1",
-								"@jimp/plugin-resize": "^0.16.1",
-								"@jimp/plugin-rotate": "^0.16.1",
-								"@jimp/plugin-scale": "^0.16.1",
-								"@jimp/plugin-shadow": "^0.16.1",
-								"@jimp/plugin-threshold": "^0.16.1",
-								"timm": "^1.6.1"
-							}
-						},
-						"@jimp/png": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.16.1.tgz",
-							"integrity": "sha512-iyWoCxEBTW0OUWWn6SveD4LePW89kO7ZOy5sCfYeDM/oTPLpR8iMIGvZpZUz1b8kvzFr27vPst4E5rJhGjwsdw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1",
-								"pngjs": "^3.3.3"
-							}
-						},
-						"@jimp/tiff": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.16.1.tgz",
-							"integrity": "sha512-3K3+xpJS79RmSkAvFMgqY5dhSB+/sxhwTFA9f4AVHUK0oKW+u6r52Z1L0tMXHnpbAdR9EJ+xaAl2D4x19XShkQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"utif": "^2.0.1"
-							}
-						},
-						"@jimp/types": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.16.1.tgz",
-							"integrity": "sha512-g1w/+NfWqiVW4CaXSJyD28JQqZtm2eyKMWPhBBDCJN9nLCN12/Az0WFF3JUAktzdsEC2KRN2AqB1a2oMZBNgSQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/bmp": "^0.16.1",
-								"@jimp/gif": "^0.16.1",
-								"@jimp/jpeg": "^0.16.1",
-								"@jimp/png": "^0.16.1",
-								"@jimp/tiff": "^0.16.1",
-								"timm": "^1.6.1"
-							}
-						},
-						"@jimp/utils": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.16.1.tgz",
-							"integrity": "sha512-8fULQjB0x4LzUSiSYG6ZtQl355sZjxbv8r9PPAuYHzS9sGiSHJQavNqK/nKnpDsVkU88/vRGcE7t3nMU0dEnVw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"regenerator-runtime": "^0.13.3"
-							}
-						},
-						"mkdirp": {
-							"version": "0.5.5",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-							"dev": true,
-							"requires": {
-								"minimist": "^1.2.5"
-							}
-						},
-						"pngjs": {
-							"version": "3.4.0",
-							"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-							"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
-							"dev": true
-						}
 					}
 				},
 				"jpeg-js": {
@@ -13906,14 +13125,6 @@
 					"requires": {
 						"graceful-fs": "^4.1.6",
 						"universalify": "^2.0.0"
-					},
-					"dependencies": {
-						"universalify": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-							"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-							"dev": true
-						}
 					}
 				},
 				"jsprim": {
@@ -13929,9 +13140,9 @@
 					}
 				},
 				"jszip": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.5.0.tgz",
-					"integrity": "sha512-WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
+					"integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
 					"dev": true,
 					"requires": {
 						"lie": "~3.3.0",
@@ -13967,9 +13178,9 @@
 					}
 				},
 				"keyv": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
-					"integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.4.tgz",
+					"integrity": "sha512-vqNHbAc8BBsxk+7QBYLW0Y219rWcClspR6WSeoHYKG5mnsSoOH+BL1pWq02DDCVdvvuUny5rkBlzMRzoqc+GIg==",
 					"dev": true,
 					"requires": {
 						"json-buffer": "3.0.1"
@@ -14035,13 +13246,13 @@
 					}
 				},
 				"lighthouse-logger": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.2.0.tgz",
-					"integrity": "sha512-wzUvdIeJZhRsG6gpZfmSCfysaxNEr43i+QT+Hie94wvHDKFLi4n7C2GqZ4sTC+PH5b5iktmXJvU87rWvhP3lHw==",
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.3.0.tgz",
+					"integrity": "sha512-BbqAKApLb9ywUli+0a+PcV04SyJ/N1q/8qgCNe6U97KbPCS1BTksEuHFLYdvc8DltuhfxIUBqDZsC0bBGtl3lA==",
 					"dev": true,
 					"requires": {
-						"debug": "^2.6.8",
-						"marky": "^1.2.0"
+						"debug": "^2.6.9",
+						"marky": "^1.2.2"
 					},
 					"dependencies": {
 						"debug": {
@@ -14096,9 +13307,9 @@
 					}
 				},
 				"lodash": {
-					"version": "4.17.20",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"version": "4.17.21",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+					"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 					"dev": true
 				},
 				"lodash.clonedeep": {
@@ -14220,9 +13431,9 @@
 					}
 				},
 				"marky": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/marky/-/marky-1.2.1.tgz",
-					"integrity": "sha512-md9k+Gxa3qLH6sUKpeC2CNkJK/Ld+bEz5X96nYwloqphQE0CKCVEKco/6jxEZixinqNdz5RFi/KaCyfbMDMAXQ==",
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/marky/-/marky-1.2.2.tgz",
+					"integrity": "sha512-k1dB2HNeaNyORco8ulVEhctyEGkKHb2YWAhDsxeFlW2nROIirsctBYzKwwS3Vza+sKTS1zO4Z+n9/+9WbGLIxQ==",
 					"dev": true
 				},
 				"md5": {
@@ -14301,18 +13512,18 @@
 					"dev": true
 				},
 				"mime-db": {
-					"version": "1.44.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-					"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+					"version": "1.48.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
+					"integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==",
 					"dev": true
 				},
 				"mime-types": {
-					"version": "2.1.27",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-					"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+					"version": "2.1.31",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
+					"integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
 					"dev": true,
 					"requires": {
-						"mime-db": "1.44.0"
+						"mime-db": "1.48.0"
 					}
 				},
 				"mimic-fn": {
@@ -14351,12 +13562,6 @@
 					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 					"dev": true
 				},
-				"mjpeg-server": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/mjpeg-server/-/mjpeg-server-0.3.0.tgz",
-					"integrity": "sha1-rx3hP3VkJwi6bsFw36xAi9xdlzc=",
-					"dev": true
-				},
 				"mkdirp": {
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -14376,9 +13581,9 @@
 					"dev": true
 				},
 				"moment-timezone": {
-					"version": "0.5.32",
-					"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.32.tgz",
-					"integrity": "sha512-Z8QNyuQHQAmWucp8Knmgei8YNo28aLjJq6Ma+jy1ZSpSk5nyfRT8xgUbSQvD2+2UajISfenndwvFuH3NGS+nvA==",
+					"version": "0.5.33",
+					"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz",
+					"integrity": "sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==",
 					"dev": true,
 					"requires": {
 						"moment": ">= 2.9.0"
@@ -14526,9 +13731,9 @@
 					"dev": true
 				},
 				"normalize-url": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-					"integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+					"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
 					"dev": true
 				},
 				"npm-run-path": {
@@ -14627,9 +13832,9 @@
 					"dev": true
 				},
 				"p-cancelable": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
-					"integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+					"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
 					"dev": true
 				},
 				"p-defer": {
@@ -14745,9 +13950,9 @@
 					"dev": true
 				},
 				"path-parse": {
-					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-					"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+					"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 					"dev": true
 				},
 				"path-to-regexp": {
@@ -14813,14 +14018,14 @@
 					}
 				},
 				"plist": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
-					"integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/plist/-/plist-3.0.2.tgz",
+					"integrity": "sha512-MSrkwZBdQ6YapHy87/8hDU8MnIcyxBKjeF+McXnr5A9MtffPewTs7G3hlpodT5TacyfIyFTaJEhh3GGcmasTgQ==",
 					"dev": true,
 					"requires": {
-						"base64-js": "^1.2.3",
+						"base64-js": "^1.5.1",
 						"xmlbuilder": "^9.0.7",
-						"xmldom": "0.1.x"
+						"xmldom": "^0.5.0"
 					},
 					"dependencies": {
 						"xmlbuilder": {
@@ -14838,9 +14043,9 @@
 					"dev": true
 				},
 				"pngjs": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
-					"integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+					"integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
 					"dev": true
 				},
 				"portfinder": {
@@ -14929,12 +14134,12 @@
 					"dev": true
 				},
 				"proxy-addr": {
-					"version": "2.0.6",
-					"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
-					"integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+					"version": "2.0.7",
+					"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+					"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
 					"dev": true,
 					"requires": {
-						"forwarded": "~0.1.2",
+						"forwarded": "0.2.0",
 						"ipaddr.js": "1.9.1"
 					}
 				},
@@ -15132,25 +14337,25 @@
 					"dev": true
 				},
 				"require-main-filename": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
 					"dev": true
 				},
 				"resolve": {
-					"version": "1.19.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-					"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+					"version": "1.20.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+					"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
 					"dev": true,
 					"requires": {
-						"is-core-module": "^2.1.0",
+						"is-core-module": "^2.2.0",
 						"path-parse": "^1.0.6"
 					}
 				},
 				"resolve-alpn": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.0.0.tgz",
-					"integrity": "sha512-rTuiIEqFmGxne4IovivKSDzld2lWW9QCjqv80SYjPgf+gS35eaCAjaP54CCwGAwBtnCsvNLYtqxe1Nw+i6JEmA==",
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+					"integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
 					"dev": true
 				},
 				"responselike": {
@@ -15163,9 +14368,9 @@
 					}
 				},
 				"resq": {
-					"version": "1.10.0",
-					"resolved": "https://registry.npmjs.org/resq/-/resq-1.10.0.tgz",
-					"integrity": "sha512-hCUd0xMalqtPDz4jXIqs0M5Wnv/LZXN8h7unFOo4/nvExT9dDPbhwd3udRxLlp0HgBnHcV009UlduE9NZi7A6w==",
+					"version": "1.10.1",
+					"resolved": "https://registry.npmjs.org/resq/-/resq-1.10.1.tgz",
+					"integrity": "sha512-zhp1iyUH02MLciv3bIM2bNtTFx/fqRsK4Jk73jcPqp00d/sMTTjOtjdTMAcgjrQKGx5DvQ/HSpeqaMW0atGRJA==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^2.0.1"
@@ -15208,9 +14413,9 @@
 							"dev": true
 						},
 						"ws": {
-							"version": "5.2.2",
-							"resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-							"integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+							"version": "5.2.3",
+							"resolved": "https://registry.npmjs.org/ws/-/ws-5.2.3.tgz",
+							"integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
 							"dev": true,
 							"requires": {
 								"async-limiter": "~1.0.0"
@@ -15275,9 +14480,9 @@
 					}
 				},
 				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
@@ -15330,12 +14535,12 @@
 					}
 				},
 				"serialize-error": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-					"integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
+					"integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
 					"dev": true,
 					"requires": {
-						"type-fest": "^0.13.1"
+						"type-fest": "^0.20.2"
 					}
 				},
 				"serve-favicon": {
@@ -15708,9 +14913,9 @@
 					"dev": true
 				},
 				"type-fest": {
-					"version": "0.13.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-					"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+					"version": "0.20.2",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 					"dev": true
 				},
 				"type-is": {
@@ -15724,9 +14929,9 @@
 					}
 				},
 				"ua-parser-js": {
-					"version": "0.7.23",
-					"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
-					"integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA==",
+					"version": "0.7.31",
+					"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
+					"integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==",
 					"dev": true
 				},
 				"unbzip2-stream": {
@@ -15740,9 +14945,9 @@
 					}
 				},
 				"universalify": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-					"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
 					"dev": true
 				},
 				"unorm": {
@@ -15758,9 +14963,9 @@
 					"dev": true
 				},
 				"uri-js": {
-					"version": "4.4.0",
-					"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-					"integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+					"version": "4.4.1",
+					"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+					"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 					"dev": true,
 					"requires": {
 						"punycode": "^2.1.0"
@@ -15846,43 +15051,35 @@
 					}
 				},
 				"webdriver": {
-					"version": "6.10.11",
-					"resolved": "https://registry.npmjs.org/webdriver/-/webdriver-6.10.11.tgz",
-					"integrity": "sha512-3LW1ST2ktdiW8ANO8ie09ct1zEAfk+Vn6ELJJXwwh858YL4ckG5Eu07w1HlCe+K1NwcrkHVsk7gw8Hq/qs/WyA==",
+					"version": "6.12.1",
+					"resolved": "https://registry.npmjs.org/webdriver/-/webdriver-6.12.1.tgz",
+					"integrity": "sha512-3rZgAj9o2XHp16FDTzvUYaHelPMSPbO1TpLIMUT06DfdZjNYIzZiItpIb/NbQDTPmNhzd9cuGmdI56WFBGY2BA==",
 					"dev": true,
 					"requires": {
-						"@types/lodash.merge": "^4.6.6",
-						"@wdio/config": "6.10.11",
+						"@wdio/config": "6.12.1",
 						"@wdio/logger": "6.10.10",
-						"@wdio/protocols": "6.10.6",
-						"@wdio/utils": "6.10.11",
+						"@wdio/protocols": "6.12.0",
+						"@wdio/utils": "6.11.0",
 						"got": "^11.0.2",
 						"lodash.merge": "^4.6.1"
 					}
 				},
 				"webdriverio": {
-					"version": "6.10.11",
-					"resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-6.10.11.tgz",
-					"integrity": "sha512-1EGQuX7oN2KJ1zyWmQGELP9deP1++moRLR/l8sEbZKMvv3qZ+lyT1g2t3Eu+AE7kan2wpBc94oWXmSF0KjEENQ==",
+					"version": "6.12.1",
+					"resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-6.12.1.tgz",
+					"integrity": "sha512-Nx7ge0vTWHVIRUbZCT+IuMwB5Q0Q5nLlYdgnmmJviUKLuc3XtaEBkYPTbhHWHgSBXsPZMIc023vZKNkn+6iyeQ==",
 					"dev": true,
 					"requires": {
-						"@types/archiver": "^5.1.0",
-						"@types/atob": "^2.1.2",
-						"@types/fs-extra": "^9.0.2",
-						"@types/lodash.clonedeep": "^4.5.6",
-						"@types/lodash.isobject": "^3.0.6",
-						"@types/lodash.isplainobject": "^4.0.6",
-						"@types/lodash.zip": "^4.2.6",
-						"@types/puppeteer-core": "^2.0.0",
-						"@wdio/config": "6.10.11",
+						"@types/puppeteer-core": "^5.4.0",
+						"@wdio/config": "6.12.1",
 						"@wdio/logger": "6.10.10",
-						"@wdio/repl": "6.10.11",
-						"@wdio/utils": "6.10.11",
+						"@wdio/repl": "6.11.0",
+						"@wdio/utils": "6.11.0",
 						"archiver": "^5.0.0",
 						"atob": "^2.1.2",
 						"css-shorthand-properties": "^1.1.1",
 						"css-value": "^0.0.1",
-						"devtools": "6.10.11",
+						"devtools": "6.12.1",
 						"fs-extra": "^9.0.1",
 						"get-port": "^5.1.1",
 						"grapheme-splitter": "^1.0.2",
@@ -15894,8 +15091,8 @@
 						"puppeteer-core": "^5.1.0",
 						"resq": "^1.9.1",
 						"rgb2hex": "0.2.3",
-						"serialize-error": "^7.0.0",
-						"webdriver": "6.10.11"
+						"serialize-error": "^8.0.0",
+						"webdriver": "6.12.1"
 					}
 				},
 				"which": {
@@ -15981,48 +15178,13 @@
 					"dev": true
 				},
 				"wrap-ansi": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-					"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^4.0.0",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^6.0.0"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-							"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-							"dev": true
-						},
-						"is-fullwidth-code-point": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-							"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-							"dev": true
-						},
-						"string-width": {
-							"version": "4.2.0",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-							"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-							"dev": true,
-							"requires": {
-								"emoji-regex": "^8.0.0",
-								"is-fullwidth-code-point": "^3.0.0",
-								"strip-ansi": "^6.0.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^5.0.0"
-							}
-						}
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
 					}
 				},
 				"wrappy": {
@@ -16032,9 +15194,9 @@
 					"dev": true
 				},
 				"ws": {
-					"version": "7.4.2",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
-					"integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==",
+					"version": "7.5.3",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
+					"integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
 					"dev": true
 				},
 				"xhr": {
@@ -16072,9 +15234,9 @@
 					"dev": true
 				},
 				"xmldom": {
-					"version": "0.1.31",
-					"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-					"integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
+					"integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
 					"dev": true
 				},
 				"xpath": {
@@ -16090,9 +15252,9 @@
 					"dev": true
 				},
 				"y18n": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-					"integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+					"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
 					"dev": true
 				},
 				"yallist": {
@@ -16102,59 +15264,101 @@
 					"dev": true
 				},
 				"yargs": {
-					"version": "16.2.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-					"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+					"version": "12.0.5",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
 					"dev": true,
 					"requires": {
-						"cliui": "^7.0.2",
-						"escalade": "^3.1.1",
-						"get-caller-file": "^2.0.5",
+						"cliui": "^4.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^3.0.0",
 						"require-directory": "^2.1.1",
-						"string-width": "^4.2.0",
-						"y18n": "^5.0.5",
-						"yargs-parser": "^20.2.2"
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1 || ^4.0.0",
+						"yargs-parser": "^11.1.1"
 					},
 					"dependencies": {
 						"ansi-regex": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-							"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 							"dev": true
 						},
-						"is-fullwidth-code-point": {
+						"find-up": {
 							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-							"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+							"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+							"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+							"dev": true,
+							"requires": {
+								"locate-path": "^3.0.0"
+							}
+						},
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+							"dev": true
+						},
+						"locate-path": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+							"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+							"dev": true,
+							"requires": {
+								"p-locate": "^3.0.0",
+								"path-exists": "^3.0.0"
+							}
+						},
+						"p-locate": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+							"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+							"dev": true,
+							"requires": {
+								"p-limit": "^2.0.0"
+							}
+						},
+						"path-exists": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+							"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
 							"dev": true
 						},
 						"string-width": {
-							"version": "4.2.0",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-							"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 							"dev": true,
 							"requires": {
-								"emoji-regex": "^8.0.0",
-								"is-fullwidth-code-point": "^3.0.0",
-								"strip-ansi": "^6.0.0"
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^4.0.0"
 							}
 						},
 						"strip-ansi": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 							"dev": true,
 							"requires": {
-								"ansi-regex": "^5.0.0"
+								"ansi-regex": "^3.0.0"
 							}
 						}
 					}
 				},
 				"yargs-parser": {
-					"version": "20.2.4",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-					"integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
-					"dev": true
+					"version": "11.1.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+					"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
 				},
 				"yauzl": {
 					"version": "2.10.0",
@@ -16167,13 +15371,13 @@
 					}
 				},
 				"zip-stream": {
-					"version": "4.0.4",
-					"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.4.tgz",
-					"integrity": "sha512-a65wQ3h5gcQ/nQGWV1mSZCEzCML6EK/vyVPcrPNynySP1j3VBbQKh3nhC8CbORb+jfl2vXvh56Ul5odP1bAHqw==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.0.tgz",
+					"integrity": "sha512-zshzwQW7gG7hjpBlgeQP9RuyPGNxvJdzR8SUM3QhxCnLjWN2E7j3dOvpeDcQoETfHx0urRS7EtmVToql7YpU4A==",
 					"dev": true,
 					"requires": {
 						"archiver-utils": "^2.1.0",
-						"compress-commons": "^4.0.2",
+						"compress-commons": "^4.1.0",
 						"readable-stream": "^3.6.0"
 					}
 				}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"@typescript-eslint/eslint-plugin": "^4.31.0",
 		"@wordpress/babel-preset-default": "file:gutenberg/packages/babel-preset-default",
 		"@wordpress/eslint-plugin": "file:gutenberg/packages/eslint-plugin",
-		"appium": "^1.20.2",
+		"appium": "^1.22.3",
 		"babel-core": "^7.0.0-bridge.0",
 		"babel-eslint": "^8.2.2",
 		"babel-jest": "^27.4.5",


### PR DESCRIPTION
This PR updates Appium dependency to `1.22.3` to match the same version as defined in Gutenberg ([reference](https://github.com/WordPress/gutenberg/blob/24ade9d2a508074b887e8fd6e6c5a032d9605b14/package.json#L165)), which was recently updated in [this PR](https://github.com/WordPress/gutenberg/pull/44732).

To test:
- Verify that all CI checks pass.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
