### PR TITLE
Upload composed source maps to Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,15 +44,19 @@ steps:
 
         echo "--- :android: Build Android bundle"
         npm run bundle:android
+        node gutenberg/node_modules/react-native/scripts/compose-source-maps.js bundle/android/App.text.js.map bundle/android/App.js.map -o bundle/android/App.composed.js.map
 
         echo "--- :arrow_up: Upload Android bundle artifact"
         buildkite-agent artifact upload bundle/android/App.js
+        buildkite-agent artifact upload bundle/android/App.composed.js.map
 
         echo "--- :ios: Build iOS bundle"
         npm run bundle:ios
+        node gutenberg/node_modules/react-native/scripts/compose-source-maps.js bundle/ios/App.text.js.map bundle/ios/App.js.map -o bundle/ios/App.composed.js.map
 
         echo "--- :arrow_up: Upload iOS bundle artifact"
         buildkite-agent artifact upload bundle/ios/App.js
+        buildkite-agent artifact upload bundle/ios/App.composed.js.map
   - label: "Build Android RN Aztec & Publish to S3"
     key: "publish-react-native-aztec-android"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,19 +44,27 @@ steps:
 
         echo "--- :android: Build Android bundle"
         npm run bundle:android
-        node gutenberg/node_modules/react-native/scripts/compose-source-maps.js bundle/android/App.text.js.map bundle/android/App.js.map -o bundle/android/App.composed.js.map
 
         echo "--- :arrow_up: Upload Android bundle artifact"
         buildkite-agent artifact upload bundle/android/App.js
-        buildkite-agent artifact upload bundle/android/App.composed.js.map
+
+        if [[ -n "$BUILDKITE_TAG" ]]; then
+          echo "--- :arrow_up: Upload Android source map"
+          node gutenberg/node_modules/react-native/scripts/compose-source-maps.js bundle/android/App.text.js.map bundle/android/App.js.map -o bundle/android/App.composed.js.map
+          buildkite-agent artifact upload bundle/android/App.composed.js.map
+        fi
 
         echo "--- :ios: Build iOS bundle"
         npm run bundle:ios
-        node gutenberg/node_modules/react-native/scripts/compose-source-maps.js bundle/ios/App.text.js.map bundle/ios/App.js.map -o bundle/ios/App.composed.js.map
 
         echo "--- :arrow_up: Upload iOS bundle artifact"
         buildkite-agent artifact upload bundle/ios/App.js
-        buildkite-agent artifact upload bundle/ios/App.composed.js.map
+
+        if [[ -n "$BUILDKITE_TAG" ]]; then
+          echo "--- :arrow_up: Upload iOS source map"
+          node gutenberg/node_modules/react-native/scripts/compose-source-maps.js bundle/ios/App.text.js.map bundle/ios/App.js.map -o bundle/ios/App.composed.js.map
+          buildkite-agent artifact upload bundle/ios/App.composed.js.map
+        fi
   - label: "Build Android RN Aztec & Publish to S3"
     key: "publish-react-native-aztec-android"
     plugins:


### PR DESCRIPTION
**Related to https://github.com/wordpress-mobile/gutenberg-mobile/issues/6023.**

This PR adds steps to the build workflow to upload the source maps to Buildkite. This way we'll store the most accurate source maps of bundle produced in CI. When symbolicating a stack trace, it's important to use the same source maps produced for the bundle used in the app. Otherwise, the stack trace will point to the wrong source code position.

As a side note, I compared a symbolicated stack trace between a source map generated locally and the one from the CI job and confirmed they don't match.

Currently, two source map files are produced when generating the bundle:
- `App.js.map`: Source map of the bytecode source.
- `App.text.js.map`: Source map of the javascript code.

They can be composed using a script provided by React Native ([`react-native/scripts/compose-source-maps.js`](https://github.com/facebook/react-native/blob/v0.71.11/scripts/compose-source-maps.js)) to simplify the process of symbolicating a stack trace. Further information about source maps and Hermes can be found in [Sentry documentation](https://docs.sentry.io/platforms/react-native/manual-setup/hermes/).

**To test:**
* Observe that all CI succeed.
* Check the `buildkite/gutenberg-mobile/build-js-bundles` job and observe in the Artifacts tab that it generated the following files:
<img width="400" alt="Screenshot 2023-08-04 at 15 23 36" src="https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/e906e316-ee5d-4a58-a817-ab65ab56a346">


PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
