### PR TITLE
Enable initial VideoPress test on iOS

### DIFF
--- a/src/test/videopress/edit.js
+++ b/src/test/videopress/edit.js
@@ -10,19 +10,12 @@ import {
 } from 'test/helpers';
 
 /**
- * WordPress dependencies
- */
-import { Platform } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
 import {
 	registerJetpackBlocks,
 	setupJetpackEditor,
 } from '../../jetpack-editor-setup';
-
-const onlyOnAndroid = Platform.select( { android: it, ios: it.skip } );
 
 const defaultProps = {
 	capabilities: {
@@ -39,20 +32,17 @@ beforeAll( () => {
 } );
 
 describe( 'VideoPress block', () => {
-	onlyOnAndroid(
-		'should successfully insert the VideoPress block into the editor',
-		async () => {
-			const screen = await initializeEditor();
+	it( 'should successfully insert the VideoPress block into the editor', async () => {
+		const screen = await initializeEditor();
 
-			// Add block
-			await addBlock( screen, 'VideoPress' );
+		// Add block
+		await addBlock( screen, 'VideoPress' );
 
-			// Get block
-			const videoPressBlock = await getBlock( screen, 'VideoPress' );
-			expect( videoPressBlock ).toBeVisible();
+		// Get block
+		const videoPressBlock = await getBlock( screen, 'VideoPress' );
+		expect( videoPressBlock ).toBeVisible();
 
-			const expectedHtml = `<!-- wp:videopress/video /-->`;
-			expect( getEditorHtml() ).toBe( expectedHtml );
-		}
-	);
+		const expectedHtml = `<!-- wp:videopress/video /-->`;
+		expect( getEditorHtml() ).toBe( expectedHtml );
+	} );
 } );


### PR DESCRIPTION
In https://github.com/wordpress-mobile/gutenberg-mobile/pull/5715, an initial test was introduced for the VideoPress block, with the test checking that the block can be successfully added to the editor on Android. 

It wasn't initially possible to run that test against iOS due to an error with [the `addBlock` helper](https://github.com/WordPress/gutenberg/blob/trunk/test/native/integration-test-helpers/add-block.js). However this error has been fixed as of https://github.com/WordPress/gutenberg/pull/50381.

With this PR, the initial VideoPress test has therefore been updated to run with both platforms. The following changes have been made:

* https://github.com/wordpress-mobile/gutenberg-mobile/pull/5733/commits/b58273b94bf94afb14919a3c50cb79f5942e83c0: Platform-specific conditionals have been removed to ensure the tests run for both platforms. 
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/5733/commits/bd3b29790606bcff4607e437e6ba81bad0cecae0: The Gutenberg reference has been updated to https://github.com/WordPress/gutenberg/commit/599981f395fbfd04cdc12e81092b7db49fe67a07 in order to pull in the iOS fix.

**To test:**

* Run `TEST_RN_PLATFORM=ios npm run test src/test/videopress/edit.js` in the terminal to confirm the test passes with this PR's branch checked out.
* Verify the test on the PR itself pass as expected.

<hr />

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
