### PR TITLE
Add react-native-context-menu-view library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -177,14 +177,14 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/eslint-parser": "^7.16.0",
-				"@typescript-eslint/eslint-plugin": "^5.62.0",
-				"@typescript-eslint/parser": "^5.62.0",
+				"@typescript-eslint/eslint-plugin": "^6.4.1",
+				"@typescript-eslint/parser": "^6.4.1",
 				"@wordpress/babel-preset-default": "file:../babel-preset-default",
 				"@wordpress/prettier-config": "file:../prettier-config",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-plugin-import": "^2.25.2",
-				"eslint-plugin-jest": "^27.2.1",
+				"eslint-plugin-jest": "^27.2.3",
 				"eslint-plugin-jsdoc": "^46.4.6",
 				"eslint-plugin-jsx-a11y": "^6.5.1",
 				"eslint-plugin-playwright": "^0.15.3",
@@ -228,32 +228,33 @@
 			}
 		},
 		"gutenberg/packages/eslint-plugin/node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
-			"integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.6.0.tgz",
+			"integrity": "sha512-CW9YDGTQnNYMIo5lMeuiIG08p4E0cXrXTbcZ2saT/ETE7dWUrNxlijsQeU04qAAKkILiLzdQz+cGFxCJjaZUmA==",
 			"dev": true,
 			"dependencies": {
-				"@eslint-community/regexpp": "^4.4.0",
-				"@typescript-eslint/scope-manager": "5.62.0",
-				"@typescript-eslint/type-utils": "5.62.0",
-				"@typescript-eslint/utils": "5.62.0",
+				"@eslint-community/regexpp": "^4.5.1",
+				"@typescript-eslint/scope-manager": "6.6.0",
+				"@typescript-eslint/type-utils": "6.6.0",
+				"@typescript-eslint/utils": "6.6.0",
+				"@typescript-eslint/visitor-keys": "6.6.0",
 				"debug": "^4.3.4",
 				"graphemer": "^1.4.0",
-				"ignore": "^5.2.0",
-				"natural-compare-lite": "^1.4.0",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
+				"ignore": "^5.2.4",
+				"natural-compare": "^1.4.0",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^5.0.0",
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+				"eslint": "^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -261,31 +262,103 @@
 				}
 			}
 		},
-		"gutenberg/packages/eslint-plugin/node_modules/@typescript-eslint/parser": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
-			"integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+		"gutenberg/packages/eslint-plugin/node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.6.0.tgz",
+			"integrity": "sha512-mPHFoNa2bPIWWglWYdR0QfY9GN0CfvvXX1Sv6DlSTive3jlMTUy+an67//Gysc+0Me9pjitrq0LJp0nGtLgftw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.62.0",
-				"@typescript-eslint/types": "5.62.0",
-				"@typescript-eslint/typescript-estree": "5.62.0",
-				"debug": "^4.3.4"
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@types/json-schema": "^7.0.12",
+				"@types/semver": "^7.5.0",
+				"@typescript-eslint/scope-manager": "6.6.0",
+				"@typescript-eslint/types": "6.6.0",
+				"@typescript-eslint/typescript-estree": "6.6.0",
+				"semver": "^7.5.4"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"eslint": "^7.0.0 || ^8.0.0"
+			}
+		},
+		"gutenberg/packages/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.6.0.tgz",
+			"integrity": "sha512-pT08u5W/GT4KjPUmEtc2kSYvrH8x89cVzkA0Sy2aaOUIw6YxOIjA8ilwLr/1fLjOedX1QAuBpG9XggWqIIfERw==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.6.0",
+				"@typescript-eslint/visitor-keys": "6.6.0"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"gutenberg/packages/eslint-plugin/node_modules/@typescript-eslint/types": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.6.0.tgz",
+			"integrity": "sha512-CB6QpJQ6BAHlJXdwUmiaXDBmTqIE2bzGTDLADgvqtHWuhfNP3rAOK7kAgRMAET5rDRr9Utt+qAzRBdu3AhR3sg==",
+			"dev": true,
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"gutenberg/packages/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.6.0.tgz",
+			"integrity": "sha512-hMcTQ6Al8MP2E6JKBAaSxSVw5bDhdmbCEhGW/V8QXkb9oNsFkA4SBuOMYVPxD3jbtQ4R/vSODBsr76R6fP3tbA==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.6.0",
+				"@typescript-eslint/visitor-keys": "6.6.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
 					"optional": true
 				}
+			}
+		},
+		"gutenberg/packages/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.6.0.tgz",
+			"integrity": "sha512-L61uJT26cMOfFQ+lMZKoJNbAEckLe539VhTxiGHrWl5XSKQgA0RTBZJW2HFPy5T0ZvPVSD93QsrTKDkfNwJGyQ==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.6.0",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
 		"gutenberg/packages/eslint-plugin/node_modules/comment-parser": {
@@ -359,6 +432,31 @@
 				"semver": "bin/semver.js"
 			}
 		},
+		"gutenberg/packages/eslint-plugin/node_modules/eslint-plugin-jest": {
+			"version": "27.2.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.2.3.tgz",
+			"integrity": "sha512-sRLlSCpICzWuje66Gl9zvdF6mwD5X86I4u55hJyFBsxYOsBCmT5+kSUjf+fkFWVMMgpzNEupjW8WzUqi83hJAQ==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/utils": "^5.10.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/eslint-plugin": "^5.0.0 || ^6.0.0",
+				"eslint": "^7.0.0 || ^8.0.0",
+				"jest": "*"
+			},
+			"peerDependenciesMeta": {
+				"@typescript-eslint/eslint-plugin": {
+					"optional": true
+				},
+				"jest": {
+					"optional": true
+				}
+			}
+		},
 		"gutenberg/packages/eslint-plugin/node_modules/eslint-plugin-jsdoc": {
 			"version": "46.4.6",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.4.6.tgz",
@@ -380,6 +478,18 @@
 			},
 			"peerDependencies": {
 				"eslint": "^7.0.0 || ^8.0.0"
+			}
+		},
+		"gutenberg/packages/eslint-plugin/node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"gutenberg/packages/eslint-plugin/node_modules/globals": {
@@ -5827,9 +5937,9 @@
 			"dev": true
 		},
 		"node_modules/@types/semver": {
-			"version": "7.3.13",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-			"integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+			"version": "7.5.1",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.1.tgz",
+			"integrity": "sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==",
 			"dev": true
 		},
 		"node_modules/@types/stack-utils": {
@@ -6090,6 +6200,135 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/@typescript-eslint/parser": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.6.0.tgz",
+			"integrity": "sha512-setq5aJgUwtzGrhW177/i+DMLqBaJbdwGj2CPIVFFLE0NCliy5ujIdLHd2D1ysmlmsjdL2GWW+hR85neEfc12w==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "6.6.0",
+				"@typescript-eslint/types": "6.6.0",
+				"@typescript-eslint/typescript-estree": "6.6.0",
+				"@typescript-eslint/visitor-keys": "6.6.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.6.0.tgz",
+			"integrity": "sha512-pT08u5W/GT4KjPUmEtc2kSYvrH8x89cVzkA0Sy2aaOUIw6YxOIjA8ilwLr/1fLjOedX1QAuBpG9XggWqIIfERw==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.6.0",
+				"@typescript-eslint/visitor-keys": "6.6.0"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.6.0.tgz",
+			"integrity": "sha512-CB6QpJQ6BAHlJXdwUmiaXDBmTqIE2bzGTDLADgvqtHWuhfNP3rAOK7kAgRMAET5rDRr9Utt+qAzRBdu3AhR3sg==",
+			"dev": true,
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.6.0.tgz",
+			"integrity": "sha512-hMcTQ6Al8MP2E6JKBAaSxSVw5bDhdmbCEhGW/V8QXkb9oNsFkA4SBuOMYVPxD3jbtQ4R/vSODBsr76R6fP3tbA==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.6.0",
+				"@typescript-eslint/visitor-keys": "6.6.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.6.0.tgz",
+			"integrity": "sha512-L61uJT26cMOfFQ+lMZKoJNbAEckLe539VhTxiGHrWl5XSKQgA0RTBZJW2HFPy5T0ZvPVSD93QsrTKDkfNwJGyQ==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.6.0",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/@typescript-eslint/scope-manager": {
 			"version": "5.62.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
@@ -6108,30 +6347,156 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
-			"integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.6.0.tgz",
+			"integrity": "sha512-8m16fwAcEnQc69IpeDyokNO+D5spo0w1jepWWY2Q6y5ZKNuj5EhVQXjtVAeDDqvW6Yg7dhclbsz6rTtOvcwpHg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "5.62.0",
-				"@typescript-eslint/utils": "5.62.0",
+				"@typescript-eslint/typescript-estree": "6.6.0",
+				"@typescript-eslint/utils": "6.6.0",
 				"debug": "^4.3.4",
-				"tsutils": "^3.21.0"
+				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "*"
+				"eslint": "^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/scope-manager": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.6.0.tgz",
+			"integrity": "sha512-pT08u5W/GT4KjPUmEtc2kSYvrH8x89cVzkA0Sy2aaOUIw6YxOIjA8ilwLr/1fLjOedX1QAuBpG9XggWqIIfERw==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.6.0",
+				"@typescript-eslint/visitor-keys": "6.6.0"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.6.0.tgz",
+			"integrity": "sha512-CB6QpJQ6BAHlJXdwUmiaXDBmTqIE2bzGTDLADgvqtHWuhfNP3rAOK7kAgRMAET5rDRr9Utt+qAzRBdu3AhR3sg==",
+			"dev": true,
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.6.0.tgz",
+			"integrity": "sha512-hMcTQ6Al8MP2E6JKBAaSxSVw5bDhdmbCEhGW/V8QXkb9oNsFkA4SBuOMYVPxD3jbtQ4R/vSODBsr76R6fP3tbA==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.6.0",
+				"@typescript-eslint/visitor-keys": "6.6.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.6.0.tgz",
+			"integrity": "sha512-mPHFoNa2bPIWWglWYdR0QfY9GN0CfvvXX1Sv6DlSTive3jlMTUy+an67//Gysc+0Me9pjitrq0LJp0nGtLgftw==",
+			"dev": true,
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@types/json-schema": "^7.0.12",
+				"@types/semver": "^7.5.0",
+				"@typescript-eslint/scope-manager": "6.6.0",
+				"@typescript-eslint/types": "6.6.0",
+				"@typescript-eslint/typescript-estree": "6.6.0",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.6.0.tgz",
+			"integrity": "sha512-L61uJT26cMOfFQ+lMZKoJNbAEckLe539VhTxiGHrWl5XSKQgA0RTBZJW2HFPy5T0ZvPVSD93QsrTKDkfNwJGyQ==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.6.0",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
@@ -23944,12 +24309,6 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
-		"node_modules/natural-compare-lite": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-			"dev": true
-		},
 		"node_modules/nearley": {
 			"version": "2.19.3",
 			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.19.3.tgz",
@@ -27114,6 +27473,18 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/ts-api-utils": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.2.tgz",
+			"integrity": "sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=16.13.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.2.0"
 			}
 		},
 		"node_modules/tsconfig-paths": {
@@ -32232,9 +32603,9 @@
 			"dev": true
 		},
 		"@types/semver": {
-			"version": "7.3.13",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-			"integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+			"version": "7.5.1",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.1.tgz",
+			"integrity": "sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==",
 			"dev": true
 		},
 		"@types/stack-utils": {
@@ -32395,6 +32766,77 @@
 				}
 			}
 		},
+		"@typescript-eslint/parser": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.6.0.tgz",
+			"integrity": "sha512-setq5aJgUwtzGrhW177/i+DMLqBaJbdwGj2CPIVFFLE0NCliy5ujIdLHd2D1ysmlmsjdL2GWW+hR85neEfc12w==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/scope-manager": "6.6.0",
+				"@typescript-eslint/types": "6.6.0",
+				"@typescript-eslint/typescript-estree": "6.6.0",
+				"@typescript-eslint/visitor-keys": "6.6.0",
+				"debug": "^4.3.4"
+			},
+			"dependencies": {
+				"@typescript-eslint/scope-manager": {
+					"version": "6.6.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.6.0.tgz",
+					"integrity": "sha512-pT08u5W/GT4KjPUmEtc2kSYvrH8x89cVzkA0Sy2aaOUIw6YxOIjA8ilwLr/1fLjOedX1QAuBpG9XggWqIIfERw==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/types": "6.6.0",
+						"@typescript-eslint/visitor-keys": "6.6.0"
+					}
+				},
+				"@typescript-eslint/types": {
+					"version": "6.6.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.6.0.tgz",
+					"integrity": "sha512-CB6QpJQ6BAHlJXdwUmiaXDBmTqIE2bzGTDLADgvqtHWuhfNP3rAOK7kAgRMAET5rDRr9Utt+qAzRBdu3AhR3sg==",
+					"dev": true
+				},
+				"@typescript-eslint/typescript-estree": {
+					"version": "6.6.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.6.0.tgz",
+					"integrity": "sha512-hMcTQ6Al8MP2E6JKBAaSxSVw5bDhdmbCEhGW/V8QXkb9oNsFkA4SBuOMYVPxD3jbtQ4R/vSODBsr76R6fP3tbA==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/types": "6.6.0",
+						"@typescript-eslint/visitor-keys": "6.6.0",
+						"debug": "^4.3.4",
+						"globby": "^11.1.0",
+						"is-glob": "^4.0.3",
+						"semver": "^7.5.4",
+						"ts-api-utils": "^1.0.1"
+					}
+				},
+				"@typescript-eslint/visitor-keys": {
+					"version": "6.6.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.6.0.tgz",
+					"integrity": "sha512-L61uJT26cMOfFQ+lMZKoJNbAEckLe539VhTxiGHrWl5XSKQgA0RTBZJW2HFPy5T0ZvPVSD93QsrTKDkfNwJGyQ==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/types": "6.6.0",
+						"eslint-visitor-keys": "^3.4.1"
+					}
+				},
+				"eslint-visitor-keys": {
+					"version": "3.4.3",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+					"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+					"dev": true
+				},
+				"semver": {
+					"version": "7.5.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+					"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				}
+			}
+		},
 		"@typescript-eslint/scope-manager": {
 			"version": "5.62.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
@@ -32406,15 +32848,88 @@
 			}
 		},
 		"@typescript-eslint/type-utils": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
-			"integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.6.0.tgz",
+			"integrity": "sha512-8m16fwAcEnQc69IpeDyokNO+D5spo0w1jepWWY2Q6y5ZKNuj5EhVQXjtVAeDDqvW6Yg7dhclbsz6rTtOvcwpHg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/typescript-estree": "5.62.0",
-				"@typescript-eslint/utils": "5.62.0",
+				"@typescript-eslint/typescript-estree": "6.6.0",
+				"@typescript-eslint/utils": "6.6.0",
 				"debug": "^4.3.4",
-				"tsutils": "^3.21.0"
+				"ts-api-utils": "^1.0.1"
+			},
+			"dependencies": {
+				"@typescript-eslint/scope-manager": {
+					"version": "6.6.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.6.0.tgz",
+					"integrity": "sha512-pT08u5W/GT4KjPUmEtc2kSYvrH8x89cVzkA0Sy2aaOUIw6YxOIjA8ilwLr/1fLjOedX1QAuBpG9XggWqIIfERw==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/types": "6.6.0",
+						"@typescript-eslint/visitor-keys": "6.6.0"
+					}
+				},
+				"@typescript-eslint/types": {
+					"version": "6.6.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.6.0.tgz",
+					"integrity": "sha512-CB6QpJQ6BAHlJXdwUmiaXDBmTqIE2bzGTDLADgvqtHWuhfNP3rAOK7kAgRMAET5rDRr9Utt+qAzRBdu3AhR3sg==",
+					"dev": true
+				},
+				"@typescript-eslint/typescript-estree": {
+					"version": "6.6.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.6.0.tgz",
+					"integrity": "sha512-hMcTQ6Al8MP2E6JKBAaSxSVw5bDhdmbCEhGW/V8QXkb9oNsFkA4SBuOMYVPxD3jbtQ4R/vSODBsr76R6fP3tbA==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/types": "6.6.0",
+						"@typescript-eslint/visitor-keys": "6.6.0",
+						"debug": "^4.3.4",
+						"globby": "^11.1.0",
+						"is-glob": "^4.0.3",
+						"semver": "^7.5.4",
+						"ts-api-utils": "^1.0.1"
+					}
+				},
+				"@typescript-eslint/utils": {
+					"version": "6.6.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.6.0.tgz",
+					"integrity": "sha512-mPHFoNa2bPIWWglWYdR0QfY9GN0CfvvXX1Sv6DlSTive3jlMTUy+an67//Gysc+0Me9pjitrq0LJp0nGtLgftw==",
+					"dev": true,
+					"requires": {
+						"@eslint-community/eslint-utils": "^4.4.0",
+						"@types/json-schema": "^7.0.12",
+						"@types/semver": "^7.5.0",
+						"@typescript-eslint/scope-manager": "6.6.0",
+						"@typescript-eslint/types": "6.6.0",
+						"@typescript-eslint/typescript-estree": "6.6.0",
+						"semver": "^7.5.4"
+					}
+				},
+				"@typescript-eslint/visitor-keys": {
+					"version": "6.6.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.6.0.tgz",
+					"integrity": "sha512-L61uJT26cMOfFQ+lMZKoJNbAEckLe539VhTxiGHrWl5XSKQgA0RTBZJW2HFPy5T0ZvPVSD93QsrTKDkfNwJGyQ==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/types": "6.6.0",
+						"eslint-visitor-keys": "^3.4.1"
+					}
+				},
+				"eslint-visitor-keys": {
+					"version": "3.4.3",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+					"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+					"dev": true
+				},
+				"semver": {
+					"version": "7.5.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+					"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				}
 			}
 		},
 		"@typescript-eslint/types": {
@@ -32576,14 +33091,14 @@
 			"version": "file:gutenberg/packages/eslint-plugin",
 			"requires": {
 				"@babel/eslint-parser": "^7.16.0",
-				"@typescript-eslint/eslint-plugin": "^5.62.0",
-				"@typescript-eslint/parser": "^5.62.0",
+				"@typescript-eslint/eslint-plugin": "^6.4.1",
+				"@typescript-eslint/parser": "^6.4.1",
 				"@wordpress/babel-preset-default": "file:../babel-preset-default",
 				"@wordpress/prettier-config": "file:../prettier-config",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-plugin-import": "^2.25.2",
-				"eslint-plugin-jest": "^27.2.1",
+				"eslint-plugin-jest": "^27.2.3",
 				"eslint-plugin-jsdoc": "^46.4.6",
 				"eslint-plugin-jsx-a11y": "^6.5.1",
 				"eslint-plugin-playwright": "^0.15.3",
@@ -32606,33 +33121,80 @@
 					}
 				},
 				"@typescript-eslint/eslint-plugin": {
-					"version": "5.62.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
-					"integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
+					"version": "6.6.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.6.0.tgz",
+					"integrity": "sha512-CW9YDGTQnNYMIo5lMeuiIG08p4E0cXrXTbcZ2saT/ETE7dWUrNxlijsQeU04qAAKkILiLzdQz+cGFxCJjaZUmA==",
 					"dev": true,
 					"requires": {
-						"@eslint-community/regexpp": "^4.4.0",
-						"@typescript-eslint/scope-manager": "5.62.0",
-						"@typescript-eslint/type-utils": "5.62.0",
-						"@typescript-eslint/utils": "5.62.0",
+						"@eslint-community/regexpp": "^4.5.1",
+						"@typescript-eslint/scope-manager": "6.6.0",
+						"@typescript-eslint/type-utils": "6.6.0",
+						"@typescript-eslint/utils": "6.6.0",
+						"@typescript-eslint/visitor-keys": "6.6.0",
 						"debug": "^4.3.4",
 						"graphemer": "^1.4.0",
-						"ignore": "^5.2.0",
-						"natural-compare-lite": "^1.4.0",
-						"semver": "^7.3.7",
-						"tsutils": "^3.21.0"
+						"ignore": "^5.2.4",
+						"natural-compare": "^1.4.0",
+						"semver": "^7.5.4",
+						"ts-api-utils": "^1.0.1"
+					},
+					"dependencies": {
+						"@typescript-eslint/utils": {
+							"version": "6.6.0",
+							"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.6.0.tgz",
+							"integrity": "sha512-mPHFoNa2bPIWWglWYdR0QfY9GN0CfvvXX1Sv6DlSTive3jlMTUy+an67//Gysc+0Me9pjitrq0LJp0nGtLgftw==",
+							"dev": true,
+							"requires": {
+								"@eslint-community/eslint-utils": "^4.4.0",
+								"@types/json-schema": "^7.0.12",
+								"@types/semver": "^7.5.0",
+								"@typescript-eslint/scope-manager": "6.6.0",
+								"@typescript-eslint/types": "6.6.0",
+								"@typescript-eslint/typescript-estree": "6.6.0",
+								"semver": "^7.5.4"
+							}
+						}
 					}
 				},
-				"@typescript-eslint/parser": {
-					"version": "5.62.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
-					"integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+				"@typescript-eslint/scope-manager": {
+					"version": "6.6.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.6.0.tgz",
+					"integrity": "sha512-pT08u5W/GT4KjPUmEtc2kSYvrH8x89cVzkA0Sy2aaOUIw6YxOIjA8ilwLr/1fLjOedX1QAuBpG9XggWqIIfERw==",
 					"dev": true,
 					"requires": {
-						"@typescript-eslint/scope-manager": "5.62.0",
-						"@typescript-eslint/types": "5.62.0",
-						"@typescript-eslint/typescript-estree": "5.62.0",
-						"debug": "^4.3.4"
+						"@typescript-eslint/types": "6.6.0",
+						"@typescript-eslint/visitor-keys": "6.6.0"
+					}
+				},
+				"@typescript-eslint/types": {
+					"version": "6.6.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.6.0.tgz",
+					"integrity": "sha512-CB6QpJQ6BAHlJXdwUmiaXDBmTqIE2bzGTDLADgvqtHWuhfNP3rAOK7kAgRMAET5rDRr9Utt+qAzRBdu3AhR3sg==",
+					"dev": true
+				},
+				"@typescript-eslint/typescript-estree": {
+					"version": "6.6.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.6.0.tgz",
+					"integrity": "sha512-hMcTQ6Al8MP2E6JKBAaSxSVw5bDhdmbCEhGW/V8QXkb9oNsFkA4SBuOMYVPxD3jbtQ4R/vSODBsr76R6fP3tbA==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/types": "6.6.0",
+						"@typescript-eslint/visitor-keys": "6.6.0",
+						"debug": "^4.3.4",
+						"globby": "^11.1.0",
+						"is-glob": "^4.0.3",
+						"semver": "^7.5.4",
+						"ts-api-utils": "^1.0.1"
+					}
+				},
+				"@typescript-eslint/visitor-keys": {
+					"version": "6.6.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.6.0.tgz",
+					"integrity": "sha512-L61uJT26cMOfFQ+lMZKoJNbAEckLe539VhTxiGHrWl5XSKQgA0RTBZJW2HFPy5T0ZvPVSD93QsrTKDkfNwJGyQ==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/types": "6.6.0",
+						"eslint-visitor-keys": "^3.4.1"
 					}
 				},
 				"comment-parser": {
@@ -32690,6 +33252,15 @@
 						}
 					}
 				},
+				"eslint-plugin-jest": {
+					"version": "27.2.3",
+					"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.2.3.tgz",
+					"integrity": "sha512-sRLlSCpICzWuje66Gl9zvdF6mwD5X86I4u55hJyFBsxYOsBCmT5+kSUjf+fkFWVMMgpzNEupjW8WzUqi83hJAQ==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/utils": "^5.10.0"
+					}
+				},
 				"eslint-plugin-jsdoc": {
 					"version": "46.4.6",
 					"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.4.6.tgz",
@@ -32706,6 +33277,12 @@
 						"semver": "^7.5.4",
 						"spdx-expression-parse": "^3.0.1"
 					}
+				},
+				"eslint-visitor-keys": {
+					"version": "3.4.3",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+					"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+					"dev": true
 				},
 				"globals": {
 					"version": "13.20.0",
@@ -47930,12 +48507,6 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
-		"natural-compare-lite": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-			"dev": true
-		},
 		"nearley": {
 			"version": "2.19.3",
 			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.19.3.tgz",
@@ -50438,6 +51009,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
 			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
+		},
+		"ts-api-utils": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.2.tgz",
+			"integrity": "sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==",
 			"dev": true
 		},
 		"tsconfig-paths": {

--- a/third-party-podspecs/FBReactNativeSpec/FBReactNativeSpec.podspec.json
+++ b/third-party-podspecs/FBReactNativeSpec/FBReactNativeSpec.podspec.json
@@ -11,7 +11,7 @@
   "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32 -Wno-nullability-completeness",
   "source": {
     "git": "https://github.com/wordpress-mobile/gutenberg-mobile.git",
-    "commit": "f4d2319badc5adf70223a346278881273b08eaf0",
+    "commit": "85151fd1979a405ca36dfba5c6c4d5570a1a59b0",
     "submodules": "true"
   },
   "header_dir": "FBReactNativeSpec",


### PR DESCRIPTION
Adds support for using Context Menus within the mobile editor.

Related:

* https://github.com/wordpress-mobile/gutenberg-mobile/issues/6151
* https://github.com/WordPress/gutenberg/pull/54267

To test: follow instructions on https://github.com/WordPress/gutenberg/pull/54267

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
