### PR TITLE
Fix typo in Git cache Buildkite configuration

### DIFF
--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -10,7 +10,7 @@ x-common-params:
     - automattic/a8c-ci-toolkit#2.18.2
     - automattic/git-s3-cache#1.1.4:
         bucket: a8c-repo-mirrors
-        repo: automattic/gutenber-mobile/
+        repo: automattic/gutenberg-mobile/
 
 steps:
   # Build the Git Repo cache

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ x-common-params:
     automattic/git-s3-cache#1.1.4:
       # Ensure these settings match what's defined in cache-builder.yml
       bucket: a8c-repo-mirrors
-      repo: automattic/gutenber-mobile/
+      repo: automattic/gutenberg-mobile/
   - &publish-android-artifacts-docker-container
     docker#v3.8.0:
       image: "public.ecr.aws/automattic/android-build-image:v1.3.0"


### PR DESCRIPTION
You might have noticed warnings about the repo cache in Buidkite recently, e.g.:

<img width="1196" alt="image" src="https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/9020530a-24a0-48c7-bdf7-ae0b34398164">

Those were introduced after setting up the repo cache in S3 via #6048 except... _I made typo_ 🤦‍♂️ So, while the cache was successfully created using the `gutenberg-mobile` key, the pipelines where looking for a cache with the key `gutenber-mobile.

## To test

Verify this PR doesn't show the cache warning in CI:

<img width="1213" alt="image" src="https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/6ef3a8d2-e9d0-4c7b-976a-fc2a741451e5">

_No failures_ 😄 

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
