### PR TITLE
Update React Native Reanimated to `2.9.1-wp-3`

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 Unreleased
 ---
 * [*] Bump Android `minSdkVersion` to 24 [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5435]
+* [*] Update React Native Reanimated to 2.9.1-wp-3 [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5430]
 
 1.87.3
 ---

--- a/third-party-podspecs/FBReactNativeSpec/FBReactNativeSpec.podspec.json
+++ b/third-party-podspecs/FBReactNativeSpec/FBReactNativeSpec.podspec.json
@@ -11,7 +11,7 @@
   "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32 -Wno-nullability-completeness",
   "source": {
     "git": "https://github.com/wordpress-mobile/gutenberg-mobile.git",
-    "commit": "e91d1bffb713544d0d224266c17d5dccc940e775",
+    "commit": "0",
     "submodules": "true"
   },
   "header_dir": "FBReactNativeSpec",

--- a/third-party-podspecs/FBReactNativeSpec/FBReactNativeSpec.podspec.json
+++ b/third-party-podspecs/FBReactNativeSpec/FBReactNativeSpec.podspec.json
@@ -11,7 +11,7 @@
   "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32 -Wno-nullability-completeness",
   "source": {
     "git": "https://github.com/wordpress-mobile/gutenberg-mobile.git",
-    "commit": "0",
+    "commit": "1ab6dfb16553516fa01d698523f4472a57f26d99",
     "submodules": "true"
   },
   "header_dir": "FBReactNativeSpec",

--- a/third-party-podspecs/RNReanimated.podspec.json
+++ b/third-party-podspecs/RNReanimated.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RNReanimated",
-  "version": "2.9.1-wp-2",
+  "version": "2.9.1-wp-3",
   "summary": "More powerful alternative to Animated library for React Native.",
   "description": "RNReanimated",
   "homepage": "https://github.com/software-mansion/react-native-reanimated",
@@ -14,7 +14,7 @@
   },
   "source": {
     "git": "https://github.com/wordpress-mobile/react-native-reanimated.git",
-    "tag": "2.9.1-wp-2"
+    "tag": "2.9.1-wp-3"
   },
   "source_files": [
     "ios/**/*.{mm,h,m}",


### PR DESCRIPTION
**Related PRs:**
- https://github.com/WordPress/gutenberg/pull/47574
- https://github.com/wordpress-mobile/WordPress-iOS/pull/20034
- https://github.com/wordpress-mobile/WordPress-Android/pull/17846

This PR updates the React Native Reanimated library version to `2.9.1-wp-3`.

To test CI checks should pass, builds should succeed and the editor should open correctly.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
