### PR TITLE
Add test case for Contact Info block

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -23,3 +23,11 @@ jest.mock(
 		getHostAppNamespace: jest.fn(),
 	} )
 );
+
+// The module `yjs` throws an error if it's imported more than once.
+// This module is only used in the `@wordpress/sync` package which is not used
+// by the native version. Due to the nature of some of the tests and the need to
+// re-importing modules, we have to explicitly mock the module to avoid disruptions
+// when running tests.
+// Reference: https://t.ly/w4zVe
+jest.mock( 'yjs' );

--- a/src/test/contact-info/__snapshots__/edit.js.snap
+++ b/src/test/contact-info/__snapshots__/edit.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Contact Info block should successfully insert the block into the editor 1`] = `
+"<!-- wp:jetpack/contact-info -->
+<div class="wp-block-jetpack-contact-info"><!-- wp:jetpack/email /-->
+
+<!-- wp:jetpack/phone /-->
+
+<!-- wp:jetpack/address /--></div>
+<!-- /wp:jetpack/contact-info -->"
+`;

--- a/src/test/contact-info/edit.js
+++ b/src/test/contact-info/edit.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import {
+	getEditorHtml,
+	initializeEditor,
+	addBlock,
+	getBlock,
+	setupCoreBlocks,
+} from 'test/helpers';
+
+/**
+ * Internal dependencies
+ */
+import {
+	registerJetpackBlocks,
+	setupJetpackEditor,
+} from '../../jetpack-editor-setup';
+
+setupCoreBlocks();
+
+beforeAll( () => {
+	// Register Jetpack blocks
+	setupJetpackEditor( {
+		blogId: 1,
+		isJetpackActive: true,
+	} );
+	registerJetpackBlocks( {
+		capabilities: {
+			contactInfoBlock: true,
+		},
+	} );
+} );
+
+describe( 'Contact Info block', () => {
+	it( 'should successfully insert the block into the editor', async () => {
+		const screen = await initializeEditor();
+
+		// Add block
+		await addBlock( screen, 'Contact Info' );
+
+		// Get block
+		const block = await getBlock( screen, 'Contact Info' );
+		expect( block ).toBeVisible();
+
+		expect( getEditorHtml() ).toMatchSnapshot();
+	} );
+} );

--- a/src/test/contact-info/edit.js
+++ b/src/test/contact-info/edit.js
@@ -42,8 +42,8 @@ describe( 'Contact Info block', () => {
 
 		// Get block
 		const block = await getBlock( screen, 'Contact Info' );
-		expect( block ).toBeVisible();
 
+		expect( block ).toBeVisible();
 		expect( getEditorHtml() ).toMatchSnapshot();
 	} );
 } );

--- a/src/test/contact-info/edit.js
+++ b/src/test/contact-info/edit.js
@@ -7,6 +7,7 @@ import {
 	addBlock,
 	getBlock,
 	setupCoreBlocks,
+	screen,
 } from 'test/helpers';
 
 /**
@@ -34,7 +35,7 @@ beforeAll( () => {
 
 describe( 'Contact Info block', () => {
 	it( 'should successfully insert the block into the editor', async () => {
-		const screen = await initializeEditor();
+		await initializeEditor();
 
 		// Add block
 		await addBlock( screen, 'Contact Info' );


### PR DESCRIPTION
**Related PR:**
* https://github.com/WordPress/gutenberg/pull/53464

Introduces an integration test to cover the insertion of the Contact Info block.

**NOTE:** On [a separate PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/6044/commits/d66a0f09d6b762f8363a9022ef5b33e4bf68d781), I'll remove the E2E test associated with this block.

**To test:**
* Observe that all CI jobs pass.
* Run the command `npm run test` and observe that all tests pass.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
