### PR TITLE
Update RELEASE-NOTES.txt with RN 0.69 upgrade

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,5 @@
 Unreleased
 ---
-* [**] Prevent error message from unneccesarily firing when uploading to Gallery block [https://github.com/WordPress/gutenberg/pull/46175]
 * [**] Upgrade React Native from 0.66.2 to 0.69.4 [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5193]
 
 1.85.1

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 Unreleased
 ---
 * [**] Prevent error message from unneccesarily firing when uploading to Gallery block [https://github.com/WordPress/gutenberg/pull/46175]
+* [**] Upgrade React Native from 0.66.2 to 0.69.4 [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5193]
 
 1.85.1
 ---


### PR DESCRIPTION
Updates RELEASE-NOTES.txt with note about upgrading React Native from 0.66.2 to 0.69.4.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
