### PR TITLE
Clone the repo faster in Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,13 +1,15 @@
 x-common-params:
-  &publish-android-artifacts-docker-container
-  docker#v3.8.0:
-    image: "public.ecr.aws/automattic/android-build-image:v1.3.0"
-    propagate-environment: true
-    environment:
-      # DO NOT MANUALLY SET THESE VALUES!
-      # They are passed from the Buildkite agent to the Docker container
-      - "AWS_ACCESS_KEY"
-      - "AWS_SECRET_KEY"
+  - &git-shallow-clone-plugin
+    automattic/git-shallow-clone#trunk
+  - &publish-android-artifacts-docker-container
+    docker#v3.8.0:
+      image: "public.ecr.aws/automattic/android-build-image:v1.3.0"
+      propagate-environment: true
+      environment:
+        # DO NOT MANUALLY SET THESE VALUES!
+        # They are passed from the Buildkite agent to the Docker container
+        - "AWS_ACCESS_KEY"
+        - "AWS_SECRET_KEY"
 
 steps:
   - block: "Request trigger Android bundle and builds"
@@ -69,7 +71,7 @@ steps:
       - ios-xcframework/build/xcframeworks/*.tar.gz
     plugins:
       - automattic/a8c-ci-toolkit#2.16.0
-      - automattic/git-shallow-clone#trunk
+      - *git-shallow-clone-plugin
     agents:
       queue: mac
     env:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -73,7 +73,7 @@ steps:
     artifact_paths:
       - ios-xcframework/build/xcframeworks/*.tar.gz
     plugins:
-      - automattic/a8c-ci-toolkit#2.16.0
+      - automattic/a8c-ci-toolkit#2.18.2
       - *git-shallow-clone-plugin
     agents:
       queue: mac

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,6 +18,7 @@ steps:
   - label: "Build JS Bundles"
     key: "js-bundles"
     plugins:
+      - *git-shallow-clone-plugin
       - docker#v3.8.0:
           image: "public.ecr.aws/automattic/gb-mobile-image:latest"
           environment:
@@ -51,6 +52,7 @@ steps:
   - label: "Build Android RN Aztec & Publish to S3"
     key: "publish-react-native-aztec-android"
     plugins:
+      - *git-shallow-clone-plugin
       - *publish-android-artifacts-docker-container
     command: |
         .buildkite/publish-react-native-aztec-android-artifacts.sh
@@ -60,6 +62,7 @@ steps:
       - "js-bundles"
       - "publish-react-native-aztec-android"
     plugins:
+      - *git-shallow-clone-plugin
       - *publish-android-artifacts-docker-container
     command: |
         .buildkite/publish-react-native-bridge-android-artifacts.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -69,8 +69,7 @@ steps:
       - ios-xcframework/build/xcframeworks/*.tar.gz
     plugins:
       - automattic/a8c-ci-toolkit#2.16.0
-      - peakon/git-shallow-clone#v0.0.1:
-          depth: 1
+      - automattic/git-shallow-clone#trunk
     agents:
       queue: mac
     env:


### PR DESCRIPTION
By default, Buildkite runs a `git clone` that fetches the entire repository history, for the main repo as well as the submodules (e.g. `git clone -v -- git@github.com:wordpress-mobile/gutenberg-mobile.git .`)

This approach is too slow for a huge repository like ours. A faster strategy is to run a shallow clone, `git clone --depth=1 --shallows-submodules`. Buildkite allows doing this via environment variables and the environment hook, but our CI configuration blocks that for security reason.

I'm not sure what is the safest and more robust way to move forward. In the meantime, I found [a plugin that allows setting those environment variables](https://github.com/peakon/git-shallow-clone-buildkite-plugin) and copied the approach into [a plugin under our org](https://github.com/automattic/git-shallow-clone-buildkite-plugin). The reason for having our own plugin instead of relying and contributing to a community one is that it seems a safer approach. Hat tip @crazytonyli for pointing this out.

![Untitled5](https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/8e4be4b3-8282-44b6-b579-841111bfe54a)
_The screenshot shows a gain of more than 1 minute during checkout._

## Testing

Green CI is enough here.

## Alternatives

I guess something we could do is make the behavior implemented in the plugin the default in our Buildkite agents setup. Maybe this has never come up because the git checkout has never been a big problem in other repos.

In the meantime, this does the job in the context of this pipeline.

---

**PR submission checklist**:

- [x] I have considered adding unit tests where possible. – N.A.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary. – N.A.
