### PR TITLE
Update XCFramework `Podfile.lock` after 1.95.0 release

### DIFF
--- a/ios-xcframework/Podfile.lock
+++ b/ios-xcframework/Podfile.lock
@@ -386,7 +386,7 @@ PODS:
     - React-Core
   - RNSVG (9.13.6):
     - React-Core
-  - RNTAztecView (1.94.0):
+  - RNTAztecView (1.95.0):
     - React-Core
     - WordPress-Aztec-iOS (~> 1.19.8)
   - SDWebImage (5.11.1):
@@ -601,7 +601,7 @@ SPEC CHECKSUMS:
   RNReanimated: 8abe8173f54110a9ae98a629d0d8bf343a84f739
   RNScreens: bd1f43d7dfcd435bc11d4ee5c60086717c45a113
   RNSVG: 259ef12cbec2591a45fc7c5f09d7aa09e6692533
-  RNTAztecView: 80480c43423929f7e3b7012670787e7375fbac9c
+  RNTAztecView: 205677f39556c17c3ff8cc1aa76e91d62f9fd1b3
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504


### PR DESCRIPTION
Whenever the package version changes, we need to run `bundle exec pod install` in the XCFramework scaffold project. I'll update the release script accordingly (or find some automation for it). This PR fixes the current CI failure because of that version discrepancy.

<img width="1209" alt="image" src="https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/e82cd10b-d1f6-46d0-acfd-6e9ba301a55a">

To test: If CI is green, we're good.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
