### PR TITLE
build: Update caniuse-lite data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2074,12 +2074,6 @@
 						"update-browserslist-db": "^1.0.9"
 					}
 				},
-				"caniuse-lite": {
-					"version": "1.0.30001434",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz",
-					"integrity": "sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==",
-					"dev": true
-				},
 				"electron-to-chromium": {
 					"version": "1.4.284",
 					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
@@ -3124,12 +3118,6 @@
 						"update-browserslist-db": "^1.0.9"
 					}
 				},
-				"caniuse-lite": {
-					"version": "1.0.30001434",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz",
-					"integrity": "sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==",
-					"dev": true
-				},
 				"electron-to-chromium": {
 					"version": "1.4.284",
 					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
@@ -3423,12 +3411,6 @@
 						"node-releases": "^2.0.6",
 						"update-browserslist-db": "^1.0.9"
 					}
-				},
-				"caniuse-lite": {
-					"version": "1.0.30001434",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz",
-					"integrity": "sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==",
-					"dev": true
 				},
 				"electron-to-chromium": {
 					"version": "1.4.284",
@@ -4738,12 +4720,6 @@
 						"update-browserslist-db": "^1.0.9"
 					}
 				},
-				"caniuse-lite": {
-					"version": "1.0.30001434",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz",
-					"integrity": "sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==",
-					"dev": true
-				},
 				"core-js-compat": {
 					"version": "3.26.1",
 					"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.26.1.tgz",
@@ -5538,12 +5514,6 @@
 						"node-releases": "^2.0.1",
 						"picocolors": "^1.0.0"
 					}
-				},
-				"caniuse-lite": {
-					"version": "1.0.30001280",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001280.tgz",
-					"integrity": "sha512-kFXwYvHe5rix25uwueBxC569o53J6TpnGu0BEEn+6Lhl2vsnAumRFWEBhDft1fwyo6m1r4i+RqA4+163FpeFcA==",
-					"dev": true
 				},
 				"electron-to-chromium": {
 					"version": "1.3.895",
@@ -9897,14 +9867,6 @@
 						"escalade": "^3.1.1",
 						"node-releases": "^2.0.1",
 						"picocolors": "^1.0.0"
-					},
-					"dependencies": {
-						"caniuse-lite": {
-							"version": "1.0.30001280",
-							"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001280.tgz",
-							"integrity": "sha512-kFXwYvHe5rix25uwueBxC569o53J6TpnGu0BEEn+6Lhl2vsnAumRFWEBhDft1fwyo6m1r4i+RqA4+163FpeFcA==",
-							"dev": true
-						}
 					}
 				},
 				"electron-to-chromium": {
@@ -18119,9 +18081,9 @@
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001237",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001237.tgz",
-			"integrity": "sha512-pDHgRndit6p1NR2GhzMbQ6CkRrp4VKuSsqbcLeOQppYPKOYkKT/6ZvZDvKJUqcmtyWIAHuZq3SVS2vc1egCZzw==",
+			"version": "1.0.30001460",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001460.tgz",
+			"integrity": "sha512-Bud7abqjvEjipUkpLs4D7gR0l8hBYBHoa+tGtKJHvT2AYzLp1z7EmVkUT4ERpVUfca8S2HGIVs883D8pUH1ZzQ==",
 			"dev": true
 		},
 		"capital-case": {
@@ -18650,12 +18612,6 @@
 						"node-releases": "^2.0.1",
 						"picocolors": "^1.0.0"
 					}
-				},
-				"caniuse-lite": {
-					"version": "1.0.30001280",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001280.tgz",
-					"integrity": "sha512-kFXwYvHe5rix25uwueBxC569o53J6TpnGu0BEEn+6Lhl2vsnAumRFWEBhDft1fwyo6m1r4i+RqA4+163FpeFcA==",
-					"dev": true
 				},
 				"electron-to-chromium": {
 					"version": "1.3.895",

--- a/package.json
+++ b/package.json
@@ -99,5 +99,6 @@
 		"lint": "eslint . --ext .js",
 		"lint:fix": "npm run lint -- --fix",
 		"version": "npm run bundle && git add -A bundle"
-	}
+	},
+	"dependencies": {}
 }


### PR DESCRIPTION
Address the following warning by running the provided script:

```
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
```

To test:

To my understanding, this should have no impact on user-facing features. 

1. Run `npm run device-tests:local`. 
2. Verify the aforementioned warning is not logged. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
