### PR TITLE
ci: Remove WordPress-Android sync tag trigger

### DIFF
--- a/.github/workflows/sync-android.yml
+++ b/.github/workflows/sync-android.yml
@@ -16,10 +16,3 @@ jobs:
         run: |
           npm run sync:android -- "--pr=$PR"
         if: ${{ github.event_name == 'pull_request' && github.event.label.name == 'sync:android' }}
-      - name: Create a WordPress-Android (WPA) PR containing changes from a Gutenberg Mobile (GBM) Tag.
-        env:
-          TAG: ${{ github.event.release.tag_name }}
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
-        run: |
-          npm run sync:android -- "--tag=$TAG"
-        if: ${{ github.event_name == 'release' }}


### PR DESCRIPTION
## What?
Prevent duplicative integration PRs for the `WordPress-Android` repository.

## Why?
Relates to p9ugOq-3BX-p2.

The original intent of this CI tasks was to negate the need to manually
create integration PRs for tagged gutenberg-mobile releases. However,
the team never finished integrating this CI task into the existing
release process. Having not finished this work, duplicative integration
PRs are created whenever a team member runs the preexisting,
long-standing release script. Removing this script prevents duplicative
integration PRs from occurring.

As an example, here are duplicative PRs:

Release Script: https://github.com/wordpress-mobile/WordPress-Android/pull/15940
GitHub Action: https://github.com/wordpress-mobile/WordPress-Android/pull/15948

There are additional efforts to automate the release/integration
process; any additional work should take into consideration that effort
to avoid conflicting or duplicative outcomes.

p9ugOq-3hT-p2#comment-6515

Additionally, the token for this task has also expired, which means the
CI tasks never succeeds. Creating a new token is a separate task worth
doing so that the label-driven trigger — which is still in place and
triggered by a "sync:android" label — may still succeed whenever it is
used.

## How?
Remove the tag trigger for the `sync-android` GitHub Action.

To test: n/a

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
