### PR TITLE
Switch to Buildkite for lint and unit tests checks

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -46,6 +46,9 @@ steps:
     artifact_paths:
       - ./logs/*.log
       - ./reports/test-results/*.xml
+    notify:
+      - github_commit_status:
+          context: Lint and Unit Tests
 
   - label: "Build JS Bundles"
     depends_on: "unit-tests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ commands:
 
             SSH_CONFIG_DIR="$HOME/.ssh"
             echo "Using SSH Config Dir '$SSH_CONFIG_DIR'"
-            git --version 
+            git --version
 
             mkdir -p "$SSH_CONFIG_DIR"
             chmod 0700 "$SSH_CONFIG_DIR"
@@ -167,45 +167,6 @@ parameters:
     default: "ubuntu-2004:2022.10.1"
 
 jobs:
-  checks:
-    parameters:
-      platform:
-        type: string
-        default: ""
-      check-tests:
-        type: boolean
-        default: false
-      check-correctness:
-        type: boolean
-        default: false
-    machine:
-      image: << pipeline.parameters.linux-machine-image >>
-    steps:
-      - checkout-shallow
-      - checkout-submodules
-      - install-node-version
-      - when:
-          condition: <<parameters.check-correctness>>
-          steps:
-            - npm-install-full
-      - unless:
-          condition: <<parameters.check-correctness>>
-          steps:
-            - npm-install
-      - add-jest-reporter-dir
-      - run:
-          name: Set Environment Variables
-          command: |
-            echo 'export CHECK_CORRECTNESS=<<parameters.check-correctness>>' >> $BASH_ENV
-            echo 'export CHECK_TESTS=<<parameters.check-tests>>' >> $BASH_ENV
-            echo 'export TEST_RN_PLATFORM=<<parameters.platform>>' >> $BASH_ENV
-      - run:
-          name: Run Checks
-          command: bin/ci-checks-js.sh
-          environment:
-            JEST_JUNIT_OUTPUT_FILE: "reports/test-results/android-test-results.xml"
-      - store_test_results:
-          path: ./reports/test-results
   android-build:
     machine:
       image: << pipeline.parameters.linux-machine-image >>
@@ -383,17 +344,6 @@ jobs:
 workflows:
   gutenberg-mobile:
     jobs:
-      - checks:
-          name: Check Correctness
-          check-correctness: true
-      - checks:
-          name: Test iOS
-          platform: ios
-          check-tests: true
-      - checks:
-          name: Test Android
-          platform: android
-          check-tests: true
       - ios-build:
           name: iOS Build
       - android-build:
@@ -401,11 +351,11 @@ workflows:
       - ios-device-checks:
           name: Test iOS on Device - Canaries
           is-canary: "-canary"
-          requires: [ "Test iOS", "iOS Build" ]
+          requires: [ "iOS Build" ]
       - android-device-checks:
           name: Test Android on Device - Canaries
           is-canary: "-canary"
-          requires: [ "Test Android", "Android Native Unit Tests", "Android Build" ]
+          requires: [ "Android Native Unit Tests", "Android Build" ]
       - android-native-unit-tests:
           name: Android Native Unit Tests
       # For regular branches the full test suite is optional.
@@ -419,7 +369,7 @@ workflows:
                 - /^release.*/
       - ios-device-checks:
           name: Test iOS on Device - Full (Manually triggered)
-          requires: [ "Optional UI Tests", "Test iOS", "iOS Build" ]
+          requires: [ "Optional UI Tests", "iOS Build" ]
           filters:
             branches:
               ignore:
@@ -429,7 +379,7 @@ workflows:
       - ios-device-checks:
           name: Test iOS on Device - iPad (Manually triggered)
           is-ipad: "-ipad"
-          requires: [ "Optional UI Tests", "Test iOS", "iOS Build" ]
+          requires: [ "Optional UI Tests", "iOS Build" ]
           filters:
             branches:
               ignore:
@@ -438,7 +388,7 @@ workflows:
                 - /^release.*/
       - android-device-checks:
           name: Test Android on Device - Full (Manually triggered)
-          requires: [ "Optional UI Tests", "Test Android", "Android Native Unit Tests", "Android Build" ]
+          requires: [ "Optional UI Tests", "Android Native Unit Tests", "Android Build" ]
           filters:
             branches:
               ignore:
@@ -449,7 +399,7 @@ workflows:
       - ios-device-checks:
           name: Test iOS on Device - Full
           post-to-slack: true
-          requires: [ "Test iOS", "iOS Build" ]
+          requires: [ "iOS Build" ]
           filters:
             branches:
               only:
@@ -460,7 +410,7 @@ workflows:
           name: Test iOS on Device - iPad
           is-ipad: "-ipad"
           post-to-slack: true
-          requires: [ "Test iOS", "iOS Build" ]
+          requires: [ "iOS Build" ]
           filters:
             branches:
               only:
@@ -470,10 +420,10 @@ workflows:
       - android-device-checks:
           name: Test Android on Device - Full
           post-to-slack: true
-          requires: [ "Test Android", "Android Native Unit Tests", "Android Build" ]
+          requires: [ "Android Native Unit Tests", "Android Build" ]
           filters:
             branches:
-              only: 
+              only:
                 - trunk
                 - /^dependabot/submodules/.*/
                 - /^release.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,30 +22,6 @@ commands:
             - src/i18n-cache
             - ~/.local/share/pnpm/store/v3
             - ~/Library/pnpm/store/v3
-  npm-install-full:
-    parameters:
-      additional-flags:
-        type: string
-        default: ""
-    steps:
-      - restore_cache:
-          name: Restore NPM Cache
-          keys:
-            - npm-install-full-cache-{{ .Environment.CACHE_TRIGGER_VERSION }}-{{ arch }}-{{ checksum "gutenberg/package-lock.json" }}
-            - npm-install-full-cache-{{ .Environment.CACHE_TRIGGER_VERSION }}-{{ arch }}-
-      - run:
-          name: NPM Install Full
-          command: |
-            echo "Node version: $(node --version)"
-            npm install --no-audit
-      - save_cache:
-          name: Save NPM Cache
-          key: npm-install-full-cache-{{ .Environment.CACHE_TRIGGER_VERSION }}-{{ arch }}-{{ checksum "gutenberg/package-lock.json" }}
-          paths:
-            - ~/.npm
-            - src/i18n-cache
-            - ~/.local/share/pnpm/store/v3
-            - ~/Library/pnpm/store/v3
   npm-install-e2e-tests:
     parameters:
     steps:


### PR DESCRIPTION
What it says in the title.

To test, notice how:

**1. The checks have gone from CircleCI:**

<img width="987" alt="image" src="https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/b266d2f3-768b-47eb-9ba2-1a9435abd628">

I unblocked the optional UI tests steps to make sure the logic to do so still worked.

**2. There is a new "Lint and Unit Tests" check in the GitHub checks**

<img width="891" alt="image" src="https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/5e2f18da-b4e4-45c5-8d64-d7a9d0e6a996">

**After this is approved and before merging it** I'll update the GitHub configuration to replace the CircleCI checks with the new unified Buildkite checks

<img width="815" alt="image" src="https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/0f5f3968-3d06-48f3-a700-6c4596772a05">

Notice that in the close future we'll split the Buildkite checks in three, which will require a further checks-settings switcheroo. That's an accepted tradeoff because we value moving away from CircleCI ASAP.

---

PR submission checklist:

- [x] I have considered adding unit tests where possible. – N.A.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary. – N.A.