### PR TITLE
Update VideoPress block support from dev-only to iOS-only

### DIFF
--- a/src/block-support/supported-blocks.json
+++ b/src/block-support/supported-blocks.json
@@ -34,7 +34,7 @@
 		"jetpack/phone",
 		"jetpack/address"
 	],
-	"devOnly": [ "core/code", "jetpack/tiled-gallery", "videopress/video" ],
-	"iOSOnly": [],
+	"devOnly": [ "core/code", "jetpack/tiled-gallery" ],
+	"iOSOnly": [ "videopress/video" ],
 	"androidOnly": []
 }


### PR DESCRIPTION
Now that the VideoPress block has been released on iOS, we should update the Supported block list.

**To test:**
N/A

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
