### PR TITLE
Release 1.102.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,8 +3,8 @@ Unreleased
 
 1.102.0
 ---
-* [*] Add outline around selected Social Link block [https://github.com/WordPress/gutenberg/pull/53377]
-* [**] Fixed images not rendering in Help section on iOS [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6067]
+* [**] Add outline around selected Social Link block [https://github.com/WordPress/gutenberg/pull/53377]
+* [*] Display custom color value in mobile Cover Block color picker [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5852]
 * [**] Fixes font customization not getting updated on iOS [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6036]
 
 1.101.1

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,8 @@
 Unreleased
 ---
+
+1.102.0
+---
 * [*] Add outline around selected Social Link block [https://github.com/WordPress/gutenberg/pull/53377]
 * [**] Fixed images not rendering in Help section on iOS [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6067]
 * [**] Fixes font customization not getting updated on iOS [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6036]

--- a/ios-xcframework/Podfile.lock
+++ b/ios-xcframework/Podfile.lock
@@ -429,7 +429,7 @@ PODS:
     - React-RCTImage
   - RNSVG (13.9.0):
     - React-Core
-  - RNTAztecView (1.101.1):
+  - RNTAztecView (1.102.0):
     - React-Core
     - WordPress-Aztec-iOS (~> 1.19.8)
   - SDWebImage (5.11.1):
@@ -668,7 +668,7 @@ SPEC CHECKSUMS:
   RNReanimated: 21e1e71d7f1ac9f2fa11df37c06a8ec52ed06232
   RNScreens: e3ffdd78ff5afe8ec82c2566ee2410857ed5ce75
   RNSVG: 29dd0ac32d83774d4b0953ae92a5cd8205a782d7
-  RNTAztecView: 8e978a83876118ad4f40d8c04052e0b849005a29
+  RNTAztecView: 1ee3c83cf271dcda230fc83b97c8d27b6c8dc330
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg-mobile",
-	"version": "1.101.1",
+	"version": "1.102.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "gutenberg-mobile",
-			"version": "1.101.1",
+			"version": "1.102.0",
 			"hasInstallScript": true,
 			"devDependencies": {
 				"@babel/core": "^7.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg-mobile",
-	"version": "1.101.1",
+	"version": "1.102.0",
 	"private": true,
 	"config": {
 		"jsfiles": "./*.js src/*.js src/**/*.js src/**/**/*.js",


### PR DESCRIPTION
Release for Gutenberg Mobile 1.102.0

## Related PRs

- Gutenberg: https://github.com/WordPress/gutenberg/pull/53800
- WPAndroid: https://github.com/wordpress-mobile/WordPress-Android/pull/19003
- WPiOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/21367

## Extra PRs that Landed After the Release Was Cut

No extra PRs yet. 🎉

## Changes

<!-- To determine the changes you can check the RELEASE-NOTES.txt and gutenberg/packages/react-native-editor/CHANGELOG.md files and cross check with the list of commits that are part of the PR -->

### Change 1: Display custom color value in mobile Cover Block color picker
- **PR:** https://github.com/WordPress/gutenberg/pull/51414
- **Issue:** https://github.com/WordPress/gutenberg/issues/51283

When selecting a custom color in the Cover Block's picker, the color value was not displayed as a text or numerical value. This has now been fixed.

### Change 2: Display outline around selected Social Link block
- **PR:** https://github.com/WordPress/gutenberg/pull/53377

Block Outlines were updated in https://github.com/WordPress/gutenberg/pull/52702, with many outlines being removed. Design feedback indicated that a displaying an outline around the selected Social Link icon would help users to note which icon is selected.

### Change 3: Fix font customization not getting updated on iOS
- **PR:** https://github.com/WordPress/gutenberg/pull/53391

This changes fixes an issue that started to happen on iOS after the recent React Native upgrade, in which the post title and some other functionality related to custom font size and font styles like bold formatting wouldn't work as expected.

## Test plan

Once the installable builds of the main apps are ready, perform a quick smoke test of the editor on both iOS and Android to verify it launches without crashing. We will perform additional testing after the main apps cut their releases.

## Release Submission Checklist

- [ ] Verify Items from test plan have been completed
- [x] Check if `RELEASE-NOTES.txt` is updated with all the changes that made it to the release. Replace `Unreleased` section with the release version and create a new `Unreleased` section.
- [x] Check if `gutenberg/packages/react-native-editor/CHANGELOG.md` is updated with all the changes that made it to the release. Replace `## Unreleased` with the release version and create a new `## Unreleased`.
- [x] Bundle package of the release is updated.