### PR TITLE
Fix Jetpack pnpm install

### DIFF
--- a/bin/install-jetpack.sh
+++ b/bin/install-jetpack.sh
@@ -28,6 +28,6 @@ pnpm_version=$(npx semver -c "$listed_pnpm_version")
 cd projects/plugins/jetpack
 
 # npx might prompt to install pnpm at the requested version. Let's just agree and carry on.
-( yes || true ) | npx --cache /tmp/empty-cache pnpm@"$pnpm_version" install
+( yes || true ) | npx --cache /tmp/empty-cache pnpm@"$pnpm_version" install --ignore-scripts
 
 popd


### PR DESCRIPTION
Closes https://github.com/wordpress-mobile/gutenberg-mobile/issues/5357

This PR fixes the CI issues we were having with Jetpack.

First, it adds `--ignore-scripts` when we install the [pnpm dependencies](https://github.com/wordpress-mobile/gutenberg-mobile/pull/5366/commits/f0331ad41df2b8416a8e357808a3b13a7282165e). Without it, it was causing issues with some dependencies scripts and different node versions.

Specifically for the `image-guide` [package](https://github.com/Automattic/jetpack/blob/trunk/projects/js-packages/image-guide/package.json), which has a few [scripts](https://github.com/Automattic/jetpack/blob/trunk/projects/js-packages/image-guide/package.json#L17) in its `package.json`.

```
projects/js-packages/image-guide prepare:  ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)
projects/js-packages/image-guide prepare: Your Node version is incompatible with "/home/circleci/project/jetpack/projects/js-packages/image-guide".
projects/js-packages/image-guide prepare: Expected version: ^16.13.2
projects/js-packages/image-guide prepare: Got: 14.21.2
projects/js-packages/image-guide prepare: This is happening because the package's manifest has an engines.node field specified.
projects/js-packages/image-guide prepare: To fix this issue, install the required Node version.
projects/js-packages/image-guide prepare: Failed
```

After different tries of trying to workaround the different node/pnpm versions issue, I went for the `--ignore-scripts` approach.


Second, it [adds](https://github.com/Automattic/jetpack/commit/bd7fa2783e87e9b25cca36d38dc39dcee6174299) a `native` import to solve an issue with metro and other changes in https://github.com/Automattic/jetpack/pull/28154.

To test CI checks should pass.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
