### PR TITLE
Add `cache-builder.yml` pipeline

### DIFF
--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -5,7 +5,7 @@
 # It's meant to rebuild various CI caches on a periodic async basis, so as
 # not to waste time on every CI job updating the cache.
 
-common_params:
+x-common-params:
   - &common_plugins
     - automattic/a8c-ci-toolkit#2.18.2
     - automattic/git-s3-cache#1.1.4:

--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -1,0 +1,23 @@
+# This pipeline runs via Buildkite's scheduled jobs feature.
+#
+# It's meant to rebuild various CI caches on a periodic async basis, so as
+# not to waste time on every CI job updating the cache.
+
+common_params:
+  - &common_plugins
+    - automattic/a8c-ci-toolkit#2.18.2
+    - automattic/git-s3-cache#1.1.4:
+        bucket: a8c-repo-mirrors
+        repo: automattic/gutenber-mobile/
+
+steps:
+  # Build the Git Repo cache
+  #
+  # Because this repo is so large, we periodically create a Git Mirror and copy it to S3,
+  # from where it can be fetched by agents more quickly than from GitHub, and so that
+  # agents then have less new commits to `git pull` by using that cache as starting point
+  - label: ':git: Rebuild git cache'
+    command: cache_repo a8c-repo-mirrors
+    plugins: *common_plugins
+    agents:
+      queue: default

--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
 # This pipeline runs via Buildkite's scheduled jobs feature.
 #
 # It's meant to rebuild various CI caches on a periodic async basis, so as

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,9 @@
 x-common-params:
-  - &git-shallow-clone-plugin
-    automattic/git-shallow-clone#trunk
+  - &git-cache-plugin
+    automattic/git-s3-cache#1.1.4:
+      # Ensure these settings match what's defined in cache-builder.yml
+      bucket: a8c-repo-mirrors
+      repo: automattic/gutenber-mobile/
   - &publish-android-artifacts-docker-container
     docker#v3.8.0:
       image: "public.ecr.aws/automattic/android-build-image:v1.3.0"
@@ -18,7 +21,7 @@ steps:
   - label: "Build JS Bundles"
     key: "js-bundles"
     plugins:
-      - *git-shallow-clone-plugin
+      - *git-cache-plugin
       - docker#v3.8.0:
           image: "public.ecr.aws/automattic/gb-mobile-image:latest"
           environment:
@@ -68,7 +71,7 @@ steps:
   - label: "Build Android RN Aztec & Publish to S3"
     key: "publish-react-native-aztec-android"
     plugins:
-      - *git-shallow-clone-plugin
+      - *git-cache-plugin
       - *publish-android-artifacts-docker-container
     command: |
         .buildkite/publish-react-native-aztec-android-artifacts.sh
@@ -78,7 +81,7 @@ steps:
       - "js-bundles"
       - "publish-react-native-aztec-android"
     plugins:
-      - *git-shallow-clone-plugin
+      - *git-cache-plugin
       - *publish-android-artifacts-docker-container
     command: |
         .buildkite/publish-react-native-bridge-android-artifacts.sh
@@ -90,7 +93,7 @@ steps:
       - ios-xcframework/build/xcframeworks/*.tar.gz
     plugins:
       - automattic/a8c-ci-toolkit#2.18.2
-      - *git-shallow-clone-plugin
+      - *git-cache-plugin
     agents:
       queue: mac
     env:


### PR DESCRIPTION
This pipeline will be used by a scheduled job on Buildkite without further changes require in this repo.

To test: See this manually scheduled build: https://buildkite.com/automattic/gutenberg-mobile/builds/6790

<img width="1179" alt="image" src="https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/9c32cd64-b5f3-4232-bb57-d78091d298d6">

_The warning is expected, given this was the first cache ever 😄_

---

PR submission checklist:

- [x] I have considered adding unit tests where possible. – N.A.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary. – N.A.
