### PR TITLE
Fallback to Twitter provider when embedding X URLs

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@ Unreleased
 ---
 * [*] Prevent crashes when setting an invalid media URL for Video or Audio blocks [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6235]
 * [*] Limit inner blocks nesting depth to avoid call stack size exceeded crash [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6191]
+* [**] Fallback to Twitter provider when embedding X URLs [https://github.com/WordPress/gutenberg/pull/54876]
 
 1.104.0
 ---


### PR DESCRIPTION
**Related PRs:**
* https://github.com/WordPress/gutenberg/pull/54876

Use Twitter provider when embedding X URLs (e.g. `https://x.com/automattic/status/1395447061336711181`).

**To test:**
Follow the testing instructions from https://github.com/WordPress/gutenberg/pull/54876.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
