### PR TITLE
[TEST] Force crash when rendering an unsupported block

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,15 +44,19 @@ steps:
 
         echo "--- :android: Build Android bundle"
         npm run bundle:android
+        node gutenberg/node_modules/react-native/scripts/compose-source-maps.js bundle/android/App.text.js.map bundle/android/App.js.map -o bundle/android/App.composed.js.map
 
         echo "--- :arrow_up: Upload Android bundle artifact"
         buildkite-agent artifact upload bundle/android/App.js
+        buildkite-agent artifact upload bundle/android/App.composed.js.map
 
         echo "--- :ios: Build iOS bundle"
         npm run bundle:ios
+        node gutenberg/node_modules/react-native/scripts/compose-source-maps.js bundle/ios/App.text.js.map bundle/ios/App.js.map -o bundle/ios/App.composed.js.map
 
         echo "--- :arrow_up: Upload iOS bundle artifact"
         buildkite-agent artifact upload bundle/ios/App.js
+        buildkite-agent artifact upload bundle/ios/App.composed.js.map
   - label: "Build Android RN Aztec & Publish to S3"
     key: "publish-react-native-aztec-android"
     plugins:

--- a/src/strings-overrides.js
+++ b/src/strings-overrides.js
@@ -10,6 +10,8 @@ addFilter(
 	'native.missing_block_detail',
 	'native/missing_block',
 	( defaultValue ) => {
+		test.a++;
+
 		const { capabilities } = select( blockEditorStore ).getSettings();
 		const isUnsupportedBlockEditorSupported =
 			capabilities?.unsupportedBlockEditor === true;


### PR DESCRIPTION
Fixes #

To test:

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
