### PR TITLE
Remove cleaning Gutenberg npm packages

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -46,6 +46,7 @@ module.exports = {
 		'./gutenberg/node_modules',
 	],
 	moduleNameMapper: {
+		'^react$': '<rootDir>/gutenberg/node_modules/react',
 		// Mock the CSS modules. See https://facebook.github.io/jest/docs/en/webpack.html#handling-static-assets
 		'\\.(scss)$': '<rootDir>/' + configPath + '/__mocks__/styleMock.js',
 		'\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':

--- a/metro.config.js
+++ b/metro.config.js
@@ -29,6 +29,15 @@ gutenbergMetroConfigCopy.resolver.resolveRequest = (
 	moduleName,
 	platform
 ) => {
+	// Due to multiple React versions available in the project we force it to use the main one.
+	if ( moduleName === 'react' ) {
+		return metroResolver.resolve(
+			context,
+			path.join( __dirname, '/gutenberg/node_modules', moduleName ),
+			platform
+		);
+	}
+
 	// Add the module to the extra node modules object if the module is not on a local path.
 	if ( ! ( moduleName.startsWith( '.' ) || moduleName.startsWith( '/' ) ) ) {
 		const [ namespace, module = '' ] = moduleName.split( '/' );

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 		"wd": "^1.11.1"
 	},
 	"scripts": {
-		"postinstall": "patch-package && npm run clean:gutenberg:distclean && npm ci --prefix gutenberg && npm run i18n:check-cache && ./bin/run-jetpack-command.sh \"install --ignore-scripts\"",
+		"postinstall": "patch-package && npm ci --prefix gutenberg && npm run i18n:check-cache && ./bin/run-jetpack-command.sh \"install --ignore-scripts\"",
 		"start": "echo \"\\x1b[33mThe start command is not available in this project. It is strongly recommended to use \\x1b[1:33mstart:reset\\x1b[0m\\x1b[33m to perform some cleanup when starting the metro bundler.\nOr you may use \\x1b[1:33mstart:quick\\x1b[0m\\x1b[33m for a quicker startup, but this may lead to unexpected javascript errors when running the app.\\x1b[0m\"",
 		"start:reset": "npm run core clean:runtime && npm run start:quick -- --reset-cache",
 		"start:quick": "react-native start --config ./metro.config.js",


### PR DESCRIPTION
This is a follow-up of https://github.com/wordpress-mobile/gutenberg-mobile/pull/5193/files#r989884424

To test:

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
