### PR TITLE
Add Rich Text Writing Flow E2E tests for cases TC007, TC009, TC010

### DIFF
--- a/__device-tests__/gutenberg-editor-writing-flow.test.js
+++ b/__device-tests__/gutenberg-editor-writing-flow.test.js
@@ -1,0 +1,104 @@
+/**
+ * Internal dependencies
+ */
+const { blockNames } = editorPage;
+
+describe( 'Gutenberg Editor - Writing Flow', () => {
+	describe( 'TC007 - Test format detection under the cursor', () => {
+		it( 'checks that the proper format buttons are selected when the cursor is under', async () => {
+			const paragraphHTML = `<!-- wp:paragraph -->
+            <p><span accessibility-id="bold"><strong>bold</strong></span>
+            <span accessibility-id="bold-italic"><strong><i>bold-italic</i></strong>.</span>
+            <span accessibility-id-"strikethrough"><s>strikethrough</s></span></p>
+            <!-- /wp:paragraph -->`;
+
+			// On a rich-text based component, add bold, italic, strikethrough and link formatted text
+			await editorPage.addNewBlock( blockNames.paragraph );
+			const paragraphBlockElement = await editorPage.getTextBlockAtPosition(
+				blockNames.paragraph
+			);
+
+			await editorPage.typeTextToTextBlock(
+				paragraphBlockElement,
+				paragraphHTML
+			);
+
+			// Select bold text
+			// TODO: verify if this is the best method to select text formatting
+			await editorPage.elementsByAccessibilityId( 'bold' );
+
+			// Check that the proper format buttons get selected
+			// TODO: Identify best method to identify format buttons
+
+			// TODO: Invoke assertion or snapshot here?
+
+			// TODO: Repeat for bold-italic and strikethrough
+
+			await editorPage.removeBlock();
+		} );
+	} );
+
+	describe( `TC009 - Test autocorrection doesn't apply formatting to Heading`, () => {
+		it( 'checks that formatting is not applied to autocorrected text', async () => {
+			const headingText = `<p>Mispelled</p>`;
+
+			// Add a Heading block without any formatting applied.
+			await editorPage.addNewBlock( blockNames.heading );
+			const headingBlockElement = await editorPage.getTextBlockAtPosition(
+				blockNames.heading
+			);
+
+			// Type a sentence with a word misspelled that will be autocorrected by the editor
+			await editorPage.typeTextToTextBlock(
+				headingBlockElement,
+				headingText
+			);
+
+			// Highlight the word that was autocorrected
+			// Simulated double tap. TODO: Verify if this is the best method to highlight text
+			await editorPage.tapElement( headingBlockElement );
+			await editorPage.tapElement( headingBlockElement );
+
+			// Check that the word has no formatting applied
+			const selectedText = await editorPage.getTextForParagraphBlockAtPosition(
+				1
+			);
+			// TODO: verify if a snapshot should be used in place of an assertion, or both
+			expect( selectedText ).toMatch( headingText );
+
+			await editorPage.removeBlock();
+		} );
+	} );
+
+	describe( `TC010 - Test autocorrection doesn't remove formatting from Heading`, () => {
+		it( 'checks that formatting is not removed from autocorrected text', async () => {
+			const headingText = '<p><strong>Mispelled</strong></p>';
+
+			// Add a Heading block
+			await editorPage.addNewBlock( blockNames.heading );
+			const headingBlockElement = await editorPage.getTextBlockAtPosition(
+				blockNames.heading
+			);
+
+			// Type a sentence with a word misspelled that will be autocorrected by the editor
+			await editorPage.typeTextToTextBlock(
+				headingBlockElement,
+				headingText
+			);
+
+			// Highlight the word that was autocorrected
+			// Simulated double tap. TODO: Verify if this is the best method to highlight text
+			await editorPage.tapElement( headingBlockElement );
+			await editorPage.tapElement( headingBlockElement );
+
+			// Check that the word has formatting applied
+			const selectedText = await editorPage.getTextForParagraphBlockAtPosition(
+				1
+			);
+			// TODO: verify if a snapshot should be used in place of an assertion, or both
+			expect( selectedText ).toMatch( headingText );
+
+			await editorPage.removeBlock();
+		} );
+	} );
+} );

--- a/__device-tests__/gutenberg-editor-writing-flow.test.js
+++ b/__device-tests__/gutenberg-editor-writing-flow.test.js
@@ -58,7 +58,7 @@ describe( 'Gutenberg Editor - Writing Flow', () => {
 
 	describe( `TC009 - Test autocorrection doesn't apply formatting to Heading`, () => {
 		it( 'checks that formatting is not applied to autocorrected text', async () => {
-			const headingText = `<p>Mispelled</p>`;
+			const headingText = `Mispelled`;
 
 			// Add a Heading block without any formatting applied.
 			await editorPage.addNewBlock( blockNames.heading );
@@ -90,7 +90,7 @@ describe( 'Gutenberg Editor - Writing Flow', () => {
 
 	describe( `TC010 - Test autocorrection doesn't remove formatting from Heading`, () => {
 		it( 'checks that formatting is not removed from autocorrected text', async () => {
-			const headingText = '<p><strong>Mispelled</strong></p>';
+			const headingText = 'Mispelled';
 
 			// Add a Heading block
 			await editorPage.addNewBlock( blockNames.heading );
@@ -98,7 +98,10 @@ describe( 'Gutenberg Editor - Writing Flow', () => {
 				blockNames.heading
 			);
 
+			// Toggle bold formatting
 			// Type a sentence with a word misspelled that will be autocorrected by the editor
+
+			await editorPage.toggleFormatting( 'Bold' );
 			await editorPage.typeTextToTextBlock(
 				headingBlockElement,
 				headingText
@@ -115,6 +118,8 @@ describe( 'Gutenberg Editor - Writing Flow', () => {
 				1
 			);
 			expect( selectedText ).toMatch( headingText );
+
+			// TODO: Add assertion or visual snapshot that bold formatting is retained
 
 			await editorPage.removeBlock();
 		} );

--- a/__device-tests__/gutenberg-editor-writing-flow.test.js
+++ b/__device-tests__/gutenberg-editor-writing-flow.test.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { tapSelectAllAboveElement } from './helpers/utils';
 const { blockNames } = editorPage;
 
 describe( 'Gutenberg Editor - Writing Flow', () => {
@@ -55,9 +56,10 @@ describe( 'Gutenberg Editor - Writing Flow', () => {
 			);
 
 			// Highlight the word that was autocorrected
-			// Simulated double tap. TODO: Verify if this is the best method to highlight text
-			await editorPage.tapElement( headingBlockElement );
-			await editorPage.tapElement( headingBlockElement );
+			await tapSelectAllAboveElement(
+				editorPage.driver,
+				headingBlockElement
+			);
 
 			// Check that the word has no formatting applied
 			const selectedText = await editorPage.getTextForParagraphBlockAtPosition(
@@ -87,9 +89,10 @@ describe( 'Gutenberg Editor - Writing Flow', () => {
 			);
 
 			// Highlight the word that was autocorrected
-			// Simulated double tap. TODO: Verify if this is the best method to highlight text
-			await editorPage.tapElement( headingBlockElement );
-			await editorPage.tapElement( headingBlockElement );
+			await tapSelectAllAboveElement(
+				editorPage.driver,
+				headingBlockElement
+			);
 
 			// Check that the word has formatting applied
 			const selectedText = await editorPage.getTextForParagraphBlockAtPosition(

--- a/__device-tests__/gutenberg-editor-writing-flow.test.js
+++ b/__device-tests__/gutenberg-editor-writing-flow.test.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { tapSelectAllAboveElement } from './helpers/utils';
+import { takeScreenshot } from './utils';
 const { blockNames } = editorPage;
 
 describe( 'Gutenberg Editor - Writing Flow', () => {
@@ -28,12 +29,18 @@ describe( 'Gutenberg Editor - Writing Flow', () => {
 			// Toggle various formatting options, then proceed with typing more text
 			await editorPage.toggleFormatting( 'Bold' );
 
+			const boldScreenshot = await takeScreenshot();
+			expect( boldScreenshot ).toMatchImageSnapshot();
+
 			await editorPage.typeTextToTextBlock(
 				paragraphBlockElement,
 				paragraphText[ 1 ]
 			);
 
 			await editorPage.toggleFormatting( 'Italic' );
+
+			const boldItalicScreenshot = await takeScreenshot();
+			expect( boldItalicScreenshot ).toMatchImageSnapshot();
 
 			await editorPage.typeTextToTextBlock(
 				paragraphBlockElement,
@@ -50,7 +57,8 @@ describe( 'Gutenberg Editor - Writing Flow', () => {
 
 			await editorPage.toggleFormatting( 'Strikethrough' );
 
-			// TODO: Invoke assertion or snapshot here?
+			const strikethroughScreenshot = await takeScreenshot();
+			expect( strikethroughScreenshot ).toMatchImageSnapshot();
 
 			await editorPage.removeBlock();
 		} );

--- a/__device-tests__/gutenberg-editor-writing-flow.test.js
+++ b/__device-tests__/gutenberg-editor-writing-flow.test.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { tapSelectAllAboveElement } from './helpers/utils';
+const { tapSelectAllAboveElement } = e2eUtils;
 import { takeScreenshot } from './utils';
 const { blockNames } = editorPage;
 

--- a/__device-tests__/gutenberg-editor-writing-flow.test.js
+++ b/__device-tests__/gutenberg-editor-writing-flow.test.js
@@ -49,7 +49,6 @@ describe( 'Gutenberg Editor - Writing Flow', () => {
 			await editorPage.toggleFormatting( 'Italic' );
 			await editorPage.toggleFormatting( 'Bold' );
 
-
 			await editorPage.typeTextToTextBlock( paragraphBlockElement, '' );
 			await editorPage.typeTextToTextBlock(
 				paragraphBlockElement,

--- a/__device-tests__/gutenberg-editor-writing-flow.test.js
+++ b/__device-tests__/gutenberg-editor-writing-flow.test.js
@@ -1,19 +1,14 @@
 /**
  * Internal dependencies
  */
-const { tapSelectAllAboveElement } = e2eUtils;
+const { selectTextFromElement, tapSelectAllAboveElement } = e2eUtils;
 import { takeScreenshot } from './utils';
 const { blockNames } = editorPage;
 
 describe( 'Gutenberg Editor - Writing Flow', () => {
 	describe( 'TC007 - Test format detection under the cursor', () => {
 		it( 'checks that the proper format buttons are selected when the cursor is under', async () => {
-			const paragraphText = [
-				'Text to type',
-				'into the block',
-				'to test various',
-				'formatting options',
-			];
+			const paragraphText = [ 'Bold', 'Bold-Italic', 'Strikethrough' ];
 
 			// On a rich-text based component, add bold, italic, strikethrough and link formatted text
 			await editorPage.addNewBlock( blockNames.paragraph );
@@ -25,6 +20,10 @@ describe( 'Gutenberg Editor - Writing Flow', () => {
 				paragraphBlockElement,
 				paragraphText[ 0 ]
 			);
+			await selectTextFromElement(
+				editorPage.driver,
+				paragraphBlockElement
+			);
 
 			// Toggle various formatting options, then proceed with typing more text
 			await editorPage.toggleFormatting( 'Bold' );
@@ -32,9 +31,14 @@ describe( 'Gutenberg Editor - Writing Flow', () => {
 			const boldScreenshot = await takeScreenshot();
 			expect( boldScreenshot ).toMatchImageSnapshot();
 
+			await editorPage.typeTextToTextBlock( paragraphBlockElement, '' );
 			await editorPage.typeTextToTextBlock(
 				paragraphBlockElement,
 				paragraphText[ 1 ]
+			);
+			await selectTextFromElement(
+				editorPage.driver,
+				paragraphBlockElement
 			);
 
 			await editorPage.toggleFormatting( 'Italic' );
@@ -42,17 +46,18 @@ describe( 'Gutenberg Editor - Writing Flow', () => {
 			const boldItalicScreenshot = await takeScreenshot();
 			expect( boldItalicScreenshot ).toMatchImageSnapshot();
 
+			await editorPage.toggleFormatting( 'Italic' );
+			await editorPage.toggleFormatting( 'Bold' );
+
+
+			await editorPage.typeTextToTextBlock( paragraphBlockElement, '' );
 			await editorPage.typeTextToTextBlock(
 				paragraphBlockElement,
 				paragraphText[ 2 ]
 			);
-
-			await editorPage.toggleFormatting( 'Italic' );
-			await editorPage.toggleFormatting( 'Bold' );
-
-			await editorPage.typeTextToTextBlock(
-				paragraphBlockElement,
-				paragraphText[ 3 ]
+			await selectTextFromElement(
+				editorPage.driver,
+				paragraphBlockElement
 			);
 
 			await editorPage.toggleFormatting( 'Strikethrough' );
@@ -90,6 +95,7 @@ describe( 'Gutenberg Editor - Writing Flow', () => {
 			const selectedText = await editorPage.getTextForParagraphBlockAtPosition(
 				1
 			);
+
 			expect( selectedText ).toMatch( headingText );
 
 			await editorPage.removeBlock();

--- a/__device-tests__/gutenberg-editor-writing-flow.test.js
+++ b/__device-tests__/gutenberg-editor-writing-flow.test.js
@@ -82,7 +82,6 @@ describe( 'Gutenberg Editor - Writing Flow', () => {
 			const selectedText = await editorPage.getTextForParagraphBlockAtPosition(
 				1
 			);
-			// TODO: verify if a snapshot should be used in place of an assertion, or both
 			expect( selectedText ).toMatch( headingText );
 
 			await editorPage.removeBlock();
@@ -115,7 +114,6 @@ describe( 'Gutenberg Editor - Writing Flow', () => {
 			const selectedText = await editorPage.getTextForParagraphBlockAtPosition(
 				1
 			);
-			// TODO: verify if a snapshot should be used in place of an assertion, or both
 			expect( selectedText ).toMatch( headingText );
 
 			await editorPage.removeBlock();

--- a/__device-tests__/gutenberg-editor-writing-flow.test.js
+++ b/__device-tests__/gutenberg-editor-writing-flow.test.js
@@ -7,11 +7,12 @@ const { blockNames } = editorPage;
 describe( 'Gutenberg Editor - Writing Flow', () => {
 	describe( 'TC007 - Test format detection under the cursor', () => {
 		it( 'checks that the proper format buttons are selected when the cursor is under', async () => {
-			const paragraphHTML = `<!-- wp:paragraph -->
-            <p><span accessibility-id="bold"><strong>bold</strong></span>
-            <span accessibility-id="bold-italic"><strong><i>bold-italic</i></strong>.</span>
-            <span accessibility-id-"strikethrough"><s>strikethrough</s></span></p>
-            <!-- /wp:paragraph -->`;
+			const paragraphText = [
+				'Text to type',
+				'into the block',
+				'to test various',
+				'formatting options',
+			];
 
 			// On a rich-text based component, add bold, italic, strikethrough and link formatted text
 			await editorPage.addNewBlock( blockNames.paragraph );
@@ -21,19 +22,35 @@ describe( 'Gutenberg Editor - Writing Flow', () => {
 
 			await editorPage.typeTextToTextBlock(
 				paragraphBlockElement,
-				paragraphHTML
+				paragraphText[ 0 ]
 			);
 
-			// Select bold text
-			// TODO: verify if this is the best method to select text formatting
-			await editorPage.elementsByAccessibilityId( 'bold' );
+			// Toggle various formatting options, then proceed with typing more text
+			await editorPage.toggleFormatting( 'Bold' );
 
-			// Check that the proper format buttons get selected
-			// TODO: Identify best method to identify format buttons
+			await editorPage.typeTextToTextBlock(
+				paragraphBlockElement,
+				paragraphText[ 1 ]
+			);
+
+			await editorPage.toggleFormatting( 'Italic' );
+
+			await editorPage.typeTextToTextBlock(
+				paragraphBlockElement,
+				paragraphText[ 2 ]
+			);
+
+			await editorPage.toggleFormatting( 'Italic' );
+			await editorPage.toggleFormatting( 'Bold' );
+
+			await editorPage.typeTextToTextBlock(
+				paragraphBlockElement,
+				paragraphText[ 3 ]
+			);
+
+			await editorPage.toggleFormatting( 'Strikethrough' );
 
 			// TODO: Invoke assertion or snapshot here?
-
-			// TODO: Repeat for bold-italic and strikethrough
 
 			await editorPage.removeBlock();
 		} );


### PR DESCRIPTION
Adds Rich Text [Writing Flow](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/rich-text-formatting.md) E2E test cases for [TC007](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/rich-text-formatting.md#tc007), [TC009](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/rich-text-formatting.md#tc009), and [TC010](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/rich-text-formatting.md#tc010).

To test:
- Android: Run `TEST_RN_PLATFORM=android npm run device-tests:local gutenberg-editor-writing-flow.test`
- iOS: Run `TEST_RN_PLATFORM=ios npm run device-tests:local gutenberg-editor-writing-flow.test`

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.

**Todo Checklist**
TC007:
- [x] [Verify best method to select text formatting](https://github.com/wordpress-mobile/gutenberg-mobile/compare/test/rich-text-writing-flow?expand=1#diff-bbf7f3f59de95b206e4b35babff68b7302411774427c2862ff9ff47e648c4b71R27-R28)
- [x] [Identify best method to identify format buttons](https://github.com/wordpress-mobile/gutenberg-mobile/compare/test/rich-text-writing-flow?expand=1#diff-bbf7f3f59de95b206e4b35babff68b7302411774427c2862ff9ff47e648c4b71R31)
- [ ] [Identify if snapshot should be used in place of assertion (and implement, if so)](https://github.com/wordpress-mobile/gutenberg-mobile/compare/test/rich-text-writing-flow?expand=1#diff-bbf7f3f59de95b206e4b35babff68b7302411774427c2862ff9ff47e648c4b71R33)
- [ ] [Repeat for all formatting types](https://github.com/wordpress-mobile/gutenberg-mobile/compare/test/rich-text-writing-flow?expand=1#diff-bbf7f3f59de95b206e4b35babff68b7302411774427c2862ff9ff47e648c4b71R35)
- [ ] Verify if markup is correct with assertion

TC009:

- [x] [Identify if snapshot should be used in place of assertion (and implement, if so)](https://github.com/wordpress-mobile/gutenberg-mobile/compare/test/rich-text-writing-flow?expand=1#diff-bbf7f3f59de95b206e4b35babff68b7302411774427c2862ff9ff47e648c4b71R66)
- [ ] Verify if markup is correct with assertion

TC010:

- [x] [Identify if snapshot should be used in place of assertion (and implement, if so)](https://github.com/wordpress-mobile/gutenberg-mobile/compare/test/rich-text-writing-flow?expand=1#diff-bbf7f3f59de95b206e4b35babff68b7302411774427c2862ff9ff47e648c4b71R98)
- [ ] Verify if markup is correct with assertion
