### PR TITLE
RN upgrade: Fix test suite 1 errors

### DIFF
--- a/__device-tests__/gutenberg-editor-sanity-test-1-visual.test.js
+++ b/__device-tests__/gutenberg-editor-sanity-test-1-visual.test.js
@@ -13,7 +13,7 @@ const {
 import { NESTED_COLUMNS_3_LEVELS } from './test-editor-data';
 
 const ANDROID_COLUMN_APPENDER_BUTTON_XPATH =
-	'//android.widget.Button[@content-desc="Column Block. Row 1"]/android.view.ViewGroup[2]/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.Button';
+	'//android.widget.Button[@content-desc="Column Block. Row 1"]/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.Button/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/com.horcrux.svg.SvgView/com.horcrux.svg.GroupView/com.horcrux.svg.PathView';
 
 describe( 'Gutenberg Editor - Test Suite 1', () => {
 	describe( 'Columns block', () => {

--- a/__device-tests__/gutenberg-editor-sanity-test-1-visual.test.js
+++ b/__device-tests__/gutenberg-editor-sanity-test-1-visual.test.js
@@ -49,6 +49,9 @@ describe( 'Gutenberg Editor - Test Suite 1', () => {
 				blockNames.columns
 			);
 			await columnsBlock.click();
+
+			await editorPage.moveBlockSelectionUp( { toRoot: true } );
+
 			await editorPage.removeBlock();
 		} );
 

--- a/__device-tests__/gutenberg-editor-sanity-test-1-visual.test.js
+++ b/__device-tests__/gutenberg-editor-sanity-test-1-visual.test.js
@@ -13,7 +13,7 @@ const {
 import { NESTED_COLUMNS_3_LEVELS } from './test-editor-data';
 
 const ANDROID_COLUMN_APPENDER_BUTTON_XPATH =
-	'//android.widget.Button[@content-desc="Column Block. Row 1"]/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.Button/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/com.horcrux.svg.SvgView/com.horcrux.svg.GroupView/com.horcrux.svg.PathView';
+	'//android.widget.Button[@content-desc="Column Block. Row 1"]/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.Button';
 
 describe( 'Gutenberg Editor - Test Suite 1', () => {
 	describe( 'Columns block', () => {


### PR DESCRIPTION
# Description

Following the upgrade to React Native `0.71.11`, all but the first test in [the `gutenberg-editor-sanity-test-1-visual.test.js` suite](https://github.com/wordpress-mobile/gutenberg-mobile/blob/275bd363e5c9d9d8719ff22b84852b294eb33fff/__device-tests__/gutenberg-editor-sanity-test-1-visual.test.js) were failing for Android. 

In this PR, the following changes have been made to address the failures:

* https://github.com/wordpress-mobile/gutenberg-mobile/pull/5986/commits/7f5e9c1a69e7aa56b147924185b7da6973f2c6cf + https://github.com/wordpress-mobile/gutenberg-mobile/pull/5986/commits/c9aa8933441b14d871a39992fb3e4dba68fd1835: Updated the XPath for the appender button on Android to ensure it was selected as part of the tests.
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/5986/commits/275bd363e5c9d9d8719ff22b84852b294eb33fff: Ensured top-most column block is always selected before removing it in the suite's first test. Prior to this change, an inner column block was being selected and removed, leaving the parent column block in place. This caused a domino effect of errors with the other tests. 

# Testing

* Run the following commands locally to verify the tests pass:
   * `TEST_RN_PLATFORM=android npm run device-tests:local gutenberg-editor-sanity-test-1-visual.test.js`
   * `TEST_RN_PLATFORM=ios npm run device-tests:local gutenberg-editor-sanity-test-1-visual.test.js`
* Verify all tests pass against this PR, ensuring to run the optional tests.

<hr />

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
