### PR TITLE
Add set caption integration test of VideoPress block

### DIFF
--- a/src/test/videopress/__snapshots__/edit.js.snap
+++ b/src/test/videopress/__snapshots__/edit.js.snap
@@ -35,3 +35,5 @@ exports[`Update VideoPress block's settings should update Privacy and Rating sec
 exports[`Update VideoPress block's settings should update description 1`] = `"<!-- wp:videopress/video {"title":"default-title-is-file-name","description":"The video's new description!","useAverageColor":false,"id":1,"guid":"AbCdEfGh","privacySetting":2,"allowDownload":false,"rating":"G","isPrivate":true,"duration":2803} /-->"`;
 
 exports[`Update VideoPress block's settings should update title 1`] = `"<!-- wp:videopress/video {"title":"Hello world!","description":"","useAverageColor":false,"id":1,"guid":"AbCdEfGh","privacySetting":2,"allowDownload":false,"rating":"G","isPrivate":true,"duration":2803} /-->"`;
+
+exports[`VideoPress block sets caption 1`] = `"<!-- wp:videopress/video {"title":"default-title-is-file-name","description":"","caption":"\\u003cstrong\\u003eBold\\u003c/strong\\u003e \\u003cem\\u003eitalic\\u003c/em\\u003e \\u003cs\\u003estrikethrough\\u003c/s\\u003e VideoPress caption","useAverageColor":false,"id":1,"guid":"AbCdEfGh","privacySetting":2,"allowDownload":false,"rating":"G","isPrivate":true,"duration":2803} /-->"`;

--- a/src/test/videopress/edit.js
+++ b/src/test/videopress/edit.js
@@ -11,6 +11,8 @@ import {
 	changeTextOfTextInput,
 	withFakeTimers,
 	act,
+	within,
+	typeInRichText,
 } from 'test/helpers';
 
 /**
@@ -61,6 +63,29 @@ describe( 'VideoPress block', () => {
 
 		const expectedHtml = `<!-- wp:videopress/video /-->`;
 		expect( getEditorHtml() ).toBe( expectedHtml );
+	} );
+
+	it( 'sets caption', async () => {
+		const screen = await initializeEditor( {
+			initialHtml: VIDEOPRESS_BLOCK_HTML,
+		} );
+		const { getByLabelText } = screen;
+
+		// Select block
+		const videoPressBlock = await getBlock( screen, 'VideoPress' );
+		expect( videoPressBlock ).toBeVisible();
+		fireEvent.press( videoPressBlock );
+
+		// Set caption
+		const captionField = within(
+			getByLabelText( /Video caption. Empty/ )
+		).getByPlaceholderText( 'Add caption' );
+		typeInRichText(
+			captionField,
+			'<strong>Bold</strong> <em>italic</em> <s>strikethrough</s> VideoPress caption'
+		);
+
+		expect( getEditorHtml() ).toMatchSnapshot();
 	} );
 } );
 


### PR DESCRIPTION
Related to https://github.com/wordpress-mobile/gutenberg-mobile/issues/5734.

**To test:**

1. Run the command: npm run test and observe that all tests pass.
2. Check that all CI jobs succeed.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
