### PR TITLE
test: Update Gallery test for Appium 2

### DIFF
--- a/__device-tests__/gutenberg-editor-gallery-visual.test.js
+++ b/__device-tests__/gutenberg-editor-gallery-visual.test.js
@@ -25,7 +25,7 @@ describe( 'Gutenberg Editor Visual test for Gallery Block', () => {
 		expect( galleryBlock ).toBeTruthy();
 
 		// Wait for images to load
-		await editorPage.driver.sleep( 5000 );
+		await editorPage.driver.pause( 5000 );
 
 		// Visual test check
 		const screenshot = await takeScreenshot();


### PR DESCRIPTION
## Related PRs

- https://github.com/WordPress/gutenberg/pull/55427

## What?
<!-- In a few words, what is the PR actually doing? -->
Relates to #6276. Update the Gallery tests for Appium 2 and WebdriverIO.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Improve the stability and quality of the automated tests.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Replace `sleep` with `pause`
- Repair utility to close the bottom sheet

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Local tests should pass for both platforms when running the following commands:

```
TEST_RN_PLATFORM=ios npm run device-tests:local gutenberg-editor-gallery-visual
```

```
TEST_RN_PLATFORM=android npm run device-tests:local gutenberg-editor-gallery-visual
```

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.

