### PR TITLE
build: Fix generate-podspecs script errors

### DIFF
--- a/bin/generate-podspecs.sh
+++ b/bin/generate-podspecs.sh
@@ -17,8 +17,8 @@ function warn_missing_tag_commit() {
 }
 
 # Change to the expected directory.
-cd "$( dirname "$0" )"
-cd ..
+pushd "$( dirname "$0" )" > /dev/null
+popd > /dev/null
 WD=$(pwd)
 echo "Working directory: $WD"
 
@@ -96,7 +96,7 @@ done
 
 # Generate the React Native podspecs
 # Change to the React Native directory to get relative paths for the RN podspecs
-cd "$NODE_MODULES_DIR/react-native"
+pushd "$NODE_MODULES_DIR/react-native" > /dev/null
 
 RN_DIR="./"
 SCRIPTS_PATH="./scripts/"
@@ -196,8 +196,9 @@ do
         mv "$TMP_FBReactNativeSpec" "$DEST/FBReactNativeSpec/FBReactNativeSpec.podspec.json"
     fi
 done
+popd > /dev/null
 
 echo 'Updating XCFramework Podfile.lock with these changes'
-pushd ios-xcframework
+pushd ios-xcframework > /dev/null
 bundle exec pod update
-popd
+popd > /dev/null

--- a/bin/generate-podspecs.sh
+++ b/bin/generate-podspecs.sh
@@ -198,6 +198,8 @@ do
 done
 popd > /dev/null
 
+# We are required to run this script twice to capture the correct target.
+# 0 is the value set on the first running this script to generate the podspecs.
 if [[ "$COMMIT_HASH" != "0" ]]; then
     echo 'Updating XCFramework Podfile.lock with these changes'
     pushd ios-xcframework > /dev/null

--- a/bin/generate-podspecs.sh
+++ b/bin/generate-podspecs.sh
@@ -198,7 +198,9 @@ do
 done
 popd > /dev/null
 
-echo 'Updating XCFramework Podfile.lock with these changes'
-pushd ios-xcframework > /dev/null
-bundle exec pod update
-popd > /dev/null
+if [[ "$COMMIT_HASH" != "0" ]]; then
+    echo 'Updating XCFramework Podfile.lock with these changes'
+    pushd ios-xcframework > /dev/null
+    bundle exec pod update
+    popd > /dev/null
+fi

--- a/bin/generate-podspecs.sh
+++ b/bin/generate-podspecs.sh
@@ -199,7 +199,7 @@ done
 popd > /dev/null
 
 # We are required to run this script twice to capture the correct target.
-# 0 is the value set on the first running this script to generate the podspecs.
+# 0 is the value set during the first script run to generate the podspecs.
 if [[ "$COMMIT_HASH" != "0" ]]; then
     echo 'Updating XCFramework Podfile.lock with these changes'
     pushd ios-xcframework > /dev/null


### PR DESCRIPTION
## Description 

Fix a couple of failures when running `bin/generate-podspecs.sh`. This is a follow up to https://github.com/wordpress-mobile/gutenberg-mobile/pull/5846. 

* build: Fix script directory changes

    Rely upon pushd and popd to simplify the "breadcrumbs" of navigating
    into and out of multiple directories.
* build: Only update xcframework Podfile.lock with valid targets

    We are required to run `bin/generate-podspecs.sh` twice to capture the
    correct target. This change ensures the xcframework is only updated on
    the second run with the correct target, otherwise the following error
    occurs:

    ```
    Installing FBReactNativeSpec 0.69.4

    [!] Error installing FBReactNativeSpec
    [!] /opt/homebrew/bin/git -C /var/folders/c5/mkbb257d7fg4myx88dvsndp80000gn/T/d20230623-6856-98pfen checkout --quiet 0

    error: pathspec '0' did not match any file(s) known to git
    ```

## Testing Instructions

1. Run `./bin/generate-podspecs.sh`
1. Verify the following errors do not occur:
    ```
    ./bin/generate-podspecs.sh: line 201: pushd: ios-xcframework: No such file or directory
    ```

    ```
    Installing FBReactNativeSpec 0.69.4

    [!] Error installing FBReactNativeSpec
    [!] /opt/homebrew/bin/git -C /var/folders/c5/mkbb257d7fg4myx88dvsndp80000gn/T/d20230623-6856-98pfen checkout --quiet 0

    error: pathspec '0' did not match any file(s) known to git
    ```

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.

