### PR TITLE
Run lint and unit tests in dedicated CI steps on macOS VMs

### DIFF
--- a/.buildkite/commands/build-ios.sh
+++ b/.buildkite/commands/build-ios.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 echo '--- :node: Setup Node depenendencies'
-npm ci
+npm ci --unsafe-perm --prefer-offline --no-audit
 
 echo '--- :ios: Set env var for iOS E2E testing'
 set -x

--- a/.buildkite/commands/lint.sh
+++ b/.buildkite/commands/lint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eu
+
+echo "--- :npm: Install Node dependencies"
+npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
+
+echo "--- :node: Lint"
+CHECK_CORRECTNESS=true CHECK_TESTS=false ./bin/ci-checks-js.sh

--- a/.buildkite/commands/publish-react-native-ios-artifacts.sh
+++ b/.buildkite/commands/publish-react-native-ios-artifacts.sh
@@ -7,7 +7,7 @@ mkdir -p ios-xcframework/Gutenberg/Resources
 tar -xzvf ios-assets.tar.gz -C ios-xcframework/Gutenberg/Resources/
 
 echo '--- :node: Setup node_modules for RNReanimated'
-npm ci
+npm ci --unsafe-perm --prefer-offline --no-audit
 
 echo "--- :rubygems: Setting up Gems"
 cd ./ios-xcframework

--- a/.buildkite/commands/unit-tests-android.sh
+++ b/.buildkite/commands/unit-tests-android.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eu
+
+echo "--- :npm: Install Node dependencies"
+npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
+
+echo "--- :node: Lint and Unit Tests"
+CHECK_CORRECTNESS=false CHECK_TESTS=true TEST_RN_PLATFORM=android ./bin/ci-checks-js.sh

--- a/.buildkite/commands/unit-tests-ios.sh
+++ b/.buildkite/commands/unit-tests-ios.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eu
+
+echo "--- :npm: Install Node dependencies"
+npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
+
+echo "--- :node: Lint and Unit Tests"
+CHECK_CORRECTNESS=false CHECK_TESTS=true TEST_RN_PLATFORM=ios ./bin/ci-checks-js.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -39,19 +39,19 @@ steps:
   - label: Lint and Unit Tests
     key: unit-tests
     plugins:
-      - *gb-mobile-docker-container
+      - *ci_toolkit_plugin
+      - *nvm_plugin
+      - *git-cache-plugin
     command: |
-      source /root/.bashrc
-
-      echo "--- :node: Setup Node environment"
-      nvm install && nvm use
-
       echo "--- :npm: Install Node dependencies"
       npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 
       echo "--- :node: Lint and Unit Tests"
       ./bin/ci-checks-js.sh
+    agents:
+      queue: mac
     env:
+      <<: *xcode_agent_env
       JEST_JUNIT_OUTPUT_FILE: reports/test-results/android-test-results.xml
     artifact_paths:
       - ./logs/*.log

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,7 +36,26 @@ steps:
   - block: "Request trigger Android bundle and builds"
     branches: "dependabot/submodules/*"
 
-  - label: Lint and Unit Tests
+  - label: Lint
+    key: lint
+    plugins:
+      - *ci_toolkit_plugin
+      - *nvm_plugin
+      - *git-cache-plugin
+    command: |
+      echo "--- :npm: Install Node dependencies"
+      npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
+
+      echo "--- :node: Lint"
+      CHECK_CORRECTNESS=true CHECK_TESTS=false ./bin/ci-checks-js.sh
+    agents:
+      queue: mac
+    env: *xcode_agent_env
+    notify:
+      - github_commit_status:
+          context: Lint
+
+  - label: Unit Tests
     key: unit-tests
     plugins:
       - *ci_toolkit_plugin
@@ -47,7 +66,7 @@ steps:
       npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 
       echo "--- :node: Lint and Unit Tests"
-      ./bin/ci-checks-js.sh
+      CHECK_CORRECTNESS=false CHECK_TESTS=true ./bin/ci-checks-js.sh
     agents:
       queue: mac
     env:
@@ -56,6 +75,7 @@ steps:
     artifact_paths:
       - ./logs/*.log
       - ./reports/test-results/*.xml
+    # FIXME: Will need to update the GitHub setup again for the reporting and required checks
     notify:
       - github_commit_status:
           context: Lint and Unit Tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -89,6 +89,7 @@ steps:
 
   - label: "Build JS Bundles"
     depends_on:
+      - lint
       - android-unit-tests
       - ios-unit-tests
     key: "js-bundles"
@@ -138,7 +139,9 @@ steps:
         fi
 
   - label: "Build Android RN Aztec & Publish to S3"
-    depends_on: android-unit-tests
+    depends_on:
+      - lint
+      - android-unit-tests
     key: "publish-react-native-aztec-android"
     plugins:
       - *git-cache-plugin

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -82,10 +82,9 @@ steps:
     artifact_paths:
       - ./logs/*.log
       - ./reports/test-results/*.xml
-    # FIXME: Will need to update the GitHub setup again for the reporting and required checks
     notify:
       - github_commit_status:
-          context: Lint and Unit Tests
+          context: iOS Unit Tests
 
   - label: "Build JS Bundles"
     depends_on:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -55,8 +55,8 @@ steps:
       - github_commit_status:
           context: Lint
 
-  - label: Unit Tests
-    key: unit-tests
+  - label: Android Unit Tests
+    key: android-unit-tests
     plugins:
       - *ci_toolkit_plugin
       - *nvm_plugin
@@ -66,12 +66,34 @@ steps:
       npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 
       echo "--- :node: Lint and Unit Tests"
-      CHECK_CORRECTNESS=false CHECK_TESTS=true ./bin/ci-checks-js.sh
+      CHECK_CORRECTNESS=false CHECK_TESTS=true TEST_RN_PLATFORM=android ./bin/ci-checks-js.sh
     agents:
       queue: mac
     env:
       <<: *xcode_agent_env
       JEST_JUNIT_OUTPUT_FILE: reports/test-results/android-test-results.xml
+    artifact_paths:
+      - ./logs/*.log
+      - ./reports/test-results/*.xml
+    notify:
+      - github_commit_status:
+          context: Android Unit Tests
+
+  - label: iOS Unit Tests
+    key: ios-unit-tests
+    plugins:
+      - *ci_toolkit_plugin
+      - *nvm_plugin
+      - *git-cache-plugin
+    command: |
+      echo "--- :npm: Install Node dependencies"
+      npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
+
+      echo "--- :node: Lint and Unit Tests"
+      CHECK_CORRECTNESS=false CHECK_TESTS=true TEST_RN_PLATFORM=ios ./bin/ci-checks-js.sh
+    agents:
+      queue: mac
+    env: *xcode_agent_env
     artifact_paths:
       - ./logs/*.log
       - ./reports/test-results/*.xml
@@ -81,7 +103,9 @@ steps:
           context: Lint and Unit Tests
 
   - label: "Build JS Bundles"
-    depends_on: "unit-tests"
+    depends_on:
+      - android-unit-tests
+      - ios-unit-tests
     key: "js-bundles"
     plugins:
       - *gb-mobile-docker-container
@@ -129,7 +153,7 @@ steps:
         fi
 
   - label: "Build Android RN Aztec & Publish to S3"
-    depends_on: unit-tests
+    depends_on: android-unit-tests
     key: "publish-react-native-aztec-android"
     plugins:
       - *git-cache-plugin

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -172,6 +172,9 @@ steps:
 
   - label: iOS Build and Sauce Labs
     key: ios-build-and-saucelabs
+    depends_on:
+      - lint
+      - unit-tests-ios
     command: .buildkite/commands/build-ios.sh
     plugins:
       - *ci_toolkit_plugin

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -42,12 +42,7 @@ steps:
       - *ci_toolkit_plugin
       - *nvm_plugin
       - *git-cache-plugin
-    command: |
-      echo "--- :npm: Install Node dependencies"
-      npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
-
-      echo "--- :node: Lint"
-      CHECK_CORRECTNESS=true CHECK_TESTS=false ./bin/ci-checks-js.sh
+    command: .buildkite/commands/lint.sh
     agents:
       queue: mac
     env: *xcode_agent_env
@@ -61,12 +56,7 @@ steps:
       - *ci_toolkit_plugin
       - *nvm_plugin
       - *git-cache-plugin
-    command: |
-      echo "--- :npm: Install Node dependencies"
-      npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
-
-      echo "--- :node: Lint and Unit Tests"
-      CHECK_CORRECTNESS=false CHECK_TESTS=true TEST_RN_PLATFORM=android ./bin/ci-checks-js.sh
+    command: .buildkite/commands/unit-tests-android.sh
     agents:
       queue: mac
     env:
@@ -85,12 +75,7 @@ steps:
       - *ci_toolkit_plugin
       - *nvm_plugin
       - *git-cache-plugin
-    command: |
-      echo "--- :npm: Install Node dependencies"
-      npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
-
-      echo "--- :node: Lint and Unit Tests"
-      CHECK_CORRECTNESS=false CHECK_TESTS=true TEST_RN_PLATFORM=ios ./bin/ci-checks-js.sh
+    command: .buildkite/commands/unit-tests-ios.sh
     agents:
       queue: mac
     env: *xcode_agent_env

--- a/bin/ci-checks-js.sh
+++ b/bin/ci-checks-js.sh
@@ -14,13 +14,14 @@ function pFail() {
 
 function checkDiff() {
   set +e
-  diff=$(git diff)
+  LOCKFILE='package-lock.json'
+  diff=$(git diff -- "$LOCKFILE")
   set -e
   if [[ $? != 0 ]]; then
     pFail
   elif [[ $diff ]]; then
     echo "$diff"
-    pFail "package-lock.json has changed. Please run npm install and commit the diff"
+    pFail "$LOCKFILE has changed. Please run npm install and commit the diff"
   else
     pOk
   fi


### PR DESCRIPTION
In the interest of shortening the feedback look, I split the lint and unit tests tasks. This results in more compute because we now have three steps setting up the VM and the dependencies, but we shave off ~4 minutes from the delivery time of the results. 

**Before**
<img width="1197" alt="Screenshot 2023-10-04 at 1 20 02 pm" src="https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/af164308-5ce5-4c1b-9d12-11e3a8197283">

**After**. Notice the speed bump is also due to running on macOS agents vs Docker VMs.
<img width="1183" alt="Screenshot 2023-10-04 at 1 19 41 pm" src="https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/bc3ee835-500c-46d7-b0d1-f3f6b4e1a233">


To test, verify CI is green.

**Before merging:** We'll need to update the GitHub checks to go from one required step to three.

PR submission checklist:

- [x] I have considered adding unit tests where possible. – N.A.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary. N.A.
