### PR TITLE
test: Fix CI task failures

### DIFF
--- a/src/test/videopress/edit.js
+++ b/src/test/videopress/edit.js
@@ -122,12 +122,7 @@ describe( "Update VideoPress block's settings", () => {
 
 		fireEvent.press( screen.getByText( 'Description' ) );
 
-		const allDescriptionInputs = screen.getAllByPlaceholderText(
-			'Add description'
-		);
-
-		// The BottomSheetControl's input field is accessed via the component's second placeholder
-		const input = allDescriptionInputs[ 1 ];
+		const input = screen.getByPlaceholderText( 'Add description' );
 
 		changeTextOfTextInput( input, "The video's new description!" );
 	} );

--- a/src/test/videopress/local-helpers/utils.js
+++ b/src/test/videopress/local-helpers/utils.js
@@ -46,6 +46,8 @@ export const pressSettingInPanel = async ( screen, panel, setting ) => {
 	fireEvent.press( getByText( panel ) );
 
 	// Toggle the specified setting
+	// TODO: Determine the cause of state updates and explicitly wait for them,
+	// instead of wrapping firEvent in act.
 	await act( () => fireEvent.press( getByText( setting ) ) );
 };
 


### PR DESCRIPTION
## Description

Fixes failing CI tasks.

### test: Fix broken input query

It is unclear  me why this change is necessary, but it resolves the
following test failures.

Query returned a single input, which led to the second input being
undefined:

```
    TypeError: Cannot read property 'props' of undefined

        11 |  */
        12 | export const changeTextOfTextInput = ( textInput, text ) => {
    > 13 |      fireEvent( textInput, 'focus' );
            |      ^
        14 |      fireEvent.changeText( textInput, text );
        15 | };
        16 |

        at props (gutenberg/node_modules/@testing-library/react-native/src/fireEvent.ts:116:22)
        at getEventHandler (gutenberg/node_modules/@testing-library/react-native/src/fireEvent.ts:103:19)
        at findEventHandler (gutenberg/node_modules/@testing-library/react-native/src/fireEvent.ts:136:19)
        at changeTextOfTextInput (gutenberg/test/native/integration-test-helpers/text-input-change-text.js:13:2)
        at Object.<anonymous> (src/test/videopress/edit.js:132:3)
        at asyncGeneratorStep (node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
        at _next (node_modules/@babel/runtime/helpers/asyncToGenerator.js:25:9)
        at tryCallOne (gutenberg/node_modules/promise/lib/core.js:37:12)
        at gutenberg/node_modules/promise/lib/core.js:123:15
        at flush (gutenberg/node_modules/asap/raw.js:50:29)
```

The broken query led to an incorrect snapshot outcome:

```
    Snapshot name: `Update VideoPress block's settings should update description 1`

    - Snapshot  - 1
    + Received  + 1

    - "<!-- wp:videopress/video {"title":"default-title-is-file-name","description":"The video's new description!","useAverageColor":false,"id":1,"guid":"AbCdEfGh","privacySetting":2,"allowDownload":false,"rating":"G","isPrivate":true,"duration":2803} /-->"
    + "<!-- wp:videopress/video {"title":"default-title-is-file-name","description":"","useAverageColor":false,"id":1,"guid":"AbCdEfGh","privacySetting":2,"allowDownload":false,"rating":"G","isPrivate":true,"duration":2803} /-->"

        226 |     afterEach( async () => {
        227 |             // Assert
    > 228 |             expect( getEditorHtml() ).toMatchSnapshot();
            |                                       ^
        229 |     } );
        230 | } );
        231 |
```

### test: Add to-do note regarding test improvements

In general, we should not wrap `fireEvent` in an `act` call, as it
already leverages `act` itself. Wrapping it is an indicator of a deeper
issue: there are state updates for which we are not awaiting. Ideally,
we add a new query to await the addition/update/removal of UI to satisfy
the act warning.

## Testing Instructions
Verify CI tasks succeed.

## PR submission checklist

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
