### PR TITLE
Add xcframework:setup script to package.json

### DIFF
--- a/bin/xcframework-setup
+++ b/bin/xcframework-setup
@@ -1,0 +1,14 @@
+#!/bin/bash -eu
+
+pushd ios-xcframework || exit 1
+
+# The React Native setup process generates files as part of running CocoaPods.
+# Sometimes, having existing generated files results in build issues later on.
+# Therefore, it's best to remove them.
+rm -rf build/generated
+
+bundle install
+
+bundle exec pod install
+
+popd || exit 1

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
 		"lint": "eslint . --ext .js",
 		"lint:fix": "npm run lint -- --fix",
 		"xcframework:setup": "./bin/xcframework-setup",
+		"xcframework:build": "npm run xcframework:setup && pushd ./ios-xcframework && ./build.sh && popd",
 		"version": "npm run bundle && git add -A bundle"
 	},
 	"dependencies": {}

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
 		"clean:i18n": "rm -rf src/i18n-cache && npm run i18n:check-cache",
 		"lint": "eslint . --ext .js",
 		"lint:fix": "npm run lint -- --fix",
+		"xcframework:setup": "./bin/xcframework-setup",
 		"version": "npm run bundle && git add -A bundle"
 	},
 	"dependencies": {}


### PR DESCRIPTION
There are some gotchas in how to setup the XCFramework environment. Best to document and automate them via a script.

See conversation at https://github.com/wordpress-mobile/gutenberg-mobile/pull/6061#issuecomment-1680532174

## Development notes

While I'm relatively positive about the sequence of commands to run, I'm not sure whether putting then as scripts entries in `package.json` is the most appropriate thing to do. If there's a more idiomatic or conventional way in the context of this project, please let me know.

## Testing

Run `npm run xcframework:setup` and `npm run xcframework:build` locally and verify they succeed.

PR submission checklist:

- [x] I have considered adding unit tests where possible. – N.A.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary. – N.A.
