### PR TITLE
Remove `ui-tests-full-scheduled` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -415,17 +415,3 @@ workflows:
             branches:
               only:
                 - /^release.*/
-  ui-tests-full-scheduled:
-    jobs:
-      - ios-device-checks:
-          name: Test iOS on Device - Scheduled
-          post-to-slack: true
-      - android-device-checks:
-          name: Test Android on Device - Scheduled
-          post-to-slack: true
-    triggers:
-      - schedule:
-          cron: '1 1,13 * * *'
-          filters:
-            branches:
-              only: trunk


### PR DESCRIPTION
This PR removes the `ui-tests-full-scheduled` job that was currently running through a cron every day.

After some investigation, we could see we have other jobs that cover incoming changes very well by running the full tests suites so there is no need to have also a daily scheduled job.

We will be running the full tests in:

- Gutenberg via dependabot PRs (daily)
- Jetpack via dependabot PRs (daily)
- Any PR that gets merged into `trunk`
- Release branches

Kudos to @fluiddot for investigating the above list.

To test:
N/A

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
