### PR TITLE
Build both Android and iOS bundles in Buildkite CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -74,4 +74,4 @@ steps:
     agents:
       queue: mac
     env:
-      IMAGE_ID: xcode-14.2
+      IMAGE_ID: xcode-14.3

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,8 +13,8 @@ steps:
   - block: "Request trigger Android bundle and builds"
     branches: "dependabot/submodules/*"
 
-  - label: "Bundle Android"
-    key: "bundle-android"
+  - label: "Build JS Bundles"
+    key: "js-bundles"
     plugins:
       - docker#v3.8.0:
           image: "public.ecr.aws/automattic/gb-mobile-image:latest"
@@ -34,6 +34,8 @@ steps:
 
         buildkite-agent artifact upload bundle/android/App.js
 
+        npm run bundle:ios
+        buildkite-agent artifact upload bundle/ios/App.js
   - label: "Build Android RN Aztec & Publish to S3"
     key: "publish-react-native-aztec-android"
     plugins:
@@ -43,7 +45,7 @@ steps:
 
   - label: "Build Android RN Bridge & Publish to S3"
     depends_on:
-      - "bundle-android"
+      - "js-bundles"
       - "publish-react-native-aztec-android"
     plugins:
       - *publish-android-artifacts-docker-container
@@ -51,6 +53,7 @@ steps:
         .buildkite/publish-react-native-bridge-android-artifacts.sh
 
   - label: Build iOS RN XCFramework
+    depends_on: js-bundles
     command: .buildkite/publish-react-native-ios-artifacts.sh
     artifact_paths:
       - ios-xcframework/build/xcframeworks/*.zip

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,15 +26,25 @@ steps:
     command: |
         source /root/.bashrc
 
+        echo "--- :node: Setup Node environment"
         nvm install && nvm use
+
+        echo "--- :npm: Install Node dependencies"
         npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 
+        echo "--- :package: Run bundle prep work"
         npm run prebundle:js
+
+        echo "--- :android: Build Android bundle"
         npm run bundle:android
 
+        echo "--- :arrow_up: Upload Android bundle artifact"
         buildkite-agent artifact upload bundle/android/App.js
 
+        echo "--- :ios: Build iOS bundle"
         npm run bundle:ios
+
+        echo "--- :arrow_up: Upload iOS bundle artifact"
         buildkite-agent artifact upload bundle/ios/App.js
   - label: "Build Android RN Aztec & Publish to S3"
     key: "publish-react-native-aztec-android"

--- a/.buildkite/publish-react-native-ios-artifacts.sh
+++ b/.buildkite/publish-react-native-ios-artifacts.sh
@@ -1,8 +1,12 @@
 #!/bin/bash -eu
 
-cd ./ios-xcframework
+
+echo "--- :arrow_down: Download iOS JS bundle"
+buildkite-agent artifact download bundle/ios/App.js .
 
 echo "--- :rubygems: Setting up Gems"
+cd ./ios-xcframework
+
 install_gems
 
 echo "--- :cocoapods: Setting up Pods"

--- a/.buildkite/publish-react-native-ios-artifacts.sh
+++ b/.buildkite/publish-react-native-ios-artifacts.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -eu
 
-
 echo "--- :arrow_down: Download iOS JS bundle"
 buildkite-agent artifact download bundle/ios/App.js .
 
@@ -13,8 +12,7 @@ echo "--- :cocoapods: Setting up Pods"
 install_cocoapods
 
 echo "--- 🚧 Install xcbeautify formatter while not on the VM image"
-# The env vars should make Homebrew run faster
-HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 brew install xcbeautify
+brew install xcbeautify
 
 echo "--- :xcode: Build XCFramework"
 ./build.sh


### PR DESCRIPTION
Building the iOS JS bundle achieves two goals:

- Allows the step that builds the XCFramework to add the bundle as a resource without spending time setting up all the node stack. This is efficient because we make use of the work that has already run for the Android bundle
- Brings us one step closer to being able to run all our CI tasks in Buildkite over Circle CI

_These were originally part of #5769 but I keep running into last mile issues to the get generated and downloaded XCFramework to work, so I thought I'd track these orthogonal changes in a dedicated PR._

To test: Verify build was successful in Buildkite

<img width="1163" alt="image" src="https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/27556747-fee5-4e7c-8e5b-427e9724579d">

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
