### PR TITLE
Disable `npm` configuration parameter `engine-strict` when installing dependencies of Jetpack

### DIFF
--- a/bin/install-jetpack.sh
+++ b/bin/install-jetpack.sh
@@ -25,9 +25,23 @@ nvm install
 listed_pnpm_version=$(npx -c 'echo $npm_package_engines_pnpm')
 pnpm_version=$(npx semver -c "$listed_pnpm_version")
 
-cd projects/plugins/jetpack
+# Disable `engine-strict` parameter
+#
+# The `node` version required by Jetpack will be used to install the dependencies. However, we can't
+# ensure that the `node` version used by `npm` to check the `engines` parameter is the expected one.
+# More information in: https://github.com/wordpress-mobile/gutenberg-mobile/issues/5688
+sed -i.bak 's/^engine-strict = true/engine-strict = false/' .npmrc
+
+# Install dependecies of Jetpack plugin
+pushd projects/plugins/jetpack
 
 # npx might prompt to install pnpm at the requested version. Let's just agree and carry on.
 ( yes || true ) | npx --cache /tmp/empty-cache pnpm@"$pnpm_version" install --ignore-scripts
+
+popd
+
+# Revert `engine-strict` parameter back
+sed -i.bak 's/^engine-strict = false/engine-strict = true/' .npmrc
+rm .npmrc.bak
 
 popd


### PR DESCRIPTION
This PR disables the `engine-strict` parameter in Jetpack's `.npmrc` file as we can't ensure that the `node` version used by `npm` to check the `engines` parameter is the expected one. The parameter is reverted back after installing the dependencies.

**NOTE:** This change is a temporary workaround until we find a better solution to https://github.com/wordpress-mobile/gutenberg-mobile/issues/5688.

**To test:**
1. Checkout the last commit from `trunk` branch of the Jetpack repository.
2. Run command `npm install`.
3. Observe that the command succeds.

Additionally, the fix has been also applied to https://github.com/wordpress-mobile/gutenberg-mobile/pull/5687 in order to check that CI jobs succeed 🟢 .

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
