### PR TITLE
[Translation pipeline] Build VideoPress package to extract localization strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ These files are generated via the `i18n:update` NPM command, and like translatio
 }
 ```
 
-7. Add the i18n domain of the plugin and the callback for getting translation to the [editor initialization](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/src/index.js).
+6. Add the i18n domain of the plugin and the callback for getting translation to the [editor initialization](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/src/index.js).
 *Example:*
 ```
 import { getTranslation as getJetpackTranslation } from './i18n-translations/jetpack';
@@ -234,7 +234,7 @@ const pluginTranslations = [
 ];
 ```
 
-8. (Optional) In some cases, it's needed to build the source code in order to extract the used strings. Consider adding a command in [`bin/i18n-update.sh`](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/bin/i18n-update.sh) file for this purpose (e.g. `./bin/run-jetpack-command.sh "-C projects/packages/videopress build"` to build VideoPress package)
+7. (Optional) In some cases, it's needed to build the source code in order to extract the used strings. Consider adding a command in [`bin/i18n-update.sh`](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/bin/i18n-update.sh) file for this purpose (e.g. `./bin/run-jetpack-command.sh "-C projects/packages/videopress build"` to build VideoPress package)
 
 ### Caveats
 - Strings that are only used in the native version, and reference a [context](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#disambiguation-by-context), won't be included in the localization strings files hence, they won't be translated. This is a limitation in the format of the localization strings files.

--- a/README.md
+++ b/README.md
@@ -203,10 +203,24 @@ These files are generated via the `i18n:update` NPM command, and like translatio
 
 ### How to add a new plugin
 1. Identify the i18n domain, which usually matches the plugin's name (i.e. `jetpack`).
-2. Identify the path to the plugin source code (i.e. `./jetpack/projects/plugins/jetpack/extensions`).
-3. Append the plugin's name to the arguments of `i18n:check-cache` NPM command.
-4. Append the plugin's name and source code path to the arguments of `i18n:update` NPM command.
-5. Add the i18n domain of the plugin and the callback for getting translation to the [editor initialization](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/src/index.js).
+2. Identify the GlotPress project slug (i.e. `wp-plugins/jetpack` for URL `https://translate.wordpress.org/projects/wp-plugins/jetpack/`)
+3. Identify the path to the plugin's source code (i.e. `./jetpack/projects/plugins/jetpack/extensions`).
+4. Append the plugin's name, GlotPress project slug, and plugin's source code to the arguments of `i18n:update` NPM command.
+5. Append the plugin's name, GlotPress project slug, and plugin's source code to the arguments of `i18n:update:test` NPM command.
+6. Append the plugin's name and GlotPress project slug to the arguments of `i18n:check-cache` NPM command.
+
+*Example:*
+```
+"scripts": {
+  ...
+  "i18n:check-cache": "... jetpack wp-plugins/jetpack",
+  "i18n:update": "... jetpack wp-plugins/jetpack ./jetpack/projects/plugins/jetpack/extensions",
+  "i18n:update:test": "... jetpack wp-plugins/jetpack ./jetpack/projects/plugins/jetpack/extensions",
+  ...
+}
+```
+
+7. Add the i18n domain of the plugin and the callback for getting translation to the [editor initialization](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/src/index.js).
 *Example:*
 ```
 import { getTranslation as getJetpackTranslation } from './i18n-translations/jetpack';
@@ -220,6 +234,8 @@ const pluginTranslations = [
 	...
 ];
 ```
+
+8. (Optional) In some cases, it's needed to build the source code in order to extract the used strings. Consider adding a command in [`bin/i18n-update.sh`](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/bin/i18n-update.sh) file for this purpose (e.g. `./bin/run-jetpack-command.sh "-C projects/packages/videopress build"` to build VideoPress package)
 
 ### Caveats
 - Strings that are only used in the native version, and reference a [context](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#disambiguation-by-context), won't be included in the localization strings files hence, they won't be translated. This is a limitation in the format of the localization strings files.

--- a/README.md
+++ b/README.md
@@ -205,9 +205,8 @@ These files are generated via the `i18n:update` NPM command, and like translatio
 1. Identify the i18n domain, which usually matches the plugin's name (i.e. `jetpack`).
 2. Identify the GlotPress project slug (i.e. `wp-plugins/jetpack` for URL `https://translate.wordpress.org/projects/wp-plugins/jetpack/`)
 3. Identify the path to the plugin's source code (i.e. `./jetpack/projects/plugins/jetpack/extensions`).
-4. Append the plugin's name, GlotPress project slug, and plugin's source code to the arguments of `i18n:update` NPM command.
-5. Append the plugin's name, GlotPress project slug, and plugin's source code to the arguments of `i18n:update:test` NPM command.
-6. Append the plugin's name and GlotPress project slug to the arguments of `i18n:check-cache` NPM command.
+4. Append the plugin's name, GlotPress project slug, and plugin's source code to the arguments of `i18n:update` and `i18n:update:test` NPM commands.
+5. Append the plugin's name and GlotPress project slug to the arguments of `i18n:check-cache` NPM command.
 
 *Example:*
 ```

--- a/bin/i18n-update.sh
+++ b/bin/i18n-update.sh
@@ -123,6 +123,10 @@ USED_STRINGS_PATH="$TARGET_PATH/used-strings.json"
 echo -e "\n\033[1mBuild Gutenberg packages\033[0m"
 npm run build:gutenberg
 
+# Build Jetpack plugins
+# - VideoPress package
+./bin/run-jetpack-command.sh "-C projects/packages/videopress build"
+
 # Extract used strings for plugins
 METRO_CONFIG="metro.config.js" node gutenberg/packages/react-native-editor/bin/extract-used-strings "$USED_STRINGS_PATH" "${PLUGINS[@]}"
 


### PR DESCRIPTION
**Related PR:**
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/5667

Fixes [the issue mentioned here](https://github.com/wordpress-mobile/gutenberg-mobile/pull/5665#discussion_r1165464769).

The translation pipeline needs to extract the localization strings used in the web version to identify which ones are only used in the native version. The latter is added to the localization strings files to be translated along with the rest of the strings of the host apps. For this reason, since we'll incorporate the VideoPress block, we need to build the VideoPress package.

Additionally, the section, related to adding a new i18n domain for a plugin, has been updated in the `README` to reflect the recent changes after introducing the VideoPress package.

**To test:**
1. Verify that the VideoPress package is not built by removing the folder `jetpack/projects/packages/videopress/build`.
2. Run the command `npm run bundle`.
3. Observe that no modifications are made to the localization strings files (i.e. `bundle/ios/GutenbergNativeTranslations.swift` and `bundle/android/strings.xml`).

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
