### PR TITLE
Exclude `ios-xcframework` folder when resolving modules in Metro

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -21,6 +21,9 @@ const nodeModulePaths = [
 const possibleModulePaths = ( name ) =>
 	nodeModulePaths.map( ( dir ) => path.join( process.cwd(), dir, name ) );
 
+// Exclude `ios-xcframework` folder to avoid conflicts with packages contained in Pods.
+gutenbergMetroConfigCopy.resolver.blockList = [ /ios-xcframework\/.*/ ];
+
 gutenbergMetroConfigCopy.resolver.resolveRequest = (
 	context,
 	moduleName,


### PR DESCRIPTION
Fixes the issue mentioned in https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/pull/116#issuecomment-1568837301.

We need to exclude the `ios-xcframework` folder in Metro configuration to avoid conflicts when resolving modules. Specifically due to the potential presence of `package.json` files in Pods.

**To test:**
The issue this PR aims to fix can only be reproduced when installing the Pods of `ios-xcframework`.

1. Run the command: `cd ios-xcframework && bundle install && bundle exec pod install && cd ..`.
2. Wait until all Pods are installed.
3. Run the command: `npm run bundle:android`.
4. Observe that the bundle is generated properly.

**NOTE:** The issue could be also reproduced by connecting the Metro server to the app.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
