### PR TITLE
Update Cron for the job `ui-tests-full-scheduled`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -425,7 +425,7 @@ workflows:
           post-to-slack: true
     triggers:
       - schedule:
-          cron: '0 0 8 ? * MON,WED,FRI *'
+          cron: '0 8 * * 1,3,5'
           filters:
             branches:
               only: trunk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -425,7 +425,7 @@ workflows:
           post-to-slack: true
     triggers:
       - schedule:
-          cron: '1 1,13 * * *'
+          cron: '0 0 8 ? * MON,WED,FRI *'
           filters:
             branches:
               only: trunk


### PR DESCRIPTION
This PR updates the cron expression for the `ui-tests-full-scheduled` job to run on Monday, Wednesday, and Friday at 8:00.

Let's reduce its usage until we decide if it gives enough information related to breakages since the full tests are not required to merge into Gutenberg Mobile `trunk`

You can check the new expression in a UI interface by using this tool: https://www.atatus.com/tools/cron

To test:
CI checks should pass.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
