### PR TITLE
Add script for running `pnpm` commands in Jetpack repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
-install-jetpack.sh.local
+run-jetpack-command.sh.local
 
 npm-debug.log*
 yarn-debug.log*

--- a/bin/run-jetpack-command.sh
+++ b/bin/run-jetpack-command.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-if [ -e ./bin/install-jetpack.sh.local ]
+if [ -e ./bin/run-jetpack-command.sh.local ]
 then
-  source ./bin/install-jetpack.sh.local
+  source ./bin/run-jetpack-command.sh.local
   exit 0
 fi
 
@@ -32,16 +32,14 @@ pnpm_version=$(npx semver -c "$listed_pnpm_version")
 # More information in: https://github.com/wordpress-mobile/gutenberg-mobile/issues/5688
 sed -i.bak 's/^engine-strict = true/engine-strict = false/' .npmrc
 
-# Install dependecies of Jetpack plugin
-pushd projects/plugins/jetpack
-
 # npx might prompt to install pnpm at the requested version. Let's just agree and carry on.
-( yes || true ) | npx --cache /tmp/empty-cache pnpm@"$pnpm_version" install --ignore-scripts
-
-popd
+( yes || true ) | npx --cache /tmp/empty-cache pnpm@"$pnpm_version" $1
 
 # Revert `engine-strict` parameter back
 sed -i.bak 's/^engine-strict = false/engine-strict = true/' .npmrc
 rm .npmrc.bak
 
 popd
+
+# Revert to Gutenberg node version
+nvm use

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 		"wd": "^1.11.1"
 	},
 	"scripts": {
-		"postinstall": "patch-package && npm run clean:gutenberg:distclean && npm ci --prefix gutenberg && npm run i18n:check-cache && ./bin/install-jetpack.sh",
+		"postinstall": "patch-package && npm run clean:gutenberg:distclean && npm ci --prefix gutenberg && npm run i18n:check-cache && ./bin/run-jetpack-command.sh \"install --ignore-scripts\"",
 		"start": "echo \"\\x1b[33mThe start command is not available in this project. It is strongly recommended to use \\x1b[1:33mstart:reset\\x1b[0m\\x1b[33m to perform some cleanup when starting the metro bundler.\nOr you may use \\x1b[1:33mstart:quick\\x1b[0m\\x1b[33m for a quicker startup, but this may lead to unexpected javascript errors when running the app.\\x1b[0m\"",
 		"start:reset": "npm run core clean:runtime && npm run start:quick -- --reset-cache",
 		"start:quick": "react-native start --config ./metro.config.js",


### PR DESCRIPTION
The idea behind adding this script is to allow running any command in the Jetpack repo. Currently, we only run `install` command to install the dependencies. In the next PR, to solve [the issue mentioned here](https://github.com/wordpress-mobile/gutenberg-mobile/pull/5665#discussion_r1165464769), we'll run the script to build the VideoPress package.

**To test:**
1. Run `npm i`.
2. Observe that the command finish successfully.
3. Observe that the node version is the same before and after running the command.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
