### PR TITLE
CircleCI Config - Updates the Android docker image to the new one

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ commands:
 parameters:
   android-docker-image:
     type: string
-    default: "cimg/android:android-31"
+    default: "cimg/android:2023.02.1-node"
   linux-machine-image:
     type: string
     # Latest supported ubuntu image from https://circleci.com/docs/2.0/configuration-reference/#available-machine-images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,6 +276,7 @@ jobs:
       - checkout-shallow
       - checkout-submodules
       - install-node-version
+      - run: node -v
       - npm-install
       - run:
           name: Run Android native-editor unit tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ commands:
 parameters:
   android-docker-image:
     type: string
-    default: "cimg/android:api-31"
+    default: "cimg/android:android-31"
   linux-machine-image:
     type: string
     # Latest supported ubuntu image from https://circleci.com/docs/2.0/configuration-reference/#available-machine-images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,8 +160,7 @@ commands:
 parameters:
   android-docker-image:
     type: string
-    # Hash points to previous version with node 12. When everything works with node 14 it can be removed
-    default: "circleci/android:api-29-node@sha256:71d61d6c21b29948d57120f476a83cc322a280979bce355c5a0ad771293ca380"
+    default: "cimg/android:api-31"
   linux-machine-image:
     type: string
     # Latest supported ubuntu image from https://circleci.com/docs/2.0/configuration-reference/#available-machine-images


### PR DESCRIPTION
The current Android docker image got deprecated as it is shown in some [jobs now](https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/19631/workflows/38e7445c-ba13-499a-b63f-df920e463ef5/jobs/108870):

<kbd><img width="541" alt="Screenshot 2023-03-02 at 10 24 56" src="https://user-images.githubusercontent.com/4885740/222387096-c8e34813-0a9e-4987-87fd-69a871bc317d.png"></kbd>

This PR updates it to the current docker image as per their docs.

For more information see the [cimg/android page](https://circleci.com/developer/images/image/cimg/android).

To test:

CI checks should pass.

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
