### PR TITLE
Only run `prebundle` command when building from Git tag

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,8 +35,12 @@ steps:
         echo "--- :npm: Install Node dependencies"
         npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 
-        echo "--- :package: Run bundle prep work"
-        npm run prebundle:js
+        if [[ -z "$BUILDKITE_TAG" ]]; then
+          echo "--- :package: Skip bundle prep work"
+        else
+          echo "--- :package: Run bundle prep work"
+          npm run prebundle:js
+        fi
 
         echo "--- :android: Build Android bundle"
         npm run bundle:android


### PR DESCRIPTION
**Internal ref:** p9ugOq-3VT-p2

This PR skips the command `npm run prebundle:js` when building the bundles in CI that are not Git-tagged. This will improve the build time for PRs:
- Regular commit: [Passed in 41m 30s](https://buildkite.com/automattic/gutenberg-mobile/builds/6730).
- Git-tagged commit: [Passed in 1h 0m](https://buildkite.com/automattic/gutenberg-mobile/builds/6738).

The implications of not running the `prebundle:js` command is mainly related to the bundle size. Not running this command would result in an extra 20 MB. In theory, there won't be any undesired side effects in the editor's logic. 

To test:
* Observe that all CI jobs pass in this PR ([Buildkite job](https://buildkite.com/automattic/gutenberg-mobile/builds/6730)).
* Observe that all CI jobs pass the tag `test-ci-run-prebundle-only-with-tag` ([Buildkite job](https://buildkite.com/automattic/gutenberg-mobile/builds/6738)).

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.