### PR TITLE
Upload a dedicated XCFramework podspec for tags

### DIFF
--- a/ios-xcframework/fastlane/Fastfile
+++ b/ios-xcframework/fastlane/Fastfile
@@ -35,13 +35,15 @@ lane :upload_xcframework_to_s3 do |options|
 
   next if tag.nil? || tag.empty?
 
-  # Upload a dedicated podspec identified by the tag but pointing to the archive made for the commit, to avoid storing a duplicate archive for the tag.
-  upload_podspec_to_s3(archive_id: last_git_commit[:commit_hash], url_id: tag)
+  # Tradeoff: We are "wasting" space on S3 by uploading the same archive under different name.
+  # What we get in return is a 1-1 correspondency between archive and podspec, which keeps the setup simpler.
+  upload_to_a8c_s3(file: xcframework_archive_path, name_on_s3: tag)
+  upload_podspec_to_s3(archive_id: tag)
 end
 
 # rubocop:disable Metrics/AbcSize
 # rubocop:disable Metrics/MethodLength
-def upload_podspec_to_s3(archive_id:, url_id: nil)
+def upload_podspec_to_s3(archive_id:)
   xcconfig = Xcodeproj::Config.new(
     File.join(XCFRAMEWORK_PROJECT_ROOT_FOLDER, 'Config', 'Gutenberg-Shared.xcconfig')
   ).to_hash
@@ -60,19 +62,18 @@ def upload_podspec_to_s3(archive_id:, url_id: nil)
 
   podspec_erb = ERB.new(File.read(File.join(XCFRAMEWORK_PROJECT_ROOT_FOLDER, 'podspec.erb')))
 
-  s3_id = url_id.nil? ? archive_id : url_id
-
   Dir.mktmpdir do |tmp_dir|
     podspec_path = File.join(tmp_dir, 'podspec')
     File.write(podspec_path, podspec_erb.result(context))
-    upload_to_a8c_s3(file: podspec_path, name_on_s3: "Gutenberg-#{s3_id}.podspec")
+    upload_to_a8c_s3(file: podspec_path, name_on_s3: "Gutenberg-#{archive_id}.podspec")
   end
 end
 # rubocop:enable Metrics/AbcSize
 # rubocop:enable Metrics/MethodLength
 
 # Notice skip_if_exists is true by default.
-# CI might run on the same commit twice, once for the commit and once for the tag, and we don't want to fail the build on the second run.
+# CI might run on the same commit twice, once for the commit and once for the tag.
+# We don't want to fail on the second run.
 def upload_to_a8c_s3(file:, name_on_s3:, prefix: 'gutenberg-mobile', skip_if_exists: true)
   upload_to_s3(
     bucket: 'a8c-apps-public-artifacts',

--- a/ios-xcframework/fastlane/Fastfile
+++ b/ios-xcframework/fastlane/Fastfile
@@ -12,22 +12,14 @@ before_all do
   check_for_toolkit_updates unless is_ci || ENV['FASTLANE_SKIP_TOOLKIT_UPDATE_CHECK']
 end
 
-lane :upload_xcframework_to_s3 do |options|
+lane :upload_xcframework_to_s3 do
   xcframework_archive_path = File.join(XCFRAMEWORK_PROJECT_ROOT_FOLDER, "build/xcframeworks/Gutenberg.#{XCFRAMEWORK_ARCHIVE_TYPE}")
 
   unless File.exist? xcframework_archive_path
     UI.user_error! "Could not find XCFramework archive to upload at #{xcframework_archive_path}"
   end
 
-  name = options.fetch(:name, nil)
-
-  if name.nil?
-    name = archive_name(id: last_git_commit[:commit_hash])
-    UI.message "No name provided, will default to #{name}"
-  end
-
-  upload_to_a8c_s3(file: xcframework_archive_path, name_on_s3: name)
-  upload_podspec_to_s3(archive_id: last_git_commit[:commit_hash])
+  upload_xcframework_files_to_s3(archive_path: xcframework_archive_path, id: last_git_commit[:commit_hash])
 
   next unless is_ci
 
@@ -37,8 +29,12 @@ lane :upload_xcframework_to_s3 do |options|
 
   # Tradeoff: We are "wasting" space on S3 by uploading the same archive under different name.
   # What we get in return is a 1-1 correspondency between archive and podspec, which keeps the setup simpler.
-  upload_to_a8c_s3(file: xcframework_archive_path, name_on_s3: archive_name(id: tag))
-  upload_podspec_to_s3(archive_id: tag)
+  upload_xcframework_files_to_s3(archive_path: xcframework_archive_path, id: tag)
+end
+
+def upload_xcframework_files_to_s3(archive_path:, id:)
+  upload_to_a8c_s3(file: archive_path, name_on_s3: archive_name(id: id))
+  upload_podspec_to_s3(archive_id: id)
 end
 
 # rubocop:disable Metrics/AbcSize

--- a/ios-xcframework/fastlane/Fastfile
+++ b/ios-xcframework/fastlane/Fastfile
@@ -33,7 +33,7 @@ lane :upload_xcframework_to_s3 do
 end
 
 def upload_xcframework_files_to_s3(archive_path:, id:)
-  upload_to_a8c_s3(file: archive_path, name_on_s3: archive_name(id: id))
+  upload_to_a8c_s3(file: archive_path, name_on_s3: "Gutenberg-#{id}.#{XCFRAMEWORK_ARCHIVE_TYPE}")
   upload_podspec_to_s3(archive_id: id)
 end
 
@@ -78,8 +78,4 @@ def upload_to_a8c_s3(file:, name_on_s3:, prefix: 'gutenberg-mobile', skip_if_exi
     auto_prefix: false,
     skip_if_exists: skip_if_exists
   )
-end
-
-def archive_name(id:)
-  "Gutenberg-#{id}.#{XCFRAMEWORK_ARCHIVE_TYPE}"
 end

--- a/ios-xcframework/fastlane/Fastfile
+++ b/ios-xcframework/fastlane/Fastfile
@@ -5,6 +5,7 @@ require 'xcodeproj'
 default_platform :ios
 
 XCFRAMEWORK_PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
+XCFRAMEWORK_ARCHIVE_TYPE = 'tar.gz'
 
 before_all do
   # Ensure we use the latest version of the toolkit
@@ -12,8 +13,7 @@ before_all do
 end
 
 lane :upload_xcframework_to_s3 do |options|
-  archive_type = 'tar.gz'
-  xcframework_archive_path = File.join(XCFRAMEWORK_PROJECT_ROOT_FOLDER, "build/xcframeworks/Gutenberg.#{archive_type}")
+  xcframework_archive_path = File.join(XCFRAMEWORK_PROJECT_ROOT_FOLDER, "build/xcframeworks/Gutenberg.#{XCFRAMEWORK_ARCHIVE_TYPE}")
 
   unless File.exist? xcframework_archive_path
     UI.user_error! "Could not find XCFramework archive to upload at #{xcframework_archive_path}"
@@ -22,7 +22,7 @@ lane :upload_xcframework_to_s3 do |options|
   name = options.fetch(:name, nil)
 
   if name.nil?
-    name = "Gutenberg-#{last_git_commit[:commit_hash]}.#{archive_type}"
+    name = archive_name(id: last_git_commit[:commit_hash])
     UI.message "No name provided, will default to #{name}"
   end
 
@@ -37,7 +37,7 @@ lane :upload_xcframework_to_s3 do |options|
 
   # Tradeoff: We are "wasting" space on S3 by uploading the same archive under different name.
   # What we get in return is a 1-1 correspondency between archive and podspec, which keeps the setup simpler.
-  upload_to_a8c_s3(file: xcframework_archive_path, name_on_s3: tag)
+  upload_to_a8c_s3(file: xcframework_archive_path, name_on_s3: archive_name(id: tag))
   upload_podspec_to_s3(archive_id: tag)
 end
 
@@ -82,4 +82,8 @@ def upload_to_a8c_s3(file:, name_on_s3:, prefix: 'gutenberg-mobile', skip_if_exi
     auto_prefix: false,
     skip_if_exists: skip_if_exists
   )
+end
+
+def archive_name(id:)
+  "Gutenberg-#{id}.#{XCFRAMEWORK_ARCHIVE_TYPE}"
 end

--- a/ios-xcframework/fastlane/Fastfile
+++ b/ios-xcframework/fastlane/Fastfile
@@ -76,6 +76,7 @@ def upload_to_a8c_s3(file:, name_on_s3:, prefix: 'gutenberg-mobile', skip_if_exi
     key: "#{prefix}/#{name_on_s3}",
     file: file,
     auto_prefix: false,
+    # TODO: Replace with `if_exists: :replace` once the feature is implemented in https://github.com/wordpress-mobile/release-toolkit/pull/495
     skip_if_exists: skip_if_exists
   )
 end

--- a/ios-xcframework/fastlane/Fastfile
+++ b/ios-xcframework/fastlane/Fastfile
@@ -27,7 +27,7 @@ lane :upload_xcframework_to_s3 do |options|
   end
 
   upload_to_a8c_s3(file: xcframework_archive_path, name_on_s3: name)
-  upload_podspec_to_s3(id: last_git_commit[:commit_hash])
+  upload_podspec_to_s3(archive_id: last_git_commit[:commit_hash])
 
   next unless is_ci
 
@@ -35,12 +35,13 @@ lane :upload_xcframework_to_s3 do |options|
 
   next if tag.nil? || tag.empty?
 
-  upload_to_a8c_s3(file: xcframework_archive_path, name_on_s3: "Gutenberg-#{tag}.#{archive_type}")
+  # Upload a dedicated podspec identified by the tag but pointing to the archive made for the commit, to avoid storing a duplicate archive for the tag.
+  upload_podspec_to_s3(archive_id: last_git_commit[:commit_hash], url_id: tag)
 end
 
 # rubocop:disable Metrics/AbcSize
 # rubocop:disable Metrics/MethodLength
-def upload_podspec_to_s3(id:)
+def upload_podspec_to_s3(archive_id:, url_id: nil)
   xcconfig = Xcodeproj::Config.new(
     File.join(XCFRAMEWORK_PROJECT_ROOT_FOLDER, 'Config', 'Gutenberg-Shared.xcconfig')
   ).to_hash
@@ -59,10 +60,12 @@ def upload_podspec_to_s3(id:)
 
   podspec_erb = ERB.new(File.read(File.join(XCFRAMEWORK_PROJECT_ROOT_FOLDER, 'podspec.erb')))
 
+  s3_id = url_id.nil? ? archive_id : url_id
+
   Dir.mktmpdir do |tmp_dir|
     podspec_path = File.join(tmp_dir, 'podspec')
     File.write(podspec_path, podspec_erb.result(context))
-    upload_to_a8c_s3(file: podspec_path, name_on_s3: "Gutenberg-#{id}.podspec")
+    upload_to_a8c_s3(file: podspec_path, name_on_s3: "Gutenberg-#{s3_id}.podspec")
   end
 end
 # rubocop:enable Metrics/AbcSize

--- a/ios-xcframework/fastlane/Fastfile
+++ b/ios-xcframework/fastlane/Fastfile
@@ -71,7 +71,9 @@ end
 # rubocop:enable Metrics/AbcSize
 # rubocop:enable Metrics/MethodLength
 
-def upload_to_a8c_s3(file:, name_on_s3:, prefix: 'gutenberg-mobile', skip_if_exists: false)
+# Notice skip_if_exists is true by default.
+# CI might run on the same commit twice, once for the commit and once for the tag, and we don't want to fail the build on the second run.
+def upload_to_a8c_s3(file:, name_on_s3:, prefix: 'gutenberg-mobile', skip_if_exists: true)
   upload_to_s3(
     bucket: 'a8c-apps-public-artifacts',
     key: "#{prefix}/#{name_on_s3}",

--- a/ios-xcframework/podspec.erb
+++ b/ios-xcframework/podspec.erb
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.swift_version = '<%= swift_version %>'
 
   s.source = {
-    http: "https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-<%= id %>.tar.gz"
+    http: "https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-<%= archive_id %>.tar.gz"
   }
 
   s.vendored_frameworks = [


### PR DESCRIPTION
When building #5769 , I focused only on commits and didn't notice I hand't updated the automation to generate and upload a `podspec` for the tag version. This PR does that.

[CI build from the commit](https://buildkite.com/automattic/gutenberg-mobile/builds/6126#0188b381-0274-4c6c-b95a-5cf2b3040c3b):

<img width="1062" alt="image" src="https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/8bbba59d-1e31-476c-8f91-b2322c1dcd33">

[CI build from the tag](https://buildkite.com/automattic/gutenberg-mobile/builds/6128):

<img width="1092" alt="image" src="https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/41200ea6-5890-4d42-b9f7-2e35d0a98178">

## Testing

See it in action at https://github.com/wordpress-mobile/WordPress-iOS/pull/20845/commits/3ed5255584704b3b3eb030446523f06a381e5aff

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
