### PR TITLE
Move #35733 to unreleased in RELEASE-NOTES.txt

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,10 +1,10 @@
 Unreleased
 ---
+* [*] Allow content that is pasted into the post title to populate the post body correctly [#35733]
 
 1.93.0
 ---
 * [***] [iOS] Fixed iOS scroll jumping issue by refactoring KeyboardAwareFlatList improving writing flow and caret focus handling [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5533]
-* [*] Allow content that is pasted into the post title to populate the post body correctly [#35733]
 
 1.92.1
 ---


### PR DESCRIPTION
Fixes RELEASE-NOTES.txt to move an unreleased item from 1.93.0 to Unreleased. Apologies, I missed it in a merge. 😞 

To test: verify Unreleased and 1.93.0 sections of Release Notes.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
