### PR TITLE
Update Metro `sourceExts` config

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -8,7 +8,7 @@ const gutenbergMetroConfigCopy = {
 	...gutenbergMetroConfig,
 	resolver: {
 		...gutenbergMetroConfig.resolver,
-		sourceExts: [ 'js', 'jsx', 'json', 'scss', 'sass', 'ts', 'tsx' ],
+		sourceExts: [ 'js', 'cjs', 'jsx', 'json', 'scss', 'sass', 'ts', 'tsx' ],
 		extraNodeModules,
 	},
 };


### PR DESCRIPTION
**Related PRs:**
- https://github.com/WordPress/gutenberg/pull/49736

This PR brings changes from the referenced PR above and includes the same `cjs` addition to Metro's `sourceExts` config in Gutenberg Mobile.

To test CI checks should pass.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
