### PR TITLE
Add symbolicate stack trace script

### DIFF
--- a/bin/symbolicate-stracktrace.sh
+++ b/bin/symbolicate-stracktrace.sh
@@ -1,0 +1,66 @@
+# Exit if any command fails
+set -uo pipefail
+
+# Function to prompt for single line input
+function prompt_single_line_input {
+    local input
+    read -r input
+    echo "$input"
+}
+
+# Function to prompt for input with multiline support
+function prompt_multiline_input {
+    local input=""
+    local line
+
+    while IFS= read -r line; do
+        # Check if the line is empty (only contains whitespace)
+        if [[ -z "${line}" ]]; then
+            break
+        fi
+
+        input+="$line"$'\n'
+    done
+
+    # Remove the trailing newline from the last line
+    input=${input%$'\n'}
+
+    echo "$input"
+}
+
+# Prompt platform
+printf "Enter the platform: "
+PLATFORM=$(prompt_single_line_input)
+if [[ -z "$PLATFORM" || "$PLATFORM" != "android" && "$PLATFORM" != "ios" ]]; then
+    echo "\x1b[31mPlatform is required. The accepted values are 'android' and 'ios'.\x1b[0m"
+    exit
+fi
+
+# Prompt Gutenberg Mobile version
+printf "Enter the Gutenberg Mobile version: "
+VERSION=$(prompt_single_line_input)
+if [[ -z "$VERSION" ]]; then
+    echo "\x1b[31mGutenberg Mobile version is required.\x1b[0m"
+    exit
+fi
+
+# Prompt stack trace
+echo "Enter the stack trace (Press Enter on an empty line to finish):"
+STACKTRACE=$(prompt_multiline_input)
+if [[ -z "$STACKTRACE" ]]; then
+    echo "\x1b[31mStacktrace is required.\x1b[0m"
+    exit
+fi
+
+TEMPMAP=$(mktemp)
+DOWNLOAD_URL="https://github.com/wordpress-mobile/gutenberg-mobile/releases/download/v$VERSION/$PLATFORM-App.js.map"
+echo "Downloading source maps for version $VERSION ($PLATFORM)..."
+wget -q -O $TEMPMAP $DOWNLOAD_URL
+
+if [ $? -ne 0 ]; then
+    echo "\x1b[31mCan't find source map\x1b[0m '$DOWNLOAD_URL'.\n\x1b[33mPlease verify that the GitHub release for version '$VERSION' has the source maps attached:\x1b[0m https://github.com/wordpress-mobile/gutenberg-mobile/releases/tag/v$VERSION"
+    exit
+else
+    echo "Symbolicated stack trace:\n"
+    npx metro-symbolicate $TEMPMAP <<< "$STACKTRACE"  
+fi


### PR DESCRIPTION
**Related to https://github.com/wordpress-mobile/gutenberg-mobile/issues/6023.**

This PR adds a script that will help us to symbolicate crash stack traces coming from React Native. The script supports both Hermes and non-Hermes versions. However, since it relies on GitHub release artifacts, it's important to note that it will only work for versions in which their source maps have been uploaded to their associated GitHub release.

**NOTE:** I'll add documentation for this script in a separate PR.

# To test

## 1. Android - Hermes
⚠️ Unfortunately, we don't have a reliable source map for Android prior to version 1.100.0 because we weren't storing them. We can test using the ones generated for version `1.100.2`, although be aware that might not point accurately to the source code position if the crash happened in the first beta versions (i.e. before Gutenberg Mobile `1.100.2` was integrated).

<details><summary><strong>Click here to show crash stack trace</strong></summary>

<h3>Details</h3>

* [Sentry event](https://a8c.sentry.io/issues/4262949664/events/bfe4a681231e416991281fddde16a2a5/?project=5731682)
* Gutenberg Mobile version: [1.100.2](https://github.com/wordpress-mobile/gutenberg-mobile/releases/tag/v1.100.2)

```
S@1:3294702
E@1:3294878
anonymous@1:3295940
useMemo@1:219101
anonymous@1:147268
edit@1:3295253
Dr@1:183556
xa@1:222694
vi@1:209264
gi@1:209167
hi@1:209051
oi@1:206559
xt@1:173775
Ce@1:223066
ze@1:166806
Me@1:167079
receiveEvent@1:217410
value@1:234842
anonymous@1:233458
value@1:234407
value@1:233416
```

</details> 

1. Run `bin/symbolicate-stracktrace.sh`
2. Enter `android` for the platform.
3. Enter `1.100.2` for the version.
4. Copy and paste the above stack trace when prompted.
**NOTE:** To continue you need to type enter in an empty line.
5. Observe that the symbolicated stack trace is generated successfully.


## 2. iOS - Hermes

A [custom build](https://github.com/wordpress-mobile/WordPress-iOS/pull/21252#issuecomment-1665443371) has been created for this forcing a specific crash ([reference](https://github.com/wordpress-mobile/gutenberg-mobile/pull/6031)).

<details><summary><strong>Click here to show crash stack trace</strong></summary>

<h3>Details</h3>

* [Sentry event](https://a8c.sentry.io/share/issue/2aee277b9805438eac7e54499c5a7498/)
* Gutenberg Mobile version: [1.101.0-test](https://github.com/fluiddot/gutenberg-mobile/releases/tag/v1.101.0-test)

```
anonymous@1:12961370
anonymous@1:141182
value@1:5070812
value@1:5072137
Vl@1:389404
Wl@1:389265
Ma@1:421497
zi@1:408562
Ri@1:408464
Pi@1:408348
ki@1:405845
xt@1:370929
Ce@1:422268
Ne@1:364058
Me@1:364331
receiveEvent@1:416834
value@1:164655
anonymous@1:163155
value@1:164101
value@1:163113
```

</details> 

**Preparation:**
The source maps have been uploaded to a forked repository. So we need to tweak the script to download them from a different source.
1. Apply the following patch:
```patch
diff --git forkSrcPrefix/bin/symbolicate-stracktrace.sh forkDstPrefix/bin/symbolicate-stracktrace.sh
index 7e175cfa72efdbe5fe3452c0deab5c9d54acf4b6..0e574c0075c5af9e21fa3701d103ae4121b77567 100755
--- forkSrcPrefix/bin/symbolicate-stracktrace.sh
+++ forkDstPrefix/bin/symbolicate-stracktrace.sh
@@ -53,7 +53,7 @@ if [[ -z "$STACKTRACE" ]]; then
 fi
 
 TEMPMAP=$(mktemp)
-DOWNLOAD_URL="https://github.com/wordpress-mobile/gutenberg-mobile/releases/download/v$VERSION/$PLATFORM-App.js.map"
+DOWNLOAD_URL="https://github.com/fluiddot/gutenberg-mobile/releases/download/v$VERSION/$PLATFORM-App.js.map"
 echo "Downloading source maps for version $VERSION ($PLATFORM)..."
 wget -q -O $TEMPMAP $DOWNLOAD_URL
```

2. Run `bin/symbolicate-stracktrace.sh`
3. Enter `ios` for the platform.
4. Enter `1.101.0-test` for the version.
5. Copy and paste the above stack trace when prompted.
**NOTE:** To continue you need to type enter in an empty line.
7. Observe that the symbolicated stack trace points to [this line](https://github.com/wordpress-mobile/gutenberg-mobile/pull/6031/files#diff-45110e167ec131d1e7aa1f1d0c32788677907ee8c4bee532b802ef6fbf6b6a5dR13).

## 3. iOS - Without Hermes

<details><summary><strong>Click here to show crash stack trace</strong></summary>

<h3>Details</h3>

* [Sentry event](https://a8c.sentry.io/share/issue/f19f34e9f5954138938988dbe202ddee/)
* Gutenberg Mobile version: [1.98.1](https://github.com/wordpress-mobile/gutenberg-mobile/releases/tag/v1.98.1)

```
<unknown>@2848:462
<unknown>@1154:1100
__unstableMarkListeningStores@1078:2429
<unknown>@1078:2788
w@1154:1080
<unknown>@1154:1222
b@1154:1392
<unknown>@1154:352
<unknown>@2848:134
<unknown>@2784:3376
Dr@58:43210
Hl@58:59677
vi@58:83649
gi@58:83577
hi@58:83342
oi@58:80311
oi@(null):(null)
xt@58:27446
ni@58:77109
<unknown>@58:46307
t@1154:689
f@1154:720
<unknown>@1078:794
<unknown>@1080:2082
b@1081:3199
<unknown>@1142:188
<unknown>@1084:296
<unknown>@1139:238
<unknown>@1140:683
apply@1080:960
<unknown>@(null):(null)
<unknown>@2815:3929
<unknown>@1142:183
<unknown>@1084:296
<unknown>@1139:238
<unknown>@1140:683
<unknown>@1080:710
<unknown>@2828:933
<unknown>@2860:1844
<unknown>@1147:190
forEach@(null):(null)
c@1147:169
emit@1147:383
y@1078:303
<unknown>@1078:794
<unknown>@1080:2082
b@1081:3199
<unknown>@1142:188
<unknown>@1084:296
<unknown>@1139:238
<unknown>@1140:683
apply@1080:960
<unknown>@(null):(null)
<unknown>@2706:14373
<unknown>@1142:183
<unknown>@1084:296
<unknown>@1139:238
<unknown>@1140:683
<unknown>@1080:710
<unknown>@2780:505
<unknown>@1165:511
onSelect@2784:3882
onChange@2784:5992
<unknown>@2244:1533
value@78:3867
<unknown>@78:913
value@78:2582
value@78:883
value@(null):(null)
```

</details> 

**Preparation:**
We are going to compare the symbolication output from the script and the `metro-symbolicate` command.

**Using `metro-symbolicate` command:**
1. Create a file `stacktrace` and paste the above stack trace.
3. Run `TEMPMAP=$(mktemp) && wget -q https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.98.1/bundle/ios/App.js.map -O $TEMPMAP && npx metro-symbolicate $TEMPMAP < stacktrace`.
4. Copy the symbolicated stack trace output.

**Using the  `symbolicate-stracktrace` script:**
1. Run `bin/symbolicate-stracktrace.sh`
2. Enter `ios` for the platform.
3. Enter `1.98.1` for the version.
5. Copy and paste the above stack trace when prompted.
**NOTE:** To continue you need to type enter in an empty line.
8. Compare the symbolicated stack trace output with the one generated by `metro-symbolicate` command.
9. Observe they match.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
