### PR TITLE
Enable VideoPress on Android

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,5 @@
 Unreleased
+* [***] Enable VideoPress block on Android (Simple WPCOM sites) [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5761]
 * [**] Add fullscreen embed preview to Android [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5743]
 
 1.94.0

--- a/src/jetpack-editor-setup.js
+++ b/src/jetpack-editor-setup.js
@@ -5,7 +5,6 @@ import { dispatch, select } from '@wordpress/data';
 import { store as editPostStore } from '@wordpress/edit-post';
 import { addAction, addFilter } from '@wordpress/hooks';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { Platform } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -32,7 +31,7 @@ const supportedJetpackBlocks = {
 		available: __DEV__,
 	},
 	'videopress/video': {
-		available: Platform.select( { android: __DEV__, ios: true } ),
+		available: true,
 	},
 };
 


### PR DESCRIPTION
Enables VideoPress block on Android

To test:
- Verify that the setting is correct.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
