### PR TITLE
Update Functionality Test 1 for Appium 2

### DIFF
--- a/__device-tests__/gutenberg-editor-functionality-test-1-visual.test.js
+++ b/__device-tests__/gutenberg-editor-functionality-test-1-visual.test.js
@@ -275,6 +275,9 @@ describe( 'Gutenberg Editor - Test Suite 1', () => {
 				1000
 			);
 
+			// Wait for the scrollbars to hide
+			await editorPage.driver.pause( 3000 );
+
 			// Visual test check for adjusted columns
 			const screenshot = await takeScreenshot();
 			expect( screenshot ).toMatchImageSnapshot();

--- a/__device-tests__/gutenberg-editor-functionality-test-1-visual.test.js
+++ b/__device-tests__/gutenberg-editor-functionality-test-1-visual.test.js
@@ -201,11 +201,13 @@ describe( 'Gutenberg Editor - Test Suite 1', () => {
 			if ( isAndroid() ) {
 				await blockButton.click();
 			} else {
-				await editorPage.driver.execute( 'mobile: tap', {
-					element: blockButton,
-					x: 10,
-					y: 10,
-				} );
+				await editorPage.driver.executeScript( 'mobile: tap', [
+					{
+						element: blockButton,
+						x: 10,
+						y: 10,
+					},
+				] );
 			}
 
 			// TODO: determine a way to type a text block nested within a Columns block

--- a/__device-tests__/gutenberg-editor-functionality-test-1-visual.test.js
+++ b/__device-tests__/gutenberg-editor-functionality-test-1-visual.test.js
@@ -62,19 +62,18 @@ describe( 'Gutenberg Editor - Test Suite 1', () => {
 
 			// Click the block appender within the first column
 			if ( isAndroid() ) {
-				await editorPage.driver
-					.elementByAccessibilityId( 'Column Block. Row 1' )
-					.click();
+				await editorPage.driver.$( '~Column Block. Row 1' ).click();
 				const appenderButton =
 					await editorPage.waitForElementToBeDisplayedByXPath(
 						ANDROID_COLUMN_APPENDER_BUTTON_XPATH
 					);
 				await appenderButton.click();
 			} else {
-				await editorPage.driver
-					.elementByAccessibilityId( 'Column Block. Row 1' )
-					.click()
-					.click();
+				const firstColum = await editorPage.driver.$(
+					'~Column Block. Row 1'
+				);
+				await firstColum.click();
+				await firstColum.click();
 			}
 
 			await editorPage.addNewBlock( blockNames.columns, {
@@ -120,19 +119,18 @@ describe( 'Gutenberg Editor - Test Suite 1', () => {
 
 			// Click the block appender within the first column
 			if ( isAndroid() ) {
-				await editorPage.driver
-					.elementByAccessibilityId( 'Column Block. Row 1' )
-					.click();
+				await editorPage.driver.$( '~Column Block. Row 1' ).click();
 				const appenderButton =
 					await editorPage.waitForElementToBeDisplayedByXPath(
 						ANDROID_COLUMN_APPENDER_BUTTON_XPATH
 					);
 				await appenderButton.click();
 			} else {
-				await editorPage.driver
-					.elementByAccessibilityId( 'Column Block. Row 1' )
-					.click()
-					.click();
+				const firstColum = await editorPage.driver.$(
+					'~Column Block. Row 1'
+				);
+				await firstColum.click();
+				await firstColum.click();
 			}
 
 			await editorPage.addNewBlock( blockNames.columns, {
@@ -182,19 +180,18 @@ describe( 'Gutenberg Editor - Test Suite 1', () => {
 
 			// Click the block appender within the first column
 			if ( isAndroid() ) {
-				await editorPage.driver
-					.elementByAccessibilityId( 'Column Block. Row 1' )
-					.click();
+				await editorPage.driver.$( '~Column Block. Row 1' ).click();
 				const appenderButton =
 					await editorPage.waitForElementToBeDisplayedByXPath(
 						ANDROID_COLUMN_APPENDER_BUTTON_XPATH
 					);
 				await appenderButton.click();
 			} else {
-				await editorPage.driver
-					.elementByAccessibilityId( 'Column Block. Row 1' )
-					.click()
-					.click();
+				const firstColum = await editorPage.driver.$(
+					'~Column Block. Row 1'
+				);
+				await firstColum.click();
+				await firstColum.click();
 			}
 
 			// Append a Preformatted block
@@ -239,9 +236,8 @@ describe( 'Gutenberg Editor - Test Suite 1', () => {
 			// Wait for the modal to open
 			await editorPage.driver.pause( 3000 );
 
-			const cellId = 'Column 1. Width is 50 Percent (%).';
-			const cell =
-				await editorPage.driver.elementByAccessibilityId( cellId );
+			const cellId = '~Column 1. Width is 50 Percent (%).';
+			const cell = await editorPage.driver.$( cellId );
 			const cellSize = await cell.getSize();
 			const cellLocation = await cell.getLocation();
 			const scrollOffset = isAndroid() ? 350 : 100;
@@ -324,7 +320,7 @@ describe( 'Gutenberg Editor - Test Suite 1', () => {
 			const socialLinksBlockXpath = isAndroid()
 				? '//android.widget.Button[@content-desc="Social Icons Block. Row 1"]'
 				: '(//XCUIElementTypeOther[@name="Social Icons Block. Row 1"])[1]';
-			const socialLinksBlock = await editorPage.driver.elementByXPath(
+			const socialLinksBlock = await editorPage.driver.$(
 				socialLinksBlockXpath
 			);
 
@@ -374,7 +370,7 @@ describe( 'Gutenberg Editor - Test Suite 1', () => {
 			const socialLinksBlockXpath = isAndroid()
 				? '//android.widget.Button[@content-desc="Social Icons Block. Row 1"]'
 				: '(//XCUIElementTypeOther[@name="Social Icons Block. Row 1"])[1]';
-			const socialLinksBlock = await editorPage.driver.elementByXPath(
+			const socialLinksBlock = await editorPage.driver.$(
 				socialLinksBlockXpath
 			);
 

--- a/__device-tests__/gutenberg-editor-functionality-test-1-visual.test.js
+++ b/__device-tests__/gutenberg-editor-functionality-test-1-visual.test.js
@@ -23,11 +23,11 @@ describe( 'Gutenberg Editor - Test Suite 1', () => {
 			await editorPage.initializeEditor();
 			await editorPage.addNewBlock( blockNames.columns );
 			// Wait for the modal to open
-			await editorPage.driver.sleep( 3000 );
+			await editorPage.driver.pause( 3000 );
 			// Dismiss columns layout picker
 			await editorPage.dismissBottomSheet();
 			// Wait for the modal to close
-			await editorPage.driver.sleep( 3000 );
+			await editorPage.driver.pause( 3000 );
 			// Select title to unfocus the block
 			const titleElement = await editorPage.getTitleElement();
 			await titleElement.click();
@@ -39,7 +39,7 @@ describe( 'Gutenberg Editor - Test Suite 1', () => {
 
 			await toggleOrientation( editorPage.driver );
 			// Wait for the device to finish rotating
-			await editorPage.driver.sleep( 3000 );
+			await editorPage.driver.pause( 3000 );
 
 			// Visual test check for landscape orientation
 			screenshot = await takeScreenshot();
@@ -47,18 +47,18 @@ describe( 'Gutenberg Editor - Test Suite 1', () => {
 
 			await toggleOrientation( editorPage.driver );
 			// Wait for the device to finish rotating
-			await editorPage.driver.sleep( 3000 );
+			await editorPage.driver.pause( 3000 );
 		} );
 
 		it( 'displays correctly in portrait and landscape orientations', async () => {
 			await editorPage.initializeEditor();
 			await editorPage.addNewBlock( blockNames.columns );
 			// Wait for the modal to open
-			await editorPage.driver.sleep( 3000 );
+			await editorPage.driver.pause( 3000 );
 			// Dismiss columns layout picker
 			await editorPage.dismissBottomSheet();
 			// Wait for the modal to close
-			await editorPage.driver.sleep( 3000 );
+			await editorPage.driver.pause( 3000 );
 
 			// Click the block appender within the first column
 			if ( isAndroid() ) {
@@ -82,14 +82,14 @@ describe( 'Gutenberg Editor - Test Suite 1', () => {
 			} );
 
 			// Wait for the modal to open
-			await editorPage.driver.sleep( 3000 );
+			await editorPage.driver.pause( 3000 );
 			// Dismiss columns layout picker
 			await editorPage.dismissBottomSheet();
 			// Wait for the modal to close
-			await editorPage.driver.sleep( 3000 );
+			await editorPage.driver.pause( 3000 );
 			// Navigate upwards in block hierarchy
 			await editorPage.moveBlockSelectionUp( { toRoot: true } );
-			await editorPage.driver.sleep( 1000 );
+			await editorPage.driver.pause( 1000 );
 
 			// Visual test check for portrait orientation
 			let screenshot = await takeScreenshot();
@@ -97,7 +97,7 @@ describe( 'Gutenberg Editor - Test Suite 1', () => {
 
 			await toggleOrientation( editorPage.driver );
 			// Wait for the device to finish rotating
-			await editorPage.driver.sleep( 3000 );
+			await editorPage.driver.pause( 3000 );
 
 			// Visual test check for landscape orientation
 			screenshot = await takeScreenshot();
@@ -105,18 +105,18 @@ describe( 'Gutenberg Editor - Test Suite 1', () => {
 
 			await toggleOrientation( editorPage.driver );
 			// Wait for the device to finish rotating
-			await editorPage.driver.sleep( 3000 );
+			await editorPage.driver.pause( 3000 );
 		} );
 
 		it( 'mover buttons display in the correct positions', async () => {
 			await editorPage.initializeEditor();
 			await editorPage.addNewBlock( blockNames.columns );
 			// Wait for the modal to open
-			await editorPage.driver.sleep( 3000 );
+			await editorPage.driver.pause( 3000 );
 			// Dismiss columns layout picker
 			await editorPage.dismissBottomSheet();
 			// Wait for the modal to close
-			await editorPage.driver.sleep( 3000 );
+			await editorPage.driver.pause( 3000 );
 
 			// Click the block appender within the first column
 			if ( isAndroid() ) {
@@ -140,12 +140,12 @@ describe( 'Gutenberg Editor - Test Suite 1', () => {
 			} );
 
 			// Wait for the modal to open
-			await editorPage.driver.sleep( 3000 );
+			await editorPage.driver.pause( 3000 );
 			// Dismiss columns layout picker
 			await editorPage.dismissBottomSheet();
 			await toggleOrientation( editorPage.driver );
 			// Wait for the device to finish rotating
-			await editorPage.driver.sleep( 3000 );
+			await editorPage.driver.pause( 3000 );
 
 			// Visual test check for landscape orientation
 			let screenshot = await takeScreenshot();
@@ -153,7 +153,7 @@ describe( 'Gutenberg Editor - Test Suite 1', () => {
 
 			// Navigate upwards in block hierarchy
 			await editorPage.moveBlockSelectionUp();
-			await editorPage.driver.sleep( 1000 );
+			await editorPage.driver.pause( 1000 );
 
 			// Visual test check for landscape orientation
 			screenshot = await takeScreenshot();
@@ -161,7 +161,7 @@ describe( 'Gutenberg Editor - Test Suite 1', () => {
 
 			await toggleOrientation( editorPage.driver );
 			// Wait for the device to finish rotating
-			await editorPage.driver.sleep( 3000 );
+			await editorPage.driver.pause( 3000 );
 		} );
 
 		it( 'displays with correct colors with dark mode enabled', async () => {
@@ -170,11 +170,11 @@ describe( 'Gutenberg Editor - Test Suite 1', () => {
 
 			await editorPage.addNewBlock( blockNames.columns );
 			// Wait for the modal to open
-			await editorPage.driver.sleep( 3000 );
+			await editorPage.driver.pause( 3000 );
 			// Dismiss columns layout picker
 			await editorPage.dismissBottomSheet();
 			// Wait for the modal to close
-			await editorPage.driver.sleep( 3000 );
+			await editorPage.driver.pause( 3000 );
 
 			// Visual test check for placeholders
 			let screenshot = await takeScreenshot();
@@ -214,13 +214,13 @@ describe( 'Gutenberg Editor - Test Suite 1', () => {
 			// TODO: determine a way to type a text block nested within a Columns block
 
 			// Wait for the modal to close
-			await editorPage.driver.sleep( 3000 );
+			await editorPage.driver.pause( 3000 );
 			// Navigate upwards in block hierarchy
 			await editorPage.moveBlockSelectionUp( { toRoot: true } );
 			await editorPage.waitForKeyboardToBeHidden();
 			// Android fails to display the keyboard at times, which can cause the
 			// above `waitForKeyboardToBeHidden` to finish prematurely.
-			await editorPage.driver.sleep( 1000 );
+			await editorPage.driver.pause( 1000 );
 
 			// Visual test check for nested content
 			screenshot = await takeScreenshot();
@@ -233,11 +233,11 @@ describe( 'Gutenberg Editor - Test Suite 1', () => {
 			await editorPage.initializeEditor();
 			await editorPage.addNewBlock( blockNames.columns );
 			// Wait for the modal to open
-			await editorPage.driver.sleep( 3000 );
+			await editorPage.driver.pause( 3000 );
 			await editorPage.dismissBottomSheet();
 			await editorPage.openBlockSettings();
 			// Wait for the modal to open
-			await editorPage.driver.sleep( 3000 );
+			await editorPage.driver.pause( 3000 );
 
 			const cellId = 'Column 1. Width is 50 Percent (%).';
 			const cell =
@@ -288,7 +288,7 @@ describe( 'Gutenberg Editor - Test Suite 1', () => {
 			} );
 
 			// Wait for the block to be rendered
-			await editorPage.driver.sleep( 3000 );
+			await editorPage.driver.pause( 3000 );
 
 			// Visual test check
 			const screenshot = await takeScreenshot();
@@ -320,7 +320,7 @@ describe( 'Gutenberg Editor - Test Suite 1', () => {
 			);
 			await editorPage.dismissBottomSheet();
 			// Wait for the modal to close
-			await editorPage.driver.sleep( 3000 );
+			await editorPage.driver.pause( 3000 );
 			const socialLinksBlockXpath = isAndroid()
 				? '//android.widget.Button[@content-desc="Social Icons Block. Row 1"]'
 				: '(//XCUIElementTypeOther[@name="Social Icons Block. Row 1"])[1]';
@@ -369,7 +369,7 @@ describe( 'Gutenberg Editor - Test Suite 1', () => {
 			);
 			await editorPage.dismissBottomSheet();
 			// Wait for the modal to close
-			await editorPage.driver.sleep( 3000 );
+			await editorPage.driver.pause( 3000 );
 
 			const socialLinksBlockXpath = isAndroid()
 				? '//android.widget.Button[@content-desc="Social Icons Block. Row 1"]'

--- a/__device-tests__/gutenberg-editor-functionality-test-1-visual.test.js
+++ b/__device-tests__/gutenberg-editor-functionality-test-1-visual.test.js
@@ -198,17 +198,7 @@ describe( 'Gutenberg Editor - Test Suite 1', () => {
 			const blockButton = await editorPage.findBlockButton(
 				blockNames.preformatted
 			);
-			if ( isAndroid() ) {
-				await blockButton.click();
-			} else {
-				await editorPage.driver.executeScript( 'mobile: tap', [
-					{
-						element: blockButton,
-						x: 10,
-						y: 10,
-					},
-				] );
-			}
+			await blockButton.click();
 
 			// TODO: determine a way to type a text block nested within a Columns block
 


### PR DESCRIPTION
## Related PRs
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6276
- https://github.com/WordPress/gutenberg/pull/55166

## What?
This PR updates the Functionality Test 1 tests to WebdriverIO and Appium 2.

## Why?
To continue with the migration effort to support this new version and new driver.

## How?
- Renaming the element selectors
- Replace the usage of `sleep` in favor of `pause`
- Migrated the usage of `execute`
- Added an extra pause before capturing the screenshot due to flakiness related to the scrollbar appearing in the screenshot where it shouldn't

## Testing Instructions
Local tests should pass by running the following command for both platforms:

**Android**
```
TEST_RN_PLATFORM=android npm run device-tests:local gutenberg-editor-functionality-test-1-visual.test
```

**iOS**
```
TEST_RN_PLATFORM=ios npm run device-tests:local gutenberg-editor-functionality-test-1-visual.test
```

I've also confirmed it runs on SauceLabs by triggering the test from a local command against the Appium 2 build.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
