### PR TITLE
Update Android Docker Image to add JDK 17 support

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 x-common-params:
   &publish-android-artifacts-docker-container
   docker#v3.8.0:
-    image: "public.ecr.aws/automattic/android-build-image:v1.1.0"
+    image: "public.ecr.aws/automattic/android-build-image:v1.3.0"
     propagate-environment: true
     environment:
       # DO NOT MANUALLY SET THESE VALUES!


### PR DESCRIPTION
The only change worth noting between the two Docker images is the JDK update from `11` to `17`. That means JDK `11` will no longer be available. However, since this PR is targeting the AGP `8.0.2` update PR, which requires JDK `17`, that shouldn't be a problem for this repository.

**To test:**
Verify that Android publishing CI steps are successful

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
