### PR TITLE
Use nvm-buildkite-plugin to install node.js

### DIFF
--- a/.buildkite/build-ios.sh
+++ b/.buildkite/build-ios.sh
@@ -1,18 +1,6 @@
 #!/bin/bash -eu
 
 echo '--- :node: Setup Node depenendencies'
-echo '--- :node: 1. Install nvm'
-brew install nvm
-
-echo '--- :node: 2. Load nvm in the current shell'
-export NVM_DIR="$HOME/.nvm"
-mkdir -p "$NVM_DIR"
-[ -s "$HOMEBREW_PREFIX/opt/nvm/nvm.sh" ] && \. "$HOMEBREW_PREFIX/opt/nvm/nvm.sh" --install
-
-echo '--- :node: 3. Install node version from .nvmrc'
-nvm install "$(cat .nvmrc)" && nvm use
-
-echo '--- :node: 4. nmp ci'
 npm ci
 
 echo '--- :ios: Set env var for iOS E2E testing'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,6 +21,7 @@ x-common-params:
         # They are passed from the Buildkite agent to the Docker container
         - 'AWS_ACCESS_KEY'
         - 'AWS_SECRET_KEY'
+  - &nvm-plugin automattic/nvm#76721870
   - &xcode_agent_env
     IMAGE_ID: xcode-14.3.1
   - &is_branch_for_full_ui_tests
@@ -131,6 +132,7 @@ steps:
     plugins:
       - automattic/a8c-ci-toolkit#2.18.2
       - *git-cache-plugin
+      - *nvm-plugin
     agents:
       queue: mac
     env:
@@ -142,6 +144,7 @@ steps:
     plugins:
       - automattic/a8c-ci-toolkit#2.18.2
       - *git-cache-plugin
+      - *nvm-plugin
     artifact_paths:
       - ./gutenberg/packages/react-native-editor/ios/GutenbergDemo.app.zip
     agents:
@@ -154,6 +157,7 @@ steps:
     plugins:
       - automattic/a8c-ci-toolkit#2.18.2
       - *git-cache-plugin
+      - *nvm-plugin
     artifact_paths:
       - reports/test-results/ios-test-results.xml
     agents:

--- a/.buildkite/publish-react-native-ios-artifacts.sh
+++ b/.buildkite/publish-react-native-ios-artifacts.sh
@@ -7,18 +7,6 @@ mkdir -p ios-xcframework/Gutenberg/Resources
 tar -xzvf ios-assets.tar.gz -C ios-xcframework/Gutenberg/Resources/
 
 echo '--- :node: Setup node_modules for RNReanimated'
-echo '--- :node: 1. Install nvm'
-brew install nvm
-
-echo '--- :node: 2. Load nvm in the current shell'
-export NVM_DIR="$HOME/.nvm"
-mkdir -p "$NVM_DIR"
-[ -s "$HOMEBREW_PREFIX/opt/nvm/nvm.sh" ] && \. "$HOMEBREW_PREFIX/opt/nvm/nvm.sh" --install
-
-echo '--- :node: 3. Install node version from .nvmrc'
-nvm install "$(cat .nvmrc)" && nvm use
-
-echo '--- :node: 4. nmp ci'
 npm ci
 
 echo "--- :rubygems: Setting up Gems"

--- a/.buildkite/test-ios.sh
+++ b/.buildkite/test-ios.sh
@@ -20,18 +20,6 @@ while [ "$INPUT" != "" ]; do
 done
 
 echo '--- :node: Setup Node depenendencies'
-echo '--- :node: 1. Install nvm'
-brew install nvm
-
-echo '--- :node: 2. Load nvm in the current shell'
-export NVM_DIR="$HOME/.nvm"
-mkdir -p "$NVM_DIR"
-[ -s "$HOMEBREW_PREFIX/opt/nvm/nvm.sh" ] && \. "$HOMEBREW_PREFIX/opt/nvm/nvm.sh" --install
-
-echo '--- :node: 3. Install node version from .nvmrc'
-nvm install "$(cat .nvmrc)" && nvm use
-
-echo '--- :node: 4. npm ci (for E2E testing)'
 npm ci --prefer-offline --no-audit --ignore-scripts
 npm ci --prefix gutenberg --prefer-offline --no-audit
 


### PR DESCRIPTION
Replacing repeated multiple steps of installing nvm and node.js with [nvm-buildkite-plugin](https://github.com/Automattic/nvm-buildkite-plugin).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
