### PR TITLE
Use `UnsupportedBlockDetails` component in Missing block

### DIFF
--- a/src/jetpack-editor-setup.js
+++ b/src/jetpack-editor-setup.js
@@ -177,8 +177,7 @@ const setupStringsOverrides = () => {
 
 			if (
 				onlyCoreBlocks &&
-				jetpackBlockNames.includes( blockName ) &&
-				videoPressBlock
+				( jetpackBlockNames.includes( blockName ) || videoPressBlock )
 			) {
 				return null;
 			}

--- a/src/jetpack-editor-setup.js
+++ b/src/jetpack-editor-setup.js
@@ -169,13 +169,16 @@ const setupStringsOverrides = () => {
 			const { capabilities } = select( blockEditorStore ).getSettings();
 			const onlyCoreBlocks = capabilities?.onlyCoreBlocks === true;
 
-			const jetpackBlockNames = Object.keys( supportedJetpackBlocks ).map(
-				( name ) =>
-					// Add `jetpack` prefix if the block name doesn't contain a prefix.
-					/^(\w|-)+$/.test( name ) ? `jetpack/${ name }` : name
+			const namespacedBlockNames = Object.keys(
+				supportedJetpackBlocks
+			).map( ( name ) =>
+				/^(\w|-)+$/.test( name ) ? `jetpack/${ name }` : name
 			);
 
-			if ( onlyCoreBlocks && jetpackBlockNames.includes( blockName ) ) {
+			if (
+				onlyCoreBlocks &&
+				namespacedBlockNames.includes( blockName )
+			) {
 				return null;
 			}
 			return defaultValue;

--- a/src/jetpack-editor-setup.js
+++ b/src/jetpack-editor-setup.js
@@ -170,15 +170,12 @@ const setupStringsOverrides = () => {
 			const onlyCoreBlocks = capabilities?.onlyCoreBlocks === true;
 
 			const jetpackBlockNames = Object.keys( supportedJetpackBlocks ).map(
-				( name ) => `jetpack/${ name }`
+				( name ) =>
+					// Add `jetpack` prefix if the block name doesn't contain a prefix.
+					/^(\w|-)+$/.test( name ) ? `jetpack/${ name }` : name
 			);
 
-			const videoPressBlock = blockName === 'videopress/video';
-
-			if (
-				onlyCoreBlocks &&
-				( jetpackBlockNames.includes( blockName ) || videoPressBlock )
-			) {
+			if ( onlyCoreBlocks && jetpackBlockNames.includes( blockName ) ) {
 				return null;
 			}
 			return defaultValue;

--- a/src/strings-overrides.js
+++ b/src/strings-overrides.js
@@ -36,26 +36,6 @@ addFilter(
 	}
 );
 
-addFilter(
-	'native.missing_block_action_button',
-	'native/missing_block',
-	( defaultValue ) => {
-		const { capabilities } = select( blockEditorStore ).getSettings();
-		const isUnsupportedBlockEditorSupported =
-			capabilities?.unsupportedBlockEditor === true;
-		const canEnableUnsupportedBlockEditor =
-			capabilities?.canEnableUnsupportedBlockEditor === true;
-
-		const shouldOverwriteButtonTitle =
-			isUnsupportedBlockEditorSupported === false &&
-			canEnableUnsupportedBlockEditor;
-
-		return shouldOverwriteButtonTitle
-			? __( 'Open Jetpack Security settings' )
-			: defaultValue;
-	}
-);
-
 // Add extra note to `UnsupportedBlockDetails` description to explain how to enable UBE, in case
 // it's available but disabled due to Jetpack settings.
 addFilter(

--- a/src/strings-overrides.js
+++ b/src/strings-overrides.js
@@ -21,14 +21,9 @@ addFilter(
 		);
 
 		if (
-			isUnsupportedBlockEditorSupported === false &&
+			isUnsupportedBlockEditorSupported ||
 			canEnableUnsupportedBlockEditor
 		) {
-			const note = __(
-				'Note: You must allow WordPress.com login to edit this block in the mobile editor.'
-			);
-			return unsupportedBlocksExplanation + '\n\n' + note; // Translations can not have characters like '\n', so we add the new lines manually.
-		} else if ( isUnsupportedBlockEditorSupported ) {
 			return unsupportedBlocksExplanation;
 		}
 


### PR DESCRIPTION
**Related PRs:**
* https://github.com/WordPress/gutenberg/pull/55133

**To test:**
Follow testing instructions from https://github.com/WordPress/gutenberg/pull/55133

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
