### PR TITLE
Unify the CI jobs that run the full E2E test suites automatically

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -397,6 +397,9 @@ workflows:
           name: Test Android on Device - Canaries
           is-canary: "-canary"
           requires: [ "Test Android", "Android Native Unit Tests", "Android Build" ]
+      - android-native-unit-tests:
+          name: Android Native Unit Tests
+      # For regular branches the full test suite is optional.
       - Optional UI Tests:
           type: approval
           filters:
@@ -406,7 +409,7 @@ workflows:
                 - /^dependabot/submodules/.*/
                 - /^release.*/
       - ios-device-checks:
-          name: Test iOS on Device - Full
+          name: Test iOS on Device - Full (Manually triggered)
           requires: [ "Optional UI Tests", "Test iOS", "iOS Build" ]
           filters:
             branches:
@@ -415,7 +418,7 @@ workflows:
                 - /^dependabot/submodules/.*/
                 - /^release.*/
       - android-device-checks:
-          name: Test Android on Device - Full
+          name: Test Android on Device - Full (Manually triggered)
           requires: [ "Optional UI Tests", "Test Android", "Android Native Unit Tests", "Android Build" ]
           filters:
             branches:
@@ -423,51 +426,24 @@ workflows:
                 - trunk
                 - /^dependabot/submodules/.*/
                 - /^release.*/
-      - android-native-unit-tests:
-          name: Android Native Unit Tests
+      # For `trunk`, Dependabot, and release branches we always run the full test suite.
       - ios-device-checks:
-          name: Test iOS on Device - Full (Submodule Update)
-          post-to-slack: true
-          requires: [ "Test iOS", "iOS Build" ]
-          filters:
-            branches:
-              only: /^dependabot/submodules/.*/
-      - android-device-checks:
-          name: Test Android on Device - Full (Submodule Update)
-          post-to-slack: true
-          requires: [ "Test Android", "Android Native Unit Tests", "Android Build" ]
-          filters:
-            branches:
-              only: /^dependabot/submodules/.*/
-      - ios-device-checks:
-          name: Test iOS on Device - Full (On Trunk)
+          name: Test iOS on Device - Full
           post-to-slack: true
           requires: [ "Test iOS", "iOS Build" ]
           filters:
             branches:
               only:
                 - trunk
+                - /^dependabot/submodules/.*/
+                - /^release.*/
       - android-device-checks:
-          name: Test Android on Device - Full (On Trunk)
+          name: Test Android on Device - Full
           post-to-slack: true
           requires: [ "Test Android", "Android Native Unit Tests", "Android Build" ]
-          filters:
-            branches:
-              only:
-                - trunk
-      - ios-device-checks:
-          name: Test iOS on Device - Full (Release)
-          post-to-slack: true
-          requires: [ "Test iOS", "iOS Build" ]
           filters:
             branches:
               only: 
-                - /^release.*/
-      - android-device-checks:
-          name: Test Android on Device - Full (Release)
-          post-to-slack: true
-          requires: [ "Test Android", "Android Native Unit Tests", "Android Build" ]
-          filters:
-            branches:
-              only:
+                - trunk
+                - /^dependabot/submodules/.*/
                 - /^release.*/


### PR DESCRIPTION
The full E2E test suites are automatically triggered for the following specific branches:
- `trunk`
- Dependabot branches (e.g. `dependabot/submodules/gutenberg-caab0fe`)
- Release branches (e.g. `release/1.88.0`)

We define a single job for each branch but the same steps are executed ([reference](https://github.com/wordpress-mobile/gutenberg-mobile/blob/3a3f91a3e0576e365f20490f6f0a481e1e709919/.circleci/config.yml#L446-L461)). For this reason, I'd propose unifying them into a single job for each platform to simplify the CircleCI configuration.

## To test

#### Regular branch
- Observe in this PR that the `Test Android on Device - Full` and `Test iOS on Device - Full` are not automatically triggered. [**This can be checked in the CircleCI workflow.**](https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/19560/workflows/767bfd00-b3e4-4a2e-b67b-6ab03b8eec37)

#### Dependabot branch
- Observe in https://github.com/wordpress-mobile/gutenberg-mobile/pull/5484 that the `Test Android on Device - Full` and `Test iOS on Device - Full` are automatically triggered. [**This can be checked in the CircleCI workflow**](https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/19558/workflows/a8298acd-dc74-489f-8439-e051095168cc).

#### Release branch
- Observe in https://github.com/wordpress-mobile/gutenberg-mobile/pull/5483 that the `Test Android on Device - Full` and `Test iOS on Device - Full` are automatically triggered. [**This can be checked in the CircleCI workflow**](https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/19559/workflows/7a181a0e-a0a5-4f3f-b0f9-905ac9331546).

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
