### PR TITLE
Ensure `bundle:js` command is not executed if `clean` fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"i18n:check-cache": "./bin/i18n-check-cache.sh jetpack wp-plugins/jetpack layout-grid wp-plugins/layout-grid jetpack-videopress-pkg wp-plugins/jetpack",
 		"i18n:update": "./bin/i18n-update.sh jetpack wp-plugins/jetpack ./jetpack/projects/plugins/jetpack/extensions layout-grid wp-plugins/layout-grid ./block-experiments/blocks/layout-grid jetpack-videopress-pkg wp-plugins/jetpack ./jetpack/projects/packages/videopress",
 		"i18n:update:test": "./bin/i18n-update.sh --path i18n-test jetpack wp-plugins/jetpack ./jetpack/projects/plugins/jetpack/extensions layout-grid wp-plugins/layout-grid ./block-experiments/blocks/layout-grid jetpack-videopress-pkg wp-plugins/jetpack ./jetpack/projects/packages/videopress",
-		"bundle": "npm run clean; npm run bundle:js",
+		"bundle": "npm run clean && npm run bundle:js",
 		"prebundle:js": "npm run i18n:update",
 		"bundle:js": "npm run bundle:android && npm run bundle:ios",
 		"bundle:android": "npm run bundle:android:text && npm run bundle:android:bytecode",


### PR DESCRIPTION
Following the changes from https://github.com/WordPress/gutenberg/pull/51103, I realized that if for any reason (like a translations download failure) the `clean` command fails the bundle is still generated. We should ensure that the project is in a clean slate before generating the bundle, so I'd suggest aborting `bundle:js` command if `clean` fails.

**To test:**
1. This can be tested by introducing an error in the `clean` npm command:
```patch
diff --git forkSrcPrefix/package.json forkDstPrefix/package.json
index 8e444e9dd3172fa1bf0549de3be8c7da09019c6c..116924d8c4f08d9ac9286d744c6a72003bd7c88a 100644
--- forkSrcPrefix/package.json
+++ forkDstPrefix/package.json
@@ -94,7 +94,7 @@
 		"test:e2e:ios:local": "npm run test:e2e:bundle:ios && npm run core test:e2e:build-app:ios && npm run core test:e2e:build-wda && TEST_RN_PLATFORM=ios npm run device-tests:local",
 		"sync:android": "bin/sync-android.sh",
 		"build:gutenberg": "cd gutenberg && npm run build",
-		"clean": "npm run core clean; npm run clean:gutenberg; npm run clean:i18n",
+		"clean": "exit 1; npm run core clean; npm run clean:gutenberg; npm run clean:i18n",
 		"clean:gutenberg": "cd gutenberg && npm run clean:packages",
 		"clean:gutenberg:distclean": "cd gutenberg && npm run distclean",
 		"clean:i18n": "rm -rf src/i18n-cache && npm run i18n:check-cache",
```
2. Run the command `npm run bundle`.
3. Observe that the command is aborted and that the bundle is not generated.
4. Remove the above patch and run `npm run bundle` again.
5. Observe that the bundle is generated successfully.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
