### PR TITLE
Revert Skip Buildkite steps for branches for dependabot PRs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,9 +33,6 @@ x-common-params:
     build.branch != 'trunk' && build.branch !~ /^release.*/ && build.branch !~ /^dependabot\/submodules.*/
 
 steps:
-  - block: "Request trigger Android bundle and builds"
-    branches: "dependabot/submodules/*"
-
   - label: Lint and Unit Tests
     key: unit-tests
     plugins:


### PR DESCRIPTION
This PR reverts https://github.com/wordpress-mobile/gutenberg-mobile/pull/5476 now that all of the iOS jobs are running with Buildkite.

To test:

CI checks should pass. This branch has the name `dependabot/submodules/*` to trigger the behavior for Dependabot PRs.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
