### PR TITLE
Add iOS Sauce Labs tests steps to Buildkite pipeline

### DIFF
--- a/.buildkite/build-ios.sh
+++ b/.buildkite/build-ios.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -eu
+
+echo '--- :node: Setup Node depenendencies'
+echo '--- :node: 1. Install nvm'
+brew install nvm
+
+echo '--- :node: 2. Load nvm in the current shell'
+export NVM_DIR="$HOME/.nvm"
+mkdir -p "$NVM_DIR"
+[ -s "$HOMEBREW_PREFIX/opt/nvm/nvm.sh" ] && \. "$HOMEBREW_PREFIX/opt/nvm/nvm.sh" --install
+
+echo '--- :node: 3. Install node version from .nvmrc'
+nvm install "$(cat .nvmrc)" && nvm use
+
+echo '--- :node: 4. nmp ci'
+npm ci
+
+echo '--- :ios: Set env var for iOS E2E testing'
+set -x
+export TEST_RN_PLATFORM=ios
+export TEST_ENV=sauce
+# Set a destination different from the hardcoded one which only works in the
+# older Xcode-setup used by CircleCI
+export RN_EDITOR_E2E_IOS_DESTINATION='platform=iOS Simulator,name=iPhone 14,OS=16.4'
+set +x
+
+echo '--- :react: Build iOS app for E2E testing'
+npm run core test:e2e:build-app:ios
+
+echo '--- :react: Build iOS bundle for E2E testing'
+npm run test:e2e:bundle:ios
+
+echo '--- :compression: Prepare artifact for SauceLabs upload'
+WORK_DIR=$(pwd) \
+  && pushd ./gutenberg/packages/react-native-editor/ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator \
+  && zip -r "$WORK_DIR/gutenberg/packages/react-native-editor/ios/GutenbergDemo.app.zip" GutenbergDemo.app \
+  && popd
+
+echo '--- :saucelabs: Upload app artifact to SauceLabs'
+SAUCE_FILENAME=${BUILDKITE_BRANCH//[\/]/-}
+curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" \
+  --location \
+  --request POST 'https://api.us-west-1.saucelabs.com/v1/storage/upload' \
+  --form 'payload=@"./gutenberg/packages/react-native-editor/ios/GutenbergDemo.app.zip"' \
+  --form "name=Gutenberg-$SAUCE_FILENAME.app.zip" \
+  --form 'description="Gutenberg"'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,12 +1,12 @@
 x-common-params:
   - &gb-mobile-docker-container
     docker#v3.8.0:
-      image: "public.ecr.aws/automattic/gb-mobile-image:latest"
+      image: 'public.ecr.aws/automattic/gb-mobile-image:latest'
       environment:
-        - "CI=true"
+        - 'CI=true'
         # Allow WP-CLI to be run as root, otherwise it throws an exception.
         # Reference: https://git.io/J9q2S
-        - "WP_CLI_ALLOW_ROOT=true"
+        - 'WP_CLI_ALLOW_ROOT=true'
   - &git-cache-plugin
     automattic/git-s3-cache#1.1.4:
       # Ensure these settings match what's defined in cache-builder.yml
@@ -14,13 +14,19 @@ x-common-params:
       repo: automattic/gutenberg-mobile/
   - &publish-android-artifacts-docker-container
     docker#v3.8.0:
-      image: "public.ecr.aws/automattic/android-build-image:v1.3.0"
+      image: 'public.ecr.aws/automattic/android-build-image:v1.3.0'
       propagate-environment: true
       environment:
         # DO NOT MANUALLY SET THESE VALUES!
         # They are passed from the Buildkite agent to the Docker container
-        - "AWS_ACCESS_KEY"
-        - "AWS_SECRET_KEY"
+        - 'AWS_ACCESS_KEY'
+        - 'AWS_SECRET_KEY'
+  - &xcode_agent_env
+    IMAGE_ID: xcode-14.3.1
+  - &is_branch_for_full_ui_tests
+    build.branch == 'trunk' || build.branch =~ /^release.*/ || build.branch =~ /^dependabot\/submodules.*/
+  - &is_branch_for_quick_ui_tests
+    build.branch != 'trunk' && build.branch !~ /^release.*/ && build.branch !~ /^dependabot\/submodules.*/
 
 steps:
   - block: "Request trigger Android bundle and builds"
@@ -97,6 +103,7 @@ steps:
           node gutenberg/node_modules/react-native/scripts/compose-source-maps.js bundle/ios/App.text.js.map bundle/ios/App.js.map -o bundle/ios/App.composed.js.map
           buildkite-agent artifact upload bundle/ios/App.composed.js.map
         fi
+
   - label: "Build Android RN Aztec & Publish to S3"
     depends_on: unit-tests
     key: "publish-react-native-aztec-android"
@@ -128,3 +135,100 @@ steps:
       queue: mac
     env:
       IMAGE_ID: xcode-14.3.1
+
+  - label: iOS Build and SauceLabs
+    key: ios-build-and-saucelabs
+    command: .buildkite/build-ios.sh
+    plugins:
+      - automattic/a8c-ci-toolkit#2.18.2
+      - *git-cache-plugin
+    artifact_paths:
+      - ./gutenberg/packages/react-native-editor/ios/GutenbergDemo.app.zip
+    agents:
+      queue: mac
+    env: *xcode_agent_env
+
+  - label: Test iOS on Device – Canary Pages
+    depends_on: ios-build-and-saucelabs
+    command: .buildkite/test-ios.sh --canary
+    plugins:
+      - automattic/a8c-ci-toolkit#2.18.2
+      - *git-cache-plugin
+    artifact_paths:
+      - reports/test-results/ios-test-results.xml
+    agents:
+      queue: mac
+    env: *xcode_agent_env
+    notify:
+      - github_commit_status:
+          context: Test iOS on Device - Canaries
+
+  - block: "Full UI Tests"
+    # Show only in branches that run the quick UI tests suite, to optionally run the full suite
+    if: *is_branch_for_quick_ui_tests
+    key: run-full-ui-test
+    prompt: "Run full UI tests suites?"
+    depends_on: ios-build-and-saucelabs
+
+  - label: Test iOS on Device – Full iPhone
+    # The quick UI tests suite version depends on the block step being unblocked
+    if: *is_branch_for_quick_ui_tests
+    depends_on:
+      - ios-build-and-saucelabs
+      - run-full-ui-test
+    command: .buildkite/test-ios.sh
+    plugins:
+      - automattic/a8c-ci-toolkit#2.18.2
+      - *git-cache-plugin
+    artifact_paths:
+      - reports/test-results/ios-test-results.xml
+    agents:
+      queue: mac
+    env: *xcode_agent_env
+
+  # Same step as above, but will always run in trunk, release/, and dependabot/submodules branches
+  - label: Test iOS on Device – Full iPhone
+    # The full UI tests suite version depends only on the ios-build step, meaning it has no manual step that triggers it
+    if: *is_branch_for_full_ui_tests
+    depends_on:
+      - ios-build-and-saucelabs
+    command: .buildkite/test-ios.sh
+    plugins:
+      - automattic/a8c-ci-toolkit#2.18.2
+      - *git-cache-plugin
+    artifact_paths:
+      - reports/test-results/ios-test-results.xml
+    agents:
+      queue: mac
+    env: *xcode_agent_env
+
+  - label: Test iOS on Device – Full iPad
+    # The quick UI tests suite version depends on the block step being unblocked
+    if: *is_branch_for_quick_ui_tests
+    depends_on:
+      - ios-build-and-saucelabs
+      - run-full-ui-test
+    command: .buildkite/test-ios.sh --ipad
+    plugins:
+      - automattic/a8c-ci-toolkit#2.18.2
+      - *git-cache-plugin
+    artifact_paths:
+      - reports/test-results/ios-test-results.xml
+    agents:
+      queue: mac
+    env: *xcode_agent_env
+
+  - label: Test iOS on Device – Full iPad
+    # The full UI tests suite version depends only on the ios-build step, meaning it has no manual step that triggers it
+    if: *is_branch_for_full_ui_tests
+    depends_on:
+      - ios-build-and-saucelabs
+    command: .buildkite/test-ios.sh --ipad
+    plugins:
+      - automattic/a8c-ci-toolkit#2.18.2
+      - *git-cache-plugin
+    artifact_paths:
+      - reports/test-results/ios-test-results.xml
+    agents:
+      queue: mac
+    env: *xcode_agent_env

--- a/.buildkite/test-ios.sh
+++ b/.buildkite/test-ios.sh
@@ -1,0 +1,79 @@
+#!/bin/bash -eu
+
+MODE="iphone"
+INPUT="${1-}"
+while [ "$INPUT" != "" ]; do
+    case $INPUT in
+        --canary )
+            MODE="canary"
+            ;;
+        --ipad )
+            MODE="ipad"
+            ;;
+        * )
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+    shift
+    INPUT="${1-}"
+done
+
+echo '--- :node: Setup Node depenendencies'
+echo '--- :node: 1. Install nvm'
+brew install nvm
+
+echo '--- :node: 2. Load nvm in the current shell'
+export NVM_DIR="$HOME/.nvm"
+mkdir -p "$NVM_DIR"
+[ -s "$HOMEBREW_PREFIX/opt/nvm/nvm.sh" ] && \. "$HOMEBREW_PREFIX/opt/nvm/nvm.sh" --install
+
+echo '--- :node: 3. Install node version from .nvmrc'
+nvm install "$(cat .nvmrc)" && nvm use
+
+echo '--- :node: 4. nmp ci (for E2E testing)'
+npm ci --prefer-offline --no-audit --ignore-scripts
+npm ci --prefix gutenberg --prefer-offline --no-audit
+
+echo '--- :ios: Set env var for iOS E2E testing'
+set -x
+export TEST_RN_PLATFORM=ios
+export TEST_ENV=sauce
+export JEST_JUNIT_OUTPUT_FILE="reports/test-results/ios-test-results.xml"
+# Set a destination different from the hardcoded one which only works in the
+# older Xcode-setup used by CircleCI
+export RN_EDITOR_E2E_IOS_DESTINATION='platform=iOS Simulator,name=iPhone 13,OS=16.4'
+# This is a relic of the CircleCI setup.
+# It should be removed once the migration to Buildkite is completed.
+export CIRCLE_BRANCH=${BUILDKITE_BRANCH}
+set +x
+
+if [ "$MODE" == 'canary' ]; then
+    SECTION='--- :saucelabs: Test iOS Canary Pages'
+    TESTS_CMD='device-tests-canary'
+elif [ "$MODE" == "ipad" ]; then
+    SECTION='--- :saucelabs: Test iOS iPad'
+    TESTS_CMD='device-tests-ipad'
+else
+    SECTION='--- :saucelabs: Test iOS iPhone'
+    TESTS_CMD='device-tests'
+fi
+
+set +e
+echo "$SECTION"
+npm run "$TESTS_CMD"
+TESTS_EXIT_CODE=$?
+set -e
+
+REPORT_SECTION_NAME='🚦 Report Tests Status'
+if [[ $TESTS_EXIT_CODE -eq 0 ]]; then
+    echo "--- $REPORT_SECTION_NAME"
+    echo "npm run $TESTS_CMD passed. 🎉"
+else
+    echo "+++ $REPORT_SECTION_NAME"
+    echo "npm run $TESTS_CMD failed."
+    echo "For more details about the failed tests, check the Buildkite annotation, the logs under the '$SECTION' section and the tests results in the artifacts tab."
+
+    annotate_test_failures "$JEST_JUNIT_OUTPUT_FILE" --slack "build-and-ship"
+    exit $TESTS_EXIT_CODE
+fi

--- a/.buildkite/test-ios.sh
+++ b/.buildkite/test-ios.sh
@@ -31,7 +31,7 @@ mkdir -p "$NVM_DIR"
 echo '--- :node: 3. Install node version from .nvmrc'
 nvm install "$(cat .nvmrc)" && nvm use
 
-echo '--- :node: 4. nmp ci (for E2E testing)'
+echo '--- :node: 4. npm ci (for E2E testing)'
 npm ci --prefer-offline --no-audit --ignore-scripts
 npm ci --prefix gutenberg --prefer-offline --no-audit
 


### PR DESCRIPTION
This PR adds all the step and automation necessary to build, upload, and run E2E tests on Sauce Labs, but it does not remove the CircleCI steps yet. That will happen in a follow up PR after this new setup run in the wild for a couple days at least.

Unless I missed something, this should replicate the CircleCI configuration 1:1, minus the GitHub comment to start the tests,  more on that later. 

Highlights:

**Block step to manually run optional E2E tests** _[source](https://buildkite.com/automattic/gutenberg-mobile/builds/7205)_

![image](https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/97bbdad2-de9a-4267-8c9f-8d7f095a50fc)


**`trunk`, `release/` and Dependabot branches run all the tests** which can be verified by swapping the branch filter definitions in the common nodes at the start of the pipeline file. _[source](https://buildkite.com/automattic/gutenberg-mobile/builds/7159)_

<img width="1204" alt="Screenshot 2023-09-11 at 1 58 40 pm" src="https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/6fddb932-42f0-42c1-ab1a-46c7675d3478">

**Slack reporting when tests fail**, verified by adding a failing test to the suite [_source_](https://buildkite.com/automattic/gutenberg-mobile/builds/7181) 

<img width="1115" alt="Screenshot 2023-09-07 at 1 05 52 pm" src="https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/ad722996-44f9-4cec-bee9-bfcbd8e51e8a">

And, additionally, test failure information in the Buildkite build page, [_source_](https://buildkite.com/automattic/gutenberg-mobile/builds/7181):

<img width="1185" alt="Screenshot 2023-09-07 at 1 06 01 pm" src="https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/9fe06279-89f8-4202-8bff-79f27328754f">

### About the GitHub comment

<img width="1025" alt="Screenshot 2023-09-11 at 2 03 49 pm" src="https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/868e8e94-9992-43ee-b83d-ea4db4dadf9f">

We discussed this internally as part of the migration from Peril to [Danger](https://github.com/Automattic/dangermattic/) and  concluded that it's not required. It will be removed in sync with the CircleCI steps removal. Internal ref: paaHJt-5g5-p2#comment-7831

---

PR submission checklist:

- [x] I have considered adding unit tests where possible. – N.A.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary. – N.A.