### PR TITLE
WIP – More CI on Buildkite

### DIFF
--- a/.buildkite/build-dependencies.sh
+++ b/.buildkite/build-dependencies.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -eu
+
+set -o pipefail
+
+# FIXME: these paths expect the script to be called from the root of the project. Make it agnostic
+source .buildkite/compute-cache-key.sh
+
+# Building the dependencies with npm ci is time consuming, even with `~/.npm` already cached in the Docker image
+# (see https://github.com/wordpress-mobile/docker-gb-mobile-image/blob/25f008b93f9fe190f76c68f3a9719b45ad99a6cc/Dockerfile#L18-L25)
+#
+# Before attempting to build, check whether we have a remote cache available.
+# We trust that the logic we have in place for caching is comprehensive and precise.
+sample_cache_item=$(jq -c '.[0]' .buildkite/caches.json)
+
+sample_folder_to_archive_basedir=$(echo "$sample_cache_item" | jq -r '.folder_to_archive_basedir')
+sample_folder_to_archive=$(echo "$sample_cache_item" | jq -r '.folder_to_archive')
+sample_key=$(compute_cache_key "$sample_folder_to_archive_basedir" "$sample_folder_to_archive")
+
+if aws s3api head-object --bucket "$CACHE_BUCKET_NAME" --key "$sample_key" > /dev/null 2>&1; then
+  echo '--- :white_check_mark: Found cached dependencies. Moving on...'
+  echo 'Dependencies for the current state of the projects packages have already been cached.'
+  echo "Cache key: $sample_key"
+  echo ''
+  echo 'Will not run npm ci.'
+else
+  echo '--- :npm: No cached dependencies found. Building them...'
+  # Build dependencies with clean install, for deterministic builds.
+	npm ci --no-audit --no-progress --unsafe-perm
+  # Upload to our cache system
+  .buildkite/upload-caches.sh
+fi

--- a/.buildkite/build-js-bundles.sh
+++ b/.buildkite/build-js-bundles.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -eu
+
+.buildkite/download-caches.sh
+
+echo '--- :package: Run bundle prep work'
+npm run prebundle:js
+
+echo '--- :android: Build Android bundle'
+npm run bundle:android
+
+echo '--- :ios: Build iOS bundle'
+npm run bundle:ios

--- a/.buildkite/caches.json
+++ b/.buildkite/caches.json
@@ -1,0 +1,50 @@
+[
+  {
+    "display_name": "npm cache",
+    "folder_to_archive": ".npm",
+    "folder_to_archive_basedir": "/root",
+    "archive_name": "npm_cache.tar.gz"
+  },
+  {
+    "display_name": "node modules",
+    "folder_to_archive": "node_modules",
+    "folder_to_archive_basedir": ".",
+    "archive_name": "node_modules_cache.tar.gz"
+  },
+  {
+    "display_name": "Gutenberg node modules",
+    "folder_to_archive": "node_modules",
+    "folder_to_archive_basedir": "./gutenberg",
+    "archive_name": "gutenberg_node_modules.tar.gz"
+  },
+  {
+    "display_name": "Gutenberg components node modules",
+    "folder_to_archive": "node_modules",
+    "folder_to_archive_basedir": "./gutenberg/packages/components",
+    "archive_name": "gutenberg_components_node_modules.tar.gz"
+  },
+  {
+    "display_name": "Jetpack node modules",
+    "folder_to_archive": "node_modules",
+    "folder_to_archive_basedir": "./jetpack",
+    "archive_name": "jetpack_node_modules.tar.gz"
+  },
+  {
+    "display_name": "Jetpack js-tools node modules",
+    "folder_to_archive": "node_modules",
+    "folder_to_archive_basedir": "./jetpack/tools/js-tools",
+    "archive_name": "jetpack_tools_node_modules.tar.gz"
+  },
+  {
+    "display_name": "i18n cache",
+    "folder_to_archive": "i18n-cache",
+    "folder_to_archive_basedir": "./src",
+    "archive_name": "i18n_cache.tar.gz"
+  },
+  {
+    "display_name": "pnpm cache",
+    "folder_to_archive": ".local/share/pnpm/store/v3",
+    "folder_to_archive_basedir": "/root",
+    "archive_name": "pnpm_store.tar.gz"
+  }
+]

--- a/.buildkite/compute-cache-key.sh
+++ b/.buildkite/compute-cache-key.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -eu
+
+ARCHITECTURE=$(uname -m)
+NODE_VERSION=$(node --version)
+PACKAGE_HASH=$(hash_file package-lock.json)
+# This repo depends on the packages in its gutenberg/ and jetpack/ submodules, too
+GUTENBERG_PACKAGE_HASH=$(hash_file gutenberg/package-lock.json)
+JETPACK_PACKAGE_HASH=$(hash_file jetpack/pnpm-lock.yaml)
+# Hash the three hashes because appended together they would make the key for the tar file too long.
+# See https://buildkite.com/automattic/gutenberg-mobile/builds/6151#0188b7a7-887f-4dc8-b363-07363f261c8a/4402-4407
+#
+# Notice we use hash_file here just to avoid reimplementing the hashing logic.
+# This leverages the fact that the command doesn't check for the input being an actual file.
+HASH=$(hash_file "$PACKAGE_HASH$GUTENBERG_PACKAGE_HASH$JETPACK_PACKAGE_HASH")
+
+CACHE_KEY_ROOT="$BUILDKITE_PIPELINE_SLUG-$ARCHITECTURE-node$NODE_VERSION-$HASH"
+
+compute_cache_key() {
+  local folder_to_archive_basedir="$1"
+  local folder_to_archive="$2"
+
+  local key="$CACHE_KEY_ROOT-${folder_to_archive_basedir//\//-}-${folder_to_archive//\//-}"
+
+  echo "$key"
+}

--- a/.buildkite/download-caches.sh
+++ b/.buildkite/download-caches.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -eu
+
+set -o pipefail
+
+# FIXME: these paths expect the script to be called from the root of the project. Make it agnostic
+source .buildkite/compute-cache-key.sh
+
+jq -c '.[]' .buildkite/caches.json | while read -r item; do
+  display_name=$(echo "$item" | jq -r '.display_name')
+  folder_to_archive=$(echo "$item" | jq -r '.folder_to_archive')
+  folder_to_archive_basedir=$(echo "$item" | jq -r '.folder_to_archive_basedir')
+
+  echo "--- :arrow_down: Download $display_name cache"
+  pushd "$folder_to_archive_basedir"
+  key=$(compute_cache_key "$folder_to_archive_basedir" "$folder_to_archive")
+  restore_cache "$key"
+  popd
+done
+
+# Some of the cache data needs to be connected to the submodule projects.
+#
+# The npm postinstall hooks normally does that, but we obviously don't run it when using cached data.
+
+echo "--- :pnpm: :jetpack: Setup pnpm symlinks"
+./bin/run-jetpack-command.sh 'install --ignore-scripts'
+
+echo "--- :globe_with_meridians: Propagate i18n from local cache to submodules"
+./bin/i18n-check-cache.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,66 +1,109 @@
 x-common-params:
-  &publish-android-artifacts-docker-container
-  docker#v3.8.0:
-    image: "public.ecr.aws/automattic/android-build-image:v1.1.0"
-    propagate-environment: true
-    environment:
-      # DO NOT MANUALLY SET THESE VALUES!
-      # They are passed from the Buildkite agent to the Docker container
-      - "AWS_ACCESS_KEY"
-      - "AWS_SECRET_KEY"
+  - &gb-mobile-docker-container
+    docker#v3.8.0:
+      image: "public.ecr.aws/automattic/gb-mobile-image:latest"
+      environment:
+        - "CI=true"
+        # Allow WP-CLI to be run as root, otherwise it throws an exception.
+        # Reference: https://git.io/J9q2S
+        - "WP_CLI_ALLOW_ROOT=true"
+  - &publish-android-artifacts-docker-container
+    docker#v3.8.0:
+      image: "public.ecr.aws/automattic/android-build-image:v1.1.0"
+      propagate-environment: true
+      environment:
+        # DO NOT MANUALLY SET THESE VALUES!
+        # They are passed from the Buildkite agent to the Docker container
+        - "AWS_ACCESS_KEY"
+        - "AWS_SECRET_KEY"
 
 steps:
   - block: "Request trigger Android bundle and builds"
     branches: "dependabot/submodules/*"
 
+  - label: Build npm cache
+    key: build-npm
+    plugins:
+      - automattic/git-shallow-clone
+    command: |
+      echo "--- :docker: Build Docker image"
+      make ci_build_docker_image
+      echo "--- :npm: Build node dependencies if needed"
+      make ci_build_dependencies
+
+  - label: Lint
+    depends_on: build-npm
+    key: lint
+    plugins:
+      - automattic/git-shallow-clone
+    command: |
+      echo "--- :docker: Build Docker image"
+      make ci_build_docker_image
+      echo "--- :node: Lint"
+      make ci_lint
+
+  - label: Android Unit Tests
+    depends_on: build-npm
+    key: unit-tests-android
+    plugins:
+      - automattic/git-shallow-clone
+    command: |
+      echo "--- :docker: Build Docker image"
+      make ci_build_docker_image
+      echo "--- :node: Unit Tests"
+      make ci_unit_tests_android
+    artifact_paths:
+      - ./*-tests-out.log
+
+  - label: iOS Unit Tests
+    depends_on: build-npm
+    key: unit-tests-ios
+    plugins:
+      - automattic/git-shallow-clone
+    command: |
+      echo "--- :docker: Build Docker image"
+      make ci_build_docker_image
+      echo "--- :node: Unit Tests"
+      make ci_unit_tests_ios
+    artifact_paths:
+      - ./*-tests-out.log
+
   - label: "Build JS Bundles"
+    depends_on:
+      - build-npm
+      # Don't wait for tests while testing the setup
+      # - "unit-tests-android"
+      # - "unit-tests-ios"
     key: "js-bundles"
     plugins:
-      - docker#v3.8.0:
-          image: "public.ecr.aws/automattic/gb-mobile-image:latest"
-          environment:
-            - "CI=true"
-            # Allow WP-CLI to be run as root, otherwise it throws an exception.
-            # Reference: https://git.io/J9q2S
-            - "WP_CLI_ALLOW_ROOT=true"
+      - automattic/git-shallow-clone
     command: |
-        source /root/.bashrc
+      echo "--- :docker: Build Docker image"
+      make ci_build_docker_image
+      echo "--- :npm: Build node dependencies if needed"
+      make ci_build_js_bundles
+    artifact_paths:
+      - build/android/App.js
+      - build/ios/App.js
 
-        echo "--- :node: Setup Node environment"
-        nvm install && nvm use
-
-        echo "--- :npm: Install Node dependencies"
-        npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
-
-        echo "--- :package: Run bundle prep work"
-        npm run prebundle:js
-
-        echo "--- :android: Build Android bundle"
-        npm run bundle:android
-
-        echo "--- :arrow_up: Upload Android bundle artifact"
-        buildkite-agent artifact upload bundle/android/App.js
-
-        echo "--- :ios: Build iOS bundle"
-        npm run bundle:ios
-
-        echo "--- :arrow_up: Upload iOS bundle artifact"
-        buildkite-agent artifact upload bundle/ios/App.js
   - label: "Build Android RN Aztec & Publish to S3"
+    depends_on: "unit-tests-android"
     key: "publish-react-native-aztec-android"
     plugins:
       - *publish-android-artifacts-docker-container
+      - automattic/git-shallow-clone
     command: |
-        .buildkite/publish-react-native-aztec-android-artifacts.sh
+      .buildkite/publish-react-native-aztec-android-artifacts.sh
 
   - label: "Build Android RN Bridge & Publish to S3"
     depends_on:
       - "js-bundles"
       - "publish-react-native-aztec-android"
     plugins:
+      - automattic/git-shallow-clone
       - *publish-android-artifacts-docker-container
     command: |
-        .buildkite/publish-react-native-bridge-android-artifacts.sh
+      .buildkite/publish-react-native-bridge-android-artifacts.sh
 
   - label: Build iOS RN XCFramework & Publish to S3
     depends_on: js-bundles
@@ -68,9 +111,8 @@ steps:
     artifact_paths:
       - ios-xcframework/build/xcframeworks/*.tar.gz
     plugins:
-      - automattic/a8c-ci-toolkit#2.16.0
-      - peakon/git-shallow-clone#v0.0.1:
-          depth: 1
+      - automattic/a8c-ci-toolkit#2.17.0
+      - automattic/git-shallow-clone
     agents:
       queue: mac
     env:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -117,3 +117,28 @@ steps:
       queue: mac
     env:
       IMAGE_ID: xcode-14.3
+
+  # These steps aren't ready yet.
+  #
+  # Next steps:
+  # - Move to a Docker image that can run download-dependencies.sh (see Dockerfile)
+  #
+  # - label: Build and Test Android Editor
+  #   depends_on: 'build-npm'
+  #   plugins:
+  #     - *publish-android-artifacts-docker-container
+  #     - automattic/git-shallow-clone
+  #   command: |
+  #     .buildkite/download-dependencies.sh
+  #     cd gutenberg/packages/react-native-editor/android && ./gradlew testDebug
+
+  # - label: Build and Test Android Bridge
+  #   depends_on: 'build-npm'
+  #   plugins:
+  #     - *publish-android-artifacts-docker-container
+  #     - automattic/git-shallow-clone
+  #   command: |
+  #     .buildkite/download-dependencies.sh
+  #     cd gutenberg/packages/react-native-bridge/android && ./gradlew test
+
+  # TODO: Add a block step for UI tests

--- a/.buildkite/upload-caches.sh
+++ b/.buildkite/upload-caches.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -eu
+
+set -o pipefail
+
+# FIXME: these paths expect the script to be called from the root of the project. Make it agnostic
+source .buildkite/compute-cache-key.sh
+
+jq -c '.[]' .buildkite/caches.json | while read -r item; do
+  folder_to_archive_basedir=$(echo "$item" | jq -r '.folder_to_archive_basedir')
+  if [[ ! -d $folder_to_archive_basedir ]]; then
+    echo "Could not find folder $folder_to_archive_basedir"
+  fi
+
+  folder_to_archive=$(echo "$item" | jq -r '.folder_to_archive')
+  if [[ ! -d $folder_to_archive ]]; then
+    echo "Could not find folder $folder_to_archive"
+  fi
+
+  display_name=$(echo "$item" | jq -r '.display_name')
+  echo "--- :arrow_up: Upload $display_name cache"
+
+  pushd "$folder_to_archive_basedir"
+  key=$(compute_cache_key "$folder_to_archive_basedir" "$folder_to_archive")
+  save_cache "$folder_to_archive" "$key"
+  popd
+done

--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,12 @@ buck-out/
 
 *.pot
 
+# Unit tests output log
+#
+# These are generated only via `bin/ci-checks-js.sh`, so unlikely to appear on a dev machine.
+# Still, it's worth ignoring just to avoid these getting committed by accident while testing the CI workflow locally.
+*-test-out.log
+
 # e2e output log
 appium-out.log
 ios-screen-recordings/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+# TODO: Once stable, this should all go into the base image
+#
+# Base image at https://github.com/wordpress-mobile/docker-gb-mobile-image
+FROM public.ecr.aws/automattic/gb-mobile-image as gutenberg-test-runner
+
+WORKDIR /app
+
+ENTRYPOINT ["/bin/bash", "--login", "-c"]
+
+# Ensure the Node and npm version are the ones expected by the project
+COPY .nvmrc .nvmrc.host
+RUN nvm install $(cat .nvmrc.host)
+# Notice the old version of npm.
+RUN npm install -g npm@6
+
+# Add CI toolkit
+#
+# Using HTTPS to clone because there's no SSH key in the image
+RUN git clone https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin /ci-toolkit
+# Add ci-toolkit to the PATH
+RUN echo 'export PATH="$PATH:/ci-toolkit/bin"' >> ~/.bashrc
+
+# Install AWS CLI
+RUN apt-get update && apt-get install -y unzip
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscli.zip" && \
+    unzip awscli.zip && \
+    ./aws/install
+
+# Install jq
+RUN apt-get update && apt-get install -y jq
+
+# TODO: Once stable, this should all go into the base image
+#
+# Base image at https://github.com/wordpress-mobile/docker-android-build-image
+FROM public.ecr.aws/automattic/android-build-image as android-editor-test-runner
+
+WORKDIR /app
+
+ENTRYPOINT ["/bin/bash", "--login", "-c"]
+
+# Add CI toolkit
+#
+# Using HTTPS to clone because there's no SSH key in the image
+RUN git clone https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin /ci-toolkit
+# Add ci-toolkit to the PATH
+RUN echo 'export PATH="$PATH:/ci-toolkit/bin"' >> ~/.bashrc
+
+# Install AWS CLI
+RUN apt-get update
+RUN apt-get install -y unzip
+RUN apt-get install -y curl
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscli.zip" && \
+    unzip awscli.zip && \
+    ./aws/install

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+test_runner = gutenberg-test-runner
+android_editor_test_runner = android-editor-test-runner
+
+docker_run_opts = --interactive --tty --volume $(shell pwd):/app
+
+docker_run_env = --env BUILDKITE_PLUGIN_BASH_CACHE_BUCKET=$$BUILDKITE_PLUGIN_BASH_CACHE_BUCKET \
+								 --env CACHE_BUCKET_NAME=$$CACHE_BUCKET_NAME \
+								 --env AWS_SECRET_KEY=$$AWS_SECRET_KEY \
+								 --env AWS_ACCESS_KEY=$$AWS_ACCESS_KEY \
+								 --env BUILDKITE_PIPELINE_SLUG=$$BUILDKITE_PIPELINE_SLUG
+
+docker_run = docker run $(docker_run_opts) $(docker_run_env) $(test_runner)
+
+download_caches_cmd = .buildkite/download-caches.sh
+upload_caches_cmd = .buildkite/upload-caches.sh
+
+ci_build_docker_image:
+	docker build \
+		--target $(test_runner) \
+		--tag $(test_runner) \
+		.
+
+ci_build_docker_android_editor_image:
+	docker build \
+		--target $(android_editor_test_runner) \
+		--tag $(android_editor_test_runner) \
+		.
+
+# Without --unsafe-perm, the postinstall hook will fail to run.
+#
+# See:
+# - https://github.com/npm/npm/issues/3497#issue-14876484
+# - https://buildkite.com/automattic/gutenberg-mobile/builds/6101#0188a503-600b-4839-913f-2b13254a92d4/243-422
+ci_build_dependencies:
+	$(docker_run) ".buildkite/build-dependencies.sh"
+
+ci_lint:
+	$(docker_run) "$(download_caches_cmd) && CHECK_CORRECTNESS=true CHECK_TESTS=false ./bin/ci-checks-js.sh"
+
+ci_unit_tests_android:
+	$(docker_run) "$(download_caches_cmd) && CHECK_CORRECTNESS=false CHECK_TESTS=true TEST_RN_PLATFORM=android ./bin/ci-checks-js.sh"
+
+ci_unit_tests_ios:
+	$(docker_run) "$(download_caches_cmd) && CHECK_CORRECTNESS=false CHECK_TESTS=true TEST_RN_PLATFORM=ios ./bin/ci-checks-js.sh"
+
+ci_build_js_bundles:
+	$(docker_run) ".buildkite/build-js-bundles.sh"

--- a/bin/ci-checks-js.sh
+++ b/bin/ci-checks-js.sh
@@ -1,10 +1,11 @@
+#!/bin/bash -eu
+
 function pOk() {
   echo "[OK]"
 }
 
 function pFail() {
-  if [ -n "$1" ]
-  then
+  if [ -n "${1:-}" ]; then
     echo "Message: $1"
   fi
   echo "[KO]"
@@ -12,7 +13,9 @@ function pFail() {
 }
 
 function checkDiff() {
+  set +e
   diff=$(git diff)
+  set -e
   if [[ $? != 0 ]]; then
     pFail
   elif [[ $diff ]]; then
@@ -24,14 +27,16 @@ function checkDiff() {
 }
 
 # if both env variables are missing then force them to `true`. Otherwise will respect the combination passed externally
-if [[ -z "${CHECK_CORRECTNESS}" ]] && [[ -z "${CHECK_TESTS}" ]] ; then
+if [[ -z "${CHECK_CORRECTNESS:-}" ]] && [[ -z "${CHECK_TESTS:-}" ]] ; then
   CHECK_CORRECTNESS=true
   CHECK_TESTS=true
 fi
 
 if [ "$CHECK_CORRECTNESS" = true ] ; then
+  echo "--- :mag: Check diff"
   checkDiff
 
+  echo "--- :eslint: Lint"
   # Need to build gutenberg packages before linting so that eslint-plugin-import can resolve those.
   # See https://github.com/WordPress/gutenberg/pull/22088 for more information.
   cd gutenberg
@@ -41,12 +46,17 @@ if [ "$CHECK_CORRECTNESS" = true ] ; then
   npm run lint || pFail
 fi
 
+# Notice we forward the tests output to a file.
+# That's because they generates 70k+ lines and we don't want to pollute the logs like that.
 if [ "$CHECK_TESTS" = true ] ; then
-  # we'll run the tests twich (once for each platform) if the platform env var is not set
-  if [[ -z "${TEST_RN_PLATFORM}" ]] ; then
-    TEST_RN_PLATFORM=android npm run test --maxWorkers=4 || pFail
-    TEST_RN_PLATFORM=ios npm run test --maxWorkers=4 || pFail
+  # we'll run the tests twice (once for each platform) if the platform env var is not set
+  if [[ -z "${TEST_RN_PLATFORM:-}" ]] ; then
+    echo "--- :microscope: :android: Unit tests"
+    TEST_RN_PLATFORM=android npm run test --maxWorkers=4 > android-tests-out.log || pFail
+    echo "--- :microscope: :ios: Unit tests"
+    TEST_RN_PLATFORM=ios npm run test --maxWorkers=4 > ios-tests-out.log || pFail
   else
-    npm run test --maxWorkers=4 || pFail
+    echo "--- :microscope: :$TEST_RN_PLATFORM: Unit tests"
+    npm run test --maxWorkers=4 > "$TEST_RN_PLATFORM-tests-out.log" || pFail
   fi
 fi


### PR DESCRIPTION
I've been tinkering with this for a while and I realized it's about time I get some feedback.

Mostly works.

<img width="1178" alt="image" src="https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/b1563335-0dfa-4c24-84bc-b2a5b4908afb">

Build JS Bundles is failing with

```
Error: ENOSPC: System limit for number of file watchers reached, watch '/app/gutenberg/packages/format-library/src/keyboard'
```

The base for the image on which it runs already has code to tweak watchers, maybe that's a place to start.

---

@jkmassel @crazytonyli @oguzkocer this is a draft but I'd appreciate your input. Am I on the right track? Keep in mind I'm a Docker beginner and not much more skilled with Node or `make`, so feel free to point out the obvious.

---

Next steps after solving the issue in the current code:

- Remove the steps we have in Buildkite here from CircleCI and only run the SauceLab tests there
- Open a followup PR focused on the SauceLab tests