### PR TITLE
Add initial-html-local configuration file

### DIFF
--- a/src/initial-html-local.js
+++ b/src/initial-html-local.js
@@ -1,0 +1,1 @@
+export default ``;

--- a/src/setup.js
+++ b/src/setup.js
@@ -8,6 +8,7 @@ import { initialHtmlGutenberg } from '@wordpress/react-native-editor';
  * Internal dependencies
  */
 import initialHtml from './initial-html';
+import initialHtmlLocal from './initial-html-local';
 import initAnalytics from './analytics';
 
 const setupHooks = () => {
@@ -29,6 +30,7 @@ const setupHooks = () => {
 
 				if ( initialData === undefined ) {
 					initialData = initialHtml + initialHtmlGutenberg;
+					// initialData = initialHtmlLocal;
 				}
 
 				return {

--- a/src/setup.js
+++ b/src/setup.js
@@ -8,6 +8,7 @@ import { initialHtmlGutenberg } from '@wordpress/react-native-editor';
  * Internal dependencies
  */
 import initialHtml from './initial-html';
+// eslint-disable-next-line no-unused-vars
 import initialHtmlLocal from './initial-html-local';
 import initAnalytics from './analytics';
 


### PR DESCRIPTION
Adds configuration file to support an empty or local initial HTML configuration for the demo editor content. 

To test:
Toggle initialHtmlLocal value by commenting and uncommenting these lines in setup.js:

https://github.com/wordpress-mobile/gutenberg-mobile/blob/8f6c4cd4d2b0388071dafa195641f030e45f3b75/src/setup.js#L31-L34

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
