### PR TITLE
feat: Register the Paywall block

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 Unreleased
 ---
 * [*] Search Control - Prevent calling TextInput's methods when undefined [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6090]
+* [**] Add basic support to view, relocate, and remove the Jetpack Paywall block. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6076]
 
 1.102.0
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
 		},
 		"gutenberg/packages/babel-plugin-import-jsx-pragma": {
 			"name": "@wordpress/babel-plugin-import-jsx-pragma",
-			"version": "4.22.0",
+			"version": "4.23.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -75,7 +75,7 @@
 		},
 		"gutenberg/packages/babel-preset-default": {
 			"name": "@wordpress/babel-preset-default",
-			"version": "7.23.0",
+			"version": "7.24.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -98,7 +98,7 @@
 		},
 		"gutenberg/packages/browserslist-config": {
 			"name": "@wordpress/browserslist-config",
-			"version": "5.22.0",
+			"version": "5.23.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -107,7 +107,7 @@
 		},
 		"gutenberg/packages/element": {
 			"name": "@wordpress/element",
-			"version": "5.16.0",
+			"version": "5.17.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -160,7 +160,7 @@
 		},
 		"gutenberg/packages/escape-html": {
 			"name": "@wordpress/escape-html",
-			"version": "2.39.0",
+			"version": "2.40.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -172,7 +172,7 @@
 		},
 		"gutenberg/packages/eslint-plugin": {
 			"name": "@wordpress/eslint-plugin",
-			"version": "14.12.0",
+			"version": "15.0.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -422,7 +422,7 @@
 		},
 		"gutenberg/packages/prettier-config": {
 			"name": "@wordpress/prettier-config",
-			"version": "2.22.0",
+			"version": "2.23.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -434,7 +434,7 @@
 		},
 		"gutenberg/packages/warning": {
 			"name": "@wordpress/warning",
-			"version": "2.39.0",
+			"version": "2.40.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
 		},
 		"gutenberg/packages/babel-plugin-import-jsx-pragma": {
 			"name": "@wordpress/babel-plugin-import-jsx-pragma",
-			"version": "4.23.0",
+			"version": "4.22.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -75,7 +75,7 @@
 		},
 		"gutenberg/packages/babel-preset-default": {
 			"name": "@wordpress/babel-preset-default",
-			"version": "7.24.0",
+			"version": "7.23.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -98,7 +98,7 @@
 		},
 		"gutenberg/packages/browserslist-config": {
 			"name": "@wordpress/browserslist-config",
-			"version": "5.23.0",
+			"version": "5.22.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -107,7 +107,7 @@
 		},
 		"gutenberg/packages/element": {
 			"name": "@wordpress/element",
-			"version": "5.17.0",
+			"version": "5.16.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -160,7 +160,7 @@
 		},
 		"gutenberg/packages/escape-html": {
 			"name": "@wordpress/escape-html",
-			"version": "2.40.0",
+			"version": "2.39.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -172,7 +172,7 @@
 		},
 		"gutenberg/packages/eslint-plugin": {
 			"name": "@wordpress/eslint-plugin",
-			"version": "15.0.0",
+			"version": "14.12.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -422,7 +422,7 @@
 		},
 		"gutenberg/packages/prettier-config": {
 			"name": "@wordpress/prettier-config",
-			"version": "2.23.0",
+			"version": "2.22.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -434,7 +434,7 @@
 		},
 		"gutenberg/packages/warning": {
 			"name": "@wordpress/warning",
-			"version": "2.40.0",
+			"version": "2.39.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {

--- a/src/block-support/supported-blocks.json
+++ b/src/block-support/supported-blocks.json
@@ -31,11 +31,12 @@
 		"core/block",
 		"jetpack/contact-info",
 		"jetpack/email",
+		"jetpack/paywall",
 		"jetpack/phone",
 		"jetpack/address",
 		"videopress/video"
 	],
-	"devOnly": [ "core/code", "jetpack/paywall", "jetpack/tiled-gallery" ],
+	"devOnly": [ "core/code", "jetpack/tiled-gallery" ],
 	"iOSOnly": [],
 	"androidOnly": []
 }

--- a/src/block-support/supported-blocks.json
+++ b/src/block-support/supported-blocks.json
@@ -35,7 +35,7 @@
 		"jetpack/address",
 		"videopress/video"
 	],
-	"devOnly": [ "core/code", "jetpack/tiled-gallery" ],
+	"devOnly": [ "core/code", "jetpack/paywall", "jetpack/tiled-gallery" ],
 	"iOSOnly": [],
 	"androidOnly": []
 }

--- a/src/initial-html.js
+++ b/src/initial-html.js
@@ -1,4 +1,6 @@
 export default `
+<!-- wp:jetpack/paywall /-->
+
 <!-- wp:jetpack/contact-info -->
 <div class="wp-block-jetpack-contact-info"><!-- wp:jetpack/email {"email":"me@wordpress.org"} -->
 <div class="wp-block-jetpack-email"><a href="mailto:me@wordpress.org">me@wordpress.org</a></div>

--- a/src/jetpack-editor-setup.js
+++ b/src/jetpack-editor-setup.js
@@ -25,7 +25,7 @@ const supportedJetpackBlocks = {
 		available: true,
 	},
 	paywall: {
-		available: __DEV__,
+		available: true,
 	},
 	story: {
 		available: true,

--- a/src/jetpack-editor-setup.js
+++ b/src/jetpack-editor-setup.js
@@ -24,6 +24,9 @@ const supportedJetpackBlocks = {
 	'contact-info': {
 		available: true,
 	},
+	paywall: {
+		available: __DEV__,
+	},
 	story: {
 		available: true,
 	},
@@ -89,6 +92,7 @@ export function registerJetpackBlocks( { capabilities } ) {
 		'jetpack/tiled-gallery'
 	);
 	hideBlockByCapability( capabilities.videoPressBlock, 'videopress/video' );
+	hideBlockByCapability( capabilities.paywallBlock, 'jetpack/paywall' );
 
 	// Register Jetpack blocks
 	require( '../jetpack/projects/plugins/jetpack/extensions/editor' );

--- a/src/jetpack-editor-setup.js
+++ b/src/jetpack-editor-setup.js
@@ -92,7 +92,8 @@ export function registerJetpackBlocks( { capabilities } ) {
 		'jetpack/tiled-gallery'
 	);
 	hideBlockByCapability( capabilities.videoPressBlock, 'videopress/video' );
-	hideBlockByCapability( capabilities.paywallBlock, 'jetpack/paywall' );
+	// Limit support to rendering the Paywall block, not inserting it.
+	dispatch( editPostStore ).hideBlockTypes( [ 'jetpack/paywall' ] );
 
 	// Register Jetpack blocks
 	require( '../jetpack/projects/plugins/jetpack/extensions/editor' );

--- a/src/test/jetpack-editor-setup.js
+++ b/src/test/jetpack-editor-setup.js
@@ -153,7 +153,10 @@ describe( 'Jetpack blocks', () => {
 			'core/edit-post',
 			'hiddenBlockTypes'
 		);
-		expect( hiddenBlockTypes ).toEqual( [ 'jetpack/contact-info' ] );
+		expect( hiddenBlockTypes ).toEqual( [
+			'jetpack/paywall',
+			'jetpack/contact-info',
+		] );
 	} );
 
 	it( "should not register Jetpack blocks if 'onlyCoreBlocks' capbility is on", () => {

--- a/src/test/jetpack-editor-setup.js
+++ b/src/test/jetpack-editor-setup.js
@@ -36,6 +36,7 @@ const defaultProps = {
 };
 const jetpackBlocks = [
 	'jetpack/contact-info',
+	'jetpack/paywall',
 	'jetpack/story',
 	'jetpack/tiled-gallery',
 	'videopress/video',
@@ -73,6 +74,7 @@ describe( 'Jetpack blocks', () => {
 		const expectedJetpackData = {
 			available_blocks: {
 				'contact-info': { available: true },
+				paywall: { available: true },
 				story: { available: true },
 				'tiled-gallery': { available: true },
 				'videopress/video': { available: true },
@@ -92,6 +94,9 @@ describe( 'Jetpack blocks', () => {
 		const blocksAPI = registerJetpackBlocksIsolated( defaultProps );
 		expect( console ).toHaveLoggedWith(
 			'Block jetpack/contact-info registered.'
+		);
+		expect( console ).toHaveLoggedWith(
+			'Block jetpack/paywall registered.'
 		);
 		expect( console ).toHaveLoggedWith( 'Block jetpack/story registered.' );
 		expect( console ).toHaveLoggedWith(
@@ -125,12 +130,16 @@ describe( 'Jetpack blocks', () => {
 			capabilities: {
 				mediaFilesCollectionBlock: true,
 				contactInfoBlock: false,
+				paywallBlock: true,
 				tiledGalleryBlock: true,
 				videoPressBlock: true,
 			},
 		} );
 		expect( console ).toHaveLoggedWith(
 			'Block jetpack/contact-info registered.'
+		);
+		expect( console ).toHaveLoggedWith(
+			'Block jetpack/paywall registered.'
 		);
 		expect( console ).toHaveLoggedWith( 'Block jetpack/story registered.' );
 		expect( console ).toHaveLoggedWith(

--- a/src/test/paywall/edit.native.js
+++ b/src/test/paywall/edit.native.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { screen, initializeEditor, setupCoreBlocks } from 'test/helpers';
+
+/**
+ * Internal dependencies
+ */
+import {
+	registerJetpackBlocks,
+	setupJetpackEditor,
+} from '../../jetpack-editor-setup';
+
+setupCoreBlocks();
+
+beforeAll( () => {
+	// Register Jetpack blocks
+	setupJetpackEditor( {
+		blogId: 1,
+		isJetpackActive: true,
+	} );
+	registerJetpackBlocks( { capabilities: {} } );
+} );
+
+describe( 'Paywall block', () => {
+	it( 'should render the expected label text', async () => {
+		await initializeEditor( {
+			initialHtml: '<!-- wp:jetpack/paywall /-->',
+		} );
+
+		expect(
+			screen.getByText( 'Exclusive content below this line' )
+		).toBeVisible();
+	} );
+} );


### PR DESCRIPTION
Register the Paywall block for the mobile editor. This enables rendering the Paywall block for posts that contain it, but the Paywall block is not available for insertion with the block inserter.

## Related PRs

* https://github.com/WordPress/gutenberg/pull/53883
* https://github.com/Automattic/jetpack/pull/32553
* https://github.com/wordpress-mobile/WordPress-iOS/pull/21359
* https://github.com/wordpress-mobile/WordPress-Android/pull/18998

## Testing Instructions

### Install a _Jetpack_ app prototype build ([Jetpack iOS](https://github.com/wordpress-mobile/WordPress-iOS/pull/21359#issuecomment-1682607689), [Jetpack Android](https://github.com/wordpress-mobile/WordPress-Android/pull/18998#issuecomment-1682552711)), and then...

**Paywall block render**
1. Create and save a post on the web containing a Paywall block: `<!-- wp:jetpack/paywall /-->`
2. Open the same post in the Jetpack mobile on iOS or Android. 
3. Verify the Paywall block renders and displays a "Exclusive content below this line" label. 

**Paywall block insertion disabled**
1. Open the mobile editor. 
2. Within a Paragraph block, type `/paywall`
3. Verify the Paywall block is not available. 
4. Tap the <kbd>+</kbd> button above the keyboard to open the mobile editor block inserter. 
5. Verify the Paywall block is not available. 

### Install a _WordPress_ app prototype build ([WPiOS](https://github.com/wordpress-mobile/WordPress-iOS/pull/21359#issuecomment-1682614391), [WPAndroid](https://github.com/wordpress-mobile/WordPress-Android/pull/18998#issuecomment-1682550810)), and then...

**Paywall block remains unsupported**
1. Create and save a post on the web containing a Paywall block: `<!-- wp:jetpack/paywall /-->`
2. Open the same post in the WordPress mobile editor on iOS or Android. 
3. Verify the Paywall block renders as "unsupported." 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
