### PR TITLE
Update pods for the xcframework

### DIFF
--- a/ios-xcframework/Podfile.lock
+++ b/ios-xcframework/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.76.0)
-  - BVLinearGradient (2.5.6-wp-3):
+  - BVLinearGradient (2.5.6-wp-4):
     - React-Core
   - DoubleConversion (1.1.5)
   - FBLazyVector (0.69.4)
@@ -239,14 +239,14 @@ PODS:
     - React-Core
   - react-native-safe-area-context (3.2.0):
     - React-Core
-  - react-native-slider (3.0.2-wp-3):
+  - react-native-slider (3.0.2-wp-4):
     - React-Core
-  - react-native-video (5.2.0-wp-5):
+  - react-native-video (5.2.0-wp-6):
     - React-Core
-    - react-native-video/Video (= 5.2.0-wp-5)
-  - react-native-video/Video (5.2.0-wp-5):
+    - react-native-video/Video (= 5.2.0-wp-6)
+  - react-native-video/Video (5.2.0-wp-6):
     - React-Core
-  - react-native-webview (11.6.2):
+  - react-native-webview (11.26.1):
     - React-Core
   - React-perflogger (0.69.4)
   - React-RCTActionSheet (0.69.4):
@@ -353,9 +353,9 @@ PODS:
     - React-Core
     - SDWebImage (~> 5.11.1)
     - SDWebImageWebPCoder (~> 0.8.4)
-  - RNGestureHandler (2.3.2-wp-2):
+  - RNGestureHandler (2.3.2-wp-3):
     - React-Core
-  - RNReanimated (2.9.1-wp-3):
+  - RNReanimated (2.9.1-wp-4):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -554,10 +554,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 32a63928ef0a5bf8b60f6b930c8864113fa28779
-  BVLinearGradient: 708898fab8f7113d927b0ef611a321e759f6ad3e
+  BVLinearGradient: 9168d5f3bdb636b9bd861bf9fbe747f77e835065
   DoubleConversion: e22e0762848812a87afd67ffda3998d9ef29170c
   FBLazyVector: 16fdf30fcbc7177c6a4bdf35ef47225577eb9636
-  FBReactNativeSpec: 2ffeca5f498ddc94234d823f38abf51ce0313171
+  FBReactNativeSpec: 03365206a695e76184146098efecb19a07f98ffc
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 741689bdd65551bc8fb59d633e55c34293030d3e
   libwebp: f62cb61d0a484ba548448a4bd52aabf150ff6eef
@@ -579,9 +579,9 @@ SPEC CHECKSUMS:
   react-native-get-random-values: 2869478c635a6e33080b917ce33f2803cb69262c
   react-native-safe-area: e3de9e959c7baaae8db9bcb015d99ed1da25c9d5
   react-native-safe-area-context: 1e501ec30c260422def56e95e11edb103caa5bf2
-  react-native-slider: f1ea4381d6d43ef5b945b5b101e9c66d249630a6
-  react-native-video: 7b1832a8dcea07303f5e696b639354ea599931ff
-  react-native-webview: fca2337b045c6554b4209ab5073e922fabac8e17
+  react-native-slider: fe24b59d1cdf9ce3adc7dc53f87cfdde8da9498a
+  react-native-video: acfe36130a7476cf82eb543c7ee2b9e96794ff9e
+  react-native-webview: 07834cb4097a1c1785ac8ac13126fa03b24ae81c
   React-perflogger: 685c7bd5da242acbe09ae37488dd81c7d41afbb4
   React-RCTActionSheet: 6c194ed0520d57075d03f3daf58ad025b1fb98a2
   React-RCTAnimation: 2c9468ff7d0116801a994f445108f4be4f41f9df
@@ -597,8 +597,8 @@ SPEC CHECKSUMS:
   RNCClipboard: e2298216e12d730c3c2eb9484095e1f2e1679cce
   RNCMaskedView: b467479e450f13e5dcee04423fefd2534f08c3eb
   RNFastImage: 9407b5abc43452149a2f628107c64a7d11aa2948
-  RNGestureHandler: f1645f845fc899a01cd7f87edf634b670de91b07
-  RNReanimated: 8abe8173f54110a9ae98a629d0d8bf343a84f739
+  RNGestureHandler: 21b4ecf88948a85c163977823a7429e81c7e06a6
+  RNReanimated: b5730b32243a35f955202d807ecb43755133ac62
   RNScreens: bd1f43d7dfcd435bc11d4ee5c60086717c45a113
   RNSVG: 259ef12cbec2591a45fc7c5f09d7aa09e6692533
   RNTAztecView: cd31152d7c144a834b2103a9b5d6cba5b442fb76


### PR DESCRIPTION
Fixes #
There are some dependency issues with the Pod in the ios-xcFramework directory. This will block releases due to this step in the release script https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/blob/trunk/release_automation.sh#L235

To test:

I'm not sure how to fully verify the impact of the pod updates but running 
`bundle install && bundle exec pod installl` in the `./ios-xcFramework` directory should succeed

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
