### PR TITLE
Add crop option when taking a screenshot in e2e tests

### DIFF
--- a/__device-tests__/utils.js
+++ b/__device-tests__/utils.js
@@ -51,22 +51,17 @@ export async function takeScreenshotByElement( element, { padding } = {} ) {
  *
  * @typedef {Object} CropScreenshot
  *
- * @property {number}         x                          X offset, in pixels.
- * @property {number}         y                          Y offset, in pixels.
- * @property {number}         width                      Width, in pixels.
- * @property {number}         height                     Height, in pixels.
+ * @property {number}         x                         X offset, in pixels.
+ * @property {number}         y                         Y offset, in pixels.
+ * @property {number}         width                     Width, in pixels.
+ * @property {number}         height                    Height, in pixels.
  *
- * @param    {Object}         options                    Options
- * @param    {boolean}        [options.withoutKeyboard]  Prevents showing the keyboard in the screenshot.
- * @param    {number}         [options.heightPercentage] Specify a custom height in percentage.
- * @param    {CropScreenshot} [options.crop]             Specify values to crop the screenshot.
+ * @param    {Object}         options                   Options
+ * @param    {boolean}        [options.withoutKeyboard] Prevents showing the keyboard in the screenshot.
+ * @param    {CropScreenshot} [options.crop]            Specify values to crop the screenshot.
  * @return {Buffer} Sreenshot image.
  */
-export async function takeScreenshot( {
-	withoutKeyboard,
-	heightPercentage,
-	crop,
-} = {} ) {
+export async function takeScreenshot( { withoutKeyboard, crop } = {} ) {
 	const iPadDevice = process.env.IPAD;
 	const sessionCapabilities = await editorPage.driver.sessionCapabilities();
 	const { pixelRatio } = sessionCapabilities;
@@ -121,14 +116,6 @@ export async function takeScreenshot( {
 				toolbarLocation.y + toolbarSize.height - statusBarHeight
 			);
 		}
-	}
-
-	// Custom height in percentage
-	if ( heightPercentage ) {
-		finalSize.height = Math.min(
-			finalSize.height,
-			( heightPercentage * imageHeight ) / 100
-		);
 	}
 
 	// Crop image

--- a/__device-tests__/utils.js
+++ b/__device-tests__/utils.js
@@ -49,25 +49,25 @@ export async function takeScreenshotByElement( element, { padding } = {} ) {
 /**
  * Helper to take a screenshot and manipulate it.
  *
- * @param {Object}  options                    Options
- * @param {boolean} [options.withoutKeyboard]  Prevents showing the keyboard in the screenshot.
- * @param {number}  [options.heightPercentage] Specify a custom height in percentage.
- * @param {Object}  [options.crop]             Specify values to crop the screenshot.
- * @param {number}  [options.crop.x]           X offset to crop.
- * @param {number}  [options.crop.y]           Y offset to crop.
- * @param {number}  [options.crop.width]       Width offset to crop.
- * @param {number}  [options.crop.height]      Height offset to crop.
+ * @typedef {Object} CropScreenshot
+ *
+ * @property {number}         x                          X offset, in pixels.
+ * @property {number}         y                          Y offset, in pixels.
+ * @property {number}         width                      Width, in pixels.
+ * @property {number}         height                     Height, in pixels.
+ *
+ * @param    {Object}         options                    Options
+ * @param    {boolean}        [options.withoutKeyboard]  Prevents showing the keyboard in the screenshot.
+ * @param    {number}         [options.heightPercentage] Specify a custom height in percentage.
+ * @param    {CropScreenshot} [options.crop]             Specify values to crop the screenshot.
  * @return {Buffer} Sreenshot image.
  */
-export async function takeScreenshot(
-	options = {
-		withoutKeyboard: false,
-		heightPercentage: undefined,
-		crop: undefined,
-	}
-) {
+export async function takeScreenshot( {
+	withoutKeyboard,
+	heightPercentage,
+	crop,
+} = {} ) {
 	const iPadDevice = process.env.IPAD;
-	const { withoutKeyboard, heightPercentage, crop } = options;
 	const sessionCapabilities = await editorPage.driver.sessionCapabilities();
 	const { pixelRatio } = sessionCapabilities;
 

--- a/__device-tests__/utils.js
+++ b/__device-tests__/utils.js
@@ -6,6 +6,47 @@ import jimp from 'jimp';
 const { isAndroid } = e2eUtils;
 
 /**
+ * Helper to take a screenshot of an element.
+ *
+ * @param {*}      element           Element instance.
+ * @param {Object} options           Options
+ * @param {number} [options.padding] Padding offset to apply to the screenshot.
+ * @return {Buffer} Sreenshot image.
+ */
+export async function takeScreenshotByElement( element, { padding } = {} ) {
+	const sessionCapabilities = await editorPage.driver.sessionCapabilities();
+	const { pixelRatio } = sessionCapabilities;
+
+	const location = await element.getLocation();
+	const size = await element.getSize();
+	const crop = {
+		x: location.x,
+		y: location.y,
+		width: size.width,
+		height: size.height,
+	};
+	// Location and size value are in pixels on iOS, we need to
+	// convert them to device coordinates.
+	if ( ! isAndroid() ) {
+		crop.x *= pixelRatio;
+		crop.y *= pixelRatio;
+		crop.width *= pixelRatio;
+		crop.height *= pixelRatio;
+	}
+	if ( padding ) {
+		// The padding value is in pixels, so we need to convert
+		// it to device coordinates.
+		padding *= pixelRatio;
+
+		crop.x -= padding;
+		crop.y -= padding;
+		crop.width += padding * 2;
+		crop.height += padding * 2;
+	}
+	return takeScreenshot( { crop } );
+}
+
+/**
  * Helper to take a screenshot and manipulate it.
  *
  * @param {Object}  options                    Options

--- a/__device-tests__/utils.js
+++ b/__device-tests__/utils.js
@@ -53,10 +53,10 @@ export async function takeScreenshotByElement( element, { padding } = {} ) {
  * @param {boolean} [options.withoutKeyboard]  Prevents showing the keyboard in the screenshot.
  * @param {number}  [options.heightPercentage] Specify a custom height in percentage.
  * @param {Object}  [options.crop]             Specify values to crop the screenshot.
- * @param {number}  [options.offset.x]         X offset to crop.
- * @param {number}  [options.offset.y]         Y offset to crop.
- * @param {number}  [options.offset.width]     Width offset to crop.
- * @param {number}  [options.offset.height]    Height offset to crop.
+ * @param {number}  [options.crop.x]           X offset to crop.
+ * @param {number}  [options.crop.y]           Y offset to crop.
+ * @param {number}  [options.crop.width]       Width offset to crop.
+ * @param {number}  [options.crop.height]      Height offset to crop.
  * @return {Buffer} Sreenshot image.
  */
 export async function takeScreenshot(

--- a/__device-tests__/utils.js
+++ b/__device-tests__/utils.js
@@ -84,9 +84,8 @@ export async function takeScreenshot(
 	const base64Image = Buffer.from( screenshot, 'base64' );
 	const image = await jimp.read( base64Image );
 
-	const windowSize = await editorPage.driver.getWindowSize();
 	const imageWidth = image.getWidth();
-	const imageHeight = isAndroid() ? windowSize.height : image.getHeight();
+	const imageHeight = image.getHeight();
 
 	// We use this variable to store the final image size after applying cropping actions
 	const finalSize = {


### PR DESCRIPTION
This PR introduces a new option to crop the screenshots taken in e2e tests. Additionally, a new util has been added to take screenshots of specific elements. This will be very handy to produce screenshots of smaller areas of the editor, as well as make them more resilient to device specifics, like size, safe area, and status bar.

<details><summary>Here are some examples using the test file referenced below</summary>

| Android | iOS - iPhone | iOS - iPad |
|--------|--------|--------|
| **Title element:**<br><br>![gutenberg-editor-test-visual-test-js-test-1-android](https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/c1a17865-b8e7-4aa7-aeb1-796d736e6a87) | **Title element:**<br><br>![gutenberg-editor-test-visual-test-js-test-1-ios](https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/a551d957-d811-4574-a127-dd838d533dc3) | **Title element:**<br><br>![gutenberg-editor-test-visual-test-js-test-1-ios](https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/603cd246-77bb-4e36-a09e-b392678dde35) |
| **Toolbar element:**<br><br>![gutenberg-editor-test-visual-test-js-test-2-android](https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/7db770cc-cb78-4f59-a3bc-869e1477cbba) | **Toolbar element:**<br><br>![gutenberg-editor-test-visual-test-js-test-2-ios](https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/74e0df64-f7ee-4d0b-8ac8-b533b96ec3cc) | **Toolbar element:**<br><br>![gutenberg-editor-test-visual-test-js-test-2-ios](https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/fc326f38-549e-4fe9-ba65-d526d38f80dc) |
| **Shortcode block:**<br><br>![gutenberg-editor-test-visual-test-js-test-3-android](https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/1ca85228-d469-4242-9dcc-7003363b46bf) | **Shortcode block:**<br><br>![gutenberg-editor-test-visual-test-js-test-3-ios](https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/8ae66744-8b83-49d3-9a68-86d7c6553145) | **Shortcode block:**<br><br>![gutenberg-editor-test-visual-test-js-test-3-ios](https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/1514e8e8-4b68-469a-8438-e6a64ee656a7) |
| **Shortcode block with extra padding:**<br><br>![gutenberg-editor-test-visual-test-js-test-4-android](https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/30e7b11d-8276-4107-8e97-e8fda005a9e6) | **Shortcode block with extra padding:**<br><br>![gutenberg-editor-test-visual-test-js-test-4-ios](https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/0fd10a1e-4f86-4ddd-8084-c6b5fd91c6c2) | **Shortcode block with extra padding:**<br><br>![gutenberg-editor-test-visual-test-js-test-4-ios](https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/31701435-bf65-4b93-bcae-48311500750c) |
| **Full screen:**<br><br>![gutenberg-editor-test-visual-test-js-test-5-android](https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/f3654315-1a05-48b7-9df5-7a726f46af45) | **Full screen:**<br><br>![gutenberg-editor-test-visual-test-js-test-5-ios](https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/139624c6-86fb-4cdd-8a5d-eb3ba8e84f65) | **Full screen:**<br><br>![gutenberg-editor-test-visual-test-js-test-5-ios](https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/60f7c8d6-3899-4605-9882-50a3d69b1339) | 
| **Full screen without keyboard:**<br><br>![gutenberg-editor-test-visual-test-js-test-6-android](https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/b5692f07-2d93-4ca9-9471-0c1574b1c499) | **Full screen without keyboard:**<br><br>![gutenberg-editor-test-visual-test-js-test-6-ios](https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/8ba832a6-0041-4bff-9805-6e7f23ed365b) | **Full screen without keyboard:**<br><br>![gutenberg-editor-test-visual-test-js-test-6-ios](https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/161ccc42-a380-433e-9579-3107fbc3d4d4) |
| **Specific position:**<br><br>![gutenberg-editor-test-visual-test-js-test-8-android](https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/8acef67d-3239-4e02-8280-fbb27f3c91aa) | **Specific position:**<br><br>![gutenberg-editor-test-visual-test-js-test-8-ios](https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/e6794820-4913-4658-bbc6-de5e0108c7b0) | **Specific position:**<br><br>![gutenberg-editor-test-visual-test-js-test-8-ios](https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/5dfc06ab-c2e5-472c-bc3b-c48cf27293b3) |
| **Specific height:**<br><br>![gutenberg-editor-test-visual-test-js-test-9-android](https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/5b27cc98-3fbb-494e-99dc-013e18984203) | **Specific height:**<br><br>![gutenberg-editor-test-visual-test-js-test-9-ios](https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/6d68ea09-07d9-47ee-bbe9-68af16785b7c) | **Specific height:**<br><br>![gutenberg-editor-test-visual-test-js-test-9-ios](https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/278da0fe-80c3-4e6d-8bc9-e9b643074766) |
| **Specific width:**<br><br><img src=https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/ff762d13-2fbf-45ae-9c2e-541fba527b5e height=300> | **Specific width:**<br><br><img src=https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/d567e1f2-a674-41b3-91c3-6519379c6893 height=300> | **Specific width:**<br><br><img src=https://github.com/wordpress-mobile/gutenberg-mobile/assets/14905380/67a3007d-aa49-4637-b039-8de766079a57 height=300> |

</details> 

## To test
### CI jobs pass
* Observe that all tests pass, including the optional tests.

### Test new util `takeScreenshotByElement`
* Apply the following patch that incorporates a new test only for debugging.
```patch
diff --git forkSrcPrefix/__device-tests__/gutenberg-editor-test-visual.test.js forkDstPrefix/__device-tests__/gutenberg-editor-test-visual.test.js
new file mode 100644
index 0000000000000000000000000000000000000000..39bd5e02c1ab218a61c31de9ef38229a9c0ba16c
--- /dev/null
+++ forkDstPrefix/__device-tests__/gutenberg-editor-test-visual.test.js
@@ -0,0 +1,65 @@
+/**
+ * Internal dependencies
+ */
+const { blockNames } = editorPage;
+import { takeScreenshot, takeScreenshotByElement } from './utils';
+
+it( 'test', async () => {
+	// Add Shortcode block
+	await editorPage.addNewBlock( blockNames.shortcode );
+	const shortcodeBlock = await editorPage.getBlockAtPosition(
+		blockNames.shortcode
+	);
+	await shortcodeBlock.click();
+	await editorPage.driver.sleep( 500 );
+	// Take screenshots:
+	// - Title
+	expect(
+		await takeScreenshotByElement( await editorPage.getTitleElement() )
+	).toMatchImageSnapshot();
+	// - Toolbar
+	expect(
+		await takeScreenshotByElement( await editorPage.getToolbar() )
+	).toMatchImageSnapshot();
+	// - Shortcode block
+	expect(
+		await takeScreenshotByElement( shortcodeBlock )
+	).toMatchImageSnapshot();
+	// - Shortcode block with extra padding
+	expect(
+		await takeScreenshotByElement( shortcodeBlock, {
+			padding: 10,
+		} )
+	).toMatchImageSnapshot();
+	// - Full screen
+	expect( await takeScreenshot() ).toMatchImageSnapshot();
+	// - Full screen without keyboard
+	expect(
+		await takeScreenshot( {
+			withoutKeyboard: true,
+		} )
+	).toMatchImageSnapshot();
+	// - Specific position
+	expect(
+		await takeScreenshot( {
+			crop: {
+				x: 0,
+				y: 200,
+				width: 300,
+				height: 300,
+			},
+		} )
+	).toMatchImageSnapshot();
+	// - Specific height
+	expect(
+		await takeScreenshot( {
+			crop: { x: 0, y: 0, height: 300 },
+		} )
+	).toMatchImageSnapshot();
+	// - Specific width
+	expect(
+		await takeScreenshot( {
+			crop: { width: 200 },
+		} )
+	).toMatchImageSnapshot();
+} );
``` 
* Run e2e tests on both platforms and check that generated screenshots match the expectations (see inline comments added to each `expect` statement).


PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
