### PR TITLE
VideoPress block: POST support for `wpcom/v2/videopress/meta` endpoint

### DIFF
--- a/src/setup.js
+++ b/src/setup.js
@@ -50,7 +50,11 @@ const setupHooks = () => {
 		( endpoints ) => {
 			return {
 				...endpoints,
-				POST: [ ...endpoints.POST, /wpcom\/v2\/(media)\/.*/i ],
+				POST: [
+					...endpoints.POST,
+					/wpcom\/v2\/(media)\/.*/i,
+					/wpcom\/v2\/videopress\/meta.*/i,
+				],
 			};
 		}
 	);


### PR DESCRIPTION
## Description

With this PR, POST support for the `wpcom/v2/videopress/meta` endpoint has been added, which is needed as it's utilised in multiple different hooks in the VideoPress block.

## Testing

* Apply the following patch file:

```patch
diff --git a/packages/react-native-editor/src/api-fetch-setup.js b/packages/react-native-editor/src/api-fetch-setup.js
index 6d2f401e04..3c8dee9d01 100644
--- a/packages/react-native-editor/src/api-fetch-setup.js
+++ b/packages/react-native-editor/src/api-fetch-setup.js
@@ -76,6 +76,7 @@ export const isPathSupported = ( path, method ) => {
 		'native.supported_endpoints',
 		SUPPORTED_ENDPOINTS
 	);
+	console.log( { supportedEndpoints } );
 	return supportedEndpoints[ method ].some( ( pattern ) =>
 		pattern.test( path )
 	);
```
* Open the app with the local Metro server.
* Observe the console logs and check that the new endpoint added (`/wpcom\/v2\/videopress\/meta.*/i`) in this PR is printed.

<hr />

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
