### PR TITLE
CircleCI checks - Fix running Full tests twice in certain branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -408,9 +408,21 @@ workflows:
       - ios-device-checks:
           name: Test iOS on Device - Full
           requires: [ "Optional UI Tests", "Test iOS", "iOS Build" ]
+          filters:
+            branches:
+              ignore:
+                - trunk
+                - /^dependabot/submodules/.*/
+                - /^release.*/
       - android-device-checks:
           name: Test Android on Device - Full
           requires: [ "Optional UI Tests", "Test Android", "Android Native Unit Tests", "Android Build" ]
+          filters:
+            branches:
+              ignore:
+                - trunk
+                - /^dependabot/submodules/.*/
+                - /^release.*/
       - android-native-unit-tests:
           name: Android Native Unit Tests
       - ios-device-checks:


### PR DESCRIPTION
This is a follow-up of https://github.com/wordpress-mobile/gutenberg-mobile/pull/5462 where it was causing an issue where the `Test iOS on Device - Full` and `Test Android on Device - Full` steps would get triggered for `release`, `dependabot`, and `trunk` branches when it shouldn't, as there are steps specifically for those branches.

Making the `Optional UI Tests` as required and that requirement being ignored for those branches would trigger full tests to run twice. This PR addresses that issue.

You could [see this happening](https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile?branch=trunk) in the `trunk` branch after the recent merge.

**To test**
CI checks should pass.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
