### PR TITLE
Skip buildkite steps for branches for dependabot PRs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,6 +10,9 @@ x-common-params:
       - "AWS_SECRET_KEY"
 
 steps:
+  - block: "Request trigger Android bundle and builds"
+    branches: "dependabot/submodules/*"
+
   - label: "Bundle Android"
     key: "bundle-android"
     plugins:
@@ -30,9 +33,6 @@ steps:
         npm run bundle:android
 
         buildkite-agent artifact upload bundle/android/App.js
-    block:
-      prompt: "Trigger build"
-      branches: "!dependabot/submodules/*"
 
   - label: "Build Android RN Aztec & Publish to S3"
     key: "publish-react-native-aztec-android"
@@ -40,9 +40,6 @@ steps:
       - *publish-android-artifacts-docker-container
     command: |
         .buildkite/publish-react-native-aztec-android-artifacts.sh
-    block:
-      prompt: "Trigger build"
-      branches: "!dependabot/submodules/*"
 
   - label: "Build Android RN Bridge & Publish to S3"
     depends_on:
@@ -52,6 +49,3 @@ steps:
       - *publish-android-artifacts-docker-container
     command: |
         .buildkite/publish-react-native-bridge-android-artifacts.sh
-    block:
-      prompt: "Trigger build"
-      branches: "!dependabot/submodules/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,6 +30,7 @@ steps:
         npm run bundle:android
 
         buildkite-agent artifact upload bundle/android/App.js
+    branches: "!dependabot/submodules/*"
 
   - label: "Build Android RN Aztec & Publish to S3"
     key: "publish-react-native-aztec-android"
@@ -37,6 +38,7 @@ steps:
       - *publish-android-artifacts-docker-container
     command: |
         .buildkite/publish-react-native-aztec-android-artifacts.sh
+    branches: "!dependabot/submodules/*"
 
   - label: "Build Android RN Bridge & Publish to S3"
     depends_on:
@@ -46,3 +48,4 @@ steps:
       - *publish-android-artifacts-docker-container
     command: |
         .buildkite/publish-react-native-bridge-android-artifacts.sh
+    branches: "!dependabot/submodules/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,7 +30,9 @@ steps:
         npm run bundle:android
 
         buildkite-agent artifact upload bundle/android/App.js
-    branches: "!dependabot/submodules/*"
+    block:
+      prompt: "Trigger build"
+      branches: "!dependabot/submodules/*"
 
   - label: "Build Android RN Aztec & Publish to S3"
     key: "publish-react-native-aztec-android"
@@ -38,7 +40,9 @@ steps:
       - *publish-android-artifacts-docker-container
     command: |
         .buildkite/publish-react-native-aztec-android-artifacts.sh
-    branches: "!dependabot/submodules/*"
+    block:
+      prompt: "Trigger build"
+      branches: "!dependabot/submodules/*"
 
   - label: "Build Android RN Bridge & Publish to S3"
     depends_on:
@@ -48,4 +52,6 @@ steps:
       - *publish-android-artifacts-docker-container
     command: |
         .buildkite/publish-react-native-bridge-android-artifacts.sh
-    branches: "!dependabot/submodules/*"
+    block:
+      prompt: "Trigger build"
+      branches: "!dependabot/submodules/*"


### PR DESCRIPTION
This PR aims to block Buildkite steps to run on the [Dependabot PRs](https://github.com/wordpress-mobile/gutenberg-mobile/labels/dependencies) we have for the submodules, `Jetpack`, `Block experiments`, and `Gutenberg`.

We are constantly seeing failed CI checks due to a pre-existing build on S3. Until there's a solution for that, I propose blocking the steps so we don't have failures on those PRs.

There will be a button to manually run these steps on these branches:

<kbd><img width="395" alt="Screen Shot 2023-02-15 at 16 39 25" src="https://user-images.githubusercontent.com/4885740/219076043-89471806-5c2a-46d6-9b62-444324908749.png"></kbd>

There's no need to have Android builds uploaded for these PRs since as far as I know we never make main apps PRs targeting those PRs.

**To test**

CI checks should pass and Builtkite steps should **be blocked**.

This other PR https://github.com/wordpress-mobile/gutenberg-mobile/pull/5477 that has the same changes but with a different branch name should run all Builtkite steps without manually approving the steps.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
