### PR TITLE
Remove `--unsafe-perm` option from `npm ci` in Buildkite to run fast

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -34,7 +34,7 @@ steps:
       nvm install && nvm use
 
       echo "--- :npm: Install Node dependencies"
-      npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
+      npm ci --prefer-offline --no-audit --no-progress
 
       echo "--- :node: Lint and Unit Tests"
       ./bin/ci-checks-js.sh
@@ -57,7 +57,7 @@ steps:
         nvm install && nvm use
 
         echo "--- :npm: Install Node dependencies"
-        npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
+        npm ci --prefer-offline --no-audit --no-progress
 
         echo "--- :package: Run bundle prep work"
         npm run prebundle:js


### PR DESCRIPTION
After some poking around (see #6041) I noticed CircleCI doesn't pass the `--unsafe-perm` option to `npm ci`. I tried the same command on the Buildkite setup and... ta-da we went from ~8m to ~1m

#### Before 
![image](https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/9694c0b3-4e1d-4574-b189-db2d51c91a76)

#### After
![image](https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/34328495-9b4f-440f-a8f3-cf5fc022337a)

### Why?

_TBD_

**To test:** Ensure CI is green and "fast" in Buildkite.

---

PR submission checklist:

- [x] I have considered adding unit tests where possible. – N.A.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary. – N.A.
