### PR TITLE
Update `eslint-plugin-jsdoc` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5913,22 +5913,16 @@
 			"dev": true
 		},
 		"@es-joy/jsdoccomment": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.6.0.tgz",
-			"integrity": "sha512-zT1EtysKMITJ7vE4RvOJqitxk/Str6It8hq+fykxkwLuTyzgak+TnVuVSIyovT/qrEz3i46ypCSXgNtIDYwNOg==",
+			"version": "0.36.1",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
+			"integrity": "sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==",
 			"dev": true,
 			"requires": {
-				"comment-parser": "^1.1.5",
+				"comment-parser": "1.3.1",
 				"esquery": "^1.4.0",
-				"jsdoctypeparser": "^9.0.0"
+				"jsdoc-type-pratt-parser": "~3.1.0"
 			},
 			"dependencies": {
-				"comment-parser": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.1.5.tgz",
-					"integrity": "sha512-RePCE4leIhBlmrqiYTvaqEeGYg7qpSl4etaIabKtdOQVi+mSTIBBklGUwIr79GXYnl3LpMwmDw4KeR2stNc6FA==",
-					"dev": true
-				},
 				"esquery": {
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
@@ -5939,9 +5933,9 @@
 					}
 				},
 				"estraverse": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-					"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 					"dev": true
 				}
 			}
@@ -8775,6 +8769,7 @@
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-plugin-import": "^2.25.2",
 				"eslint-plugin-jest": "^27.2.1",
+				"eslint-plugin-jsdoc": "^39.6.9",
 				"eslint-plugin-jsx-a11y": "^6.5.1",
 				"eslint-plugin-prettier": "^3.3.0",
 				"eslint-plugin-react": "^7.27.0",
@@ -8783,22 +8778,6 @@
 				"requireindex": "^1.2.0"
 			},
 			"dependencies": {
-				"@es-joy/jsdoccomment": {
-					"version": "0.12.0",
-					"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.12.0.tgz",
-					"integrity": "sha512-Gw4/j9v36IKY8ET+W0GoOzrRw17xjf21EIFFRL3zx21fF5MnqmeNpNi+PU/LKjqLpPb2Pw2XdlJbYM31VVo/PQ==",
-					"requires": {
-						"comment-parser": "1.2.4",
-						"esquery": "^1.4.0"
-					},
-					"dependencies": {
-						"comment-parser": {
-							"version": "1.2.4",
-							"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.2.4.tgz",
-							"integrity": "sha512-pm0b+qv+CkWNriSTMsfnjChF9kH0kxz55y44Wo5le9qLxMj5xDQAaEd9ZN1ovSuk9CsrncWaFwgpOMg7ClJwkw=="
-						}
-					}
-				},
 				"@typescript-eslint/eslint-plugin": {
 					"version": "5.6.0",
 					"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.6.0.tgz",
@@ -8852,15 +8831,11 @@
 						"resolve": "^1.12.0"
 					}
 				},
-				"comment-parser": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.0.tgz",
-					"integrity": "sha512-hRpmWIKgzd81vn0ydoWoyPoALEOnF4wt8yKD35Ib1D6XC2siLiYaiqfGkYrunuKdsXGwpBpHU3+9r+RVw2NZfA=="
-				},
 				"debug": {
 					"version": "4.3.3",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
 					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
 					}
@@ -8896,7 +8871,8 @@
 				"escape-string-regexp": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+					"dev": true
 				},
 				"eslint-import-resolver-node": {
 					"version": "0.3.6",
@@ -8989,24 +8965,45 @@
 					}
 				},
 				"eslint-plugin-jsdoc": {
-					"version": "37.1.0",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.1.0.tgz",
-					"integrity": "sha512-DpkFzX5Sqkqzy4MCgowhDXmusWcF1Gn7wYnphdGfWmIkoQr6SwL0jEtltGAVyF5Rj6ACi6ydw0oCCI5hF3yz6w==",
+					"version": "39.7.4",
+					"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.7.4.tgz",
+					"integrity": "sha512-2eJcWGKRyNQFa37UIpGcAdOp3wtES8vV3mlnFmEmJCuBNyFhK6cMhbZgMkLoLjKnipoxsN9GbfZZ+8nPY8ETZQ==",
+					"dev": true,
 					"requires": {
-						"@es-joy/jsdoccomment": "0.12.0",
-						"comment-parser": "1.3.0",
-						"debug": "^4.3.3",
+						"@es-joy/jsdoccomment": "~0.36.1",
+						"comment-parser": "1.3.1",
+						"debug": "^4.3.4",
 						"escape-string-regexp": "^4.0.0",
 						"esquery": "^1.4.0",
-						"regextras": "^0.8.0",
-						"semver": "^7.3.5",
+						"semver": "^7.3.8",
 						"spdx-expression-parse": "^3.0.1"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "4.3.4",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+							"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+							"dev": true,
+							"requires": {
+								"ms": "2.1.2"
+							}
+						},
+						"semver": {
+							"version": "7.3.8",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+							"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+							"dev": true,
+							"requires": {
+								"lru-cache": "^6.0.0"
+							}
+						}
 					}
 				},
 				"esquery": {
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
 					"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+					"dev": true,
 					"requires": {
 						"estraverse": "^5.1.0"
 					}
@@ -9014,7 +9011,8 @@
 				"estraverse": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+					"dev": true
 				},
 				"find-up": {
 					"version": "2.1.0",
@@ -9163,11 +9161,6 @@
 					"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
 					"dev": true
 				},
-				"regextras": {
-					"version": "0.8.0",
-					"resolved": "https://registry.npmjs.org/regextras/-/regextras-0.8.0.tgz",
-					"integrity": "sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ=="
-				},
 				"resolve": {
 					"version": "1.20.0",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -9181,6 +9174,7 @@
 					"version": "7.3.5",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
 					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
@@ -17166,9 +17160,9 @@
 			"dev": true
 		},
 		"comment-parser": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.1.5.tgz",
-			"integrity": "sha512-RePCE4leIhBlmrqiYTvaqEeGYg7qpSl4etaIabKtdOQVi+mSTIBBklGUwIr79GXYnl3LpMwmDw4KeR2stNc6FA==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+			"integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
 			"dev": true
 		},
 		"commoner": {
@@ -18640,30 +18634,34 @@
 			}
 		},
 		"eslint-plugin-jsdoc": {
-			"version": "34.8.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-34.8.2.tgz",
-			"integrity": "sha512-UOU9A40Cl806JMtla2vF+RM6sNqfLPbhLv9FZqhcC7+LmChD3DVaWqM7ADxpF0kMyZNWe1QKUnqGnXaA3NTn+w==",
+			"version": "39.7.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.7.4.tgz",
+			"integrity": "sha512-2eJcWGKRyNQFa37UIpGcAdOp3wtES8vV3mlnFmEmJCuBNyFhK6cMhbZgMkLoLjKnipoxsN9GbfZZ+8nPY8ETZQ==",
 			"dev": true,
 			"requires": {
-				"@es-joy/jsdoccomment": "^0.6.0",
-				"comment-parser": "1.1.5",
-				"debug": "^4.3.1",
+				"@es-joy/jsdoccomment": "~0.36.1",
+				"comment-parser": "1.3.1",
+				"debug": "^4.3.4",
+				"escape-string-regexp": "^4.0.0",
 				"esquery": "^1.4.0",
-				"jsdoctypeparser": "^9.0.0",
-				"lodash": "^4.17.21",
-				"regextras": "^0.7.1",
-				"semver": "^7.3.5",
+				"semver": "^7.3.8",
 				"spdx-expression-parse": "^3.0.1"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"version": "4.3.4",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
 					}
+				},
+				"escape-string-regexp": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+					"dev": true
 				},
 				"esquery": {
 					"version": "1.4.0",
@@ -18675,40 +18673,19 @@
 					}
 				},
 				"estraverse": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-					"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 					"dev": true
-				},
-				"lodash": {
-					"version": "4.17.21",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-					"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-					"dev": true
-				},
-				"lru-cache": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-					"dev": true,
-					"requires": {
-						"yallist": "^4.0.0"
-					}
 				},
 				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"version": "7.3.8",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
 				}
 			}
 		},
@@ -22743,10 +22720,10 @@
 			"integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
 			"dev": true
 		},
-		"jsdoctypeparser": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-9.0.0.tgz",
-			"integrity": "sha512-jrTA2jJIL6/DAEILBEh2/w9QxCuwmvNXIry39Ay/HVfhE3o2yVV0U44blYkqdHA/OKloJEqvJy0xU+GSdE2SIw==",
+		"jsdoc-type-pratt-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
+			"integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
 			"dev": true
 		},
 		"jsdom": {
@@ -23331,6 +23308,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
 			"requires": {
 				"yallist": "^4.0.0"
 			}
@@ -25304,12 +25282,6 @@
 				"unicode-match-property-value-ecmascript": "^1.2.0"
 			}
 		},
-		"regextras": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/regextras/-/regextras-0.7.1.tgz",
-			"integrity": "sha512-9YXf6xtW+qzQ+hcMQXx95MOvfqXFgsKDZodX3qZB0x2n5Z94ioetIITsBtvJbiOyxa/6s9AtyweBLCdPmPko/w==",
-			"dev": true
-		},
 		"regjsgen": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
@@ -26017,12 +25989,14 @@
 		"spdx-exceptions": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+			"dev": true
 		},
 		"spdx-expression-parse": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
 			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+			"dev": true,
 			"requires": {
 				"spdx-exceptions": "^2.1.0",
 				"spdx-license-ids": "^3.0.0"
@@ -26031,7 +26005,8 @@
 		"spdx-license-ids": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
+			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+			"dev": true
 		},
 		"split-string": {
 			"version": "3.1.0",
@@ -27335,7 +27310,8 @@
 		"yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
 		},
 		"yaml": {
 			"version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"eslint-plugin-eslint-comments": "3.1.2",
 		"eslint-plugin-import": "2.18.2",
 		"eslint-plugin-jest": "27.2.1",
-		"eslint-plugin-jsdoc": "^34.1.0",
+		"eslint-plugin-jsdoc": "^39.6.9",
 		"eslint-plugin-react-native": "^3.6.0",
 		"gettext-parser": "^4.0.3",
 		"husky": "^3.0.2",


### PR DESCRIPTION
Bump the `eslint-plugin-jsdoc` dependency to match the same version used in Gutenberg ([PR reference](https://github.com/WordPress/gutenberg/pull/47490)).

To test:
N/A

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
