### PR TITLE
Run linting and unit tests tasks in parallel in CI

### DIFF
--- a/.buildkite/commands/build-ios.sh
+++ b/.buildkite/commands/build-ios.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 echo '--- :node: Setup Node depenendencies'
-npm ci
+npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 
 echo '--- :ios: Set env var for iOS E2E testing'
 set -x

--- a/.buildkite/commands/lint.sh
+++ b/.buildkite/commands/lint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eu
+
+echo "--- :npm: Install Node dependencies"
+npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
+
+echo "--- :node: Lint"
+CHECK_CORRECTNESS=true CHECK_TESTS=false ./bin/ci-checks-js.sh

--- a/.buildkite/commands/publish-react-native-ios-artifacts.sh
+++ b/.buildkite/commands/publish-react-native-ios-artifacts.sh
@@ -7,7 +7,7 @@ mkdir -p ios-xcframework/Gutenberg/Resources
 tar -xzvf ios-assets.tar.gz -C ios-xcframework/Gutenberg/Resources/
 
 echo '--- :node: Setup node_modules for RNReanimated'
-npm ci
+npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 
 echo "--- :rubygems: Setting up Gems"
 cd ./ios-xcframework

--- a/.buildkite/commands/unit-tests-android.sh
+++ b/.buildkite/commands/unit-tests-android.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eu
+
+echo "--- :npm: Install Node dependencies"
+npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
+
+echo "--- :node: Lint and Unit Tests"
+CHECK_CORRECTNESS=false CHECK_TESTS=true TEST_RN_PLATFORM=android ./bin/ci-checks-js.sh

--- a/.buildkite/commands/unit-tests-ios.sh
+++ b/.buildkite/commands/unit-tests-ios.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eu
+
+echo "--- :npm: Install Node dependencies"
+npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
+
+echo "--- :node: Lint and Unit Tests"
+CHECK_CORRECTNESS=false CHECK_TESTS=true TEST_RN_PLATFORM=ios ./bin/ci-checks-js.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -175,6 +175,9 @@ steps:
 
   - label: iOS Build and Sauce Labs
     key: ios-build-and-saucelabs
+    depends_on:
+      - lint
+      - ios-unit-tests
     command: .buildkite/commands/build-ios.sh
     plugins:
       - *ci_toolkit_plugin

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,8 +37,6 @@ steps:
     key: lint
     plugins:
       - *gb-mobile-docker-container
-      - *ci_toolkit_plugin
-      - *nvm_plugin
       - *git-cache-plugin
     command: |
       echo "--- :docker: Additional Docker image setup"
@@ -57,8 +55,6 @@ steps:
     plugins:
       - *gb-mobile-docker-container
       - *ci_toolkit_plugin
-      - *nvm_plugin
-      - *git-cache-plugin
     command: |
       echo "--- :docker: Additional Docker image setup"
       source /root/.bashrc
@@ -81,8 +77,6 @@ steps:
     plugins:
       - *gb-mobile-docker-container
       - *ci_toolkit_plugin
-      - *nvm_plugin
-      - *git-cache-plugin
     command: |
       echo "--- :docker: Additional Docker image setup"
       source /root/.bashrc

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -56,8 +56,8 @@ steps:
       - github_commit_status:
           context: Lint
 
-  - label: Unit Tests
-    key: unit-tests
+  - label: Android Unit Tests
+    key: android-unit-tests
     plugins:
       - *gb-mobile-docker-container
       - *ci_toolkit_plugin
@@ -70,9 +70,29 @@ steps:
       echo "--- :npm: Install Node dependencies"
       npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 
-      CHECK_CORRECTNESS=false CHECK_TESTS=true ./bin/ci-checks-js.sh
+      CHECK_CORRECTNESS=false CHECK_TESTS=true TEST_RN_PLATFORM=android ./bin/ci-checks-js.sh
     env:
       JEST_JUNIT_OUTPUT_FILE: reports/test-results/android-test-results.xml
+    artifact_paths:
+      - ./logs/*.log
+      - ./reports/test-results/*.xml
+    notify:
+      - github_commit_status:
+          context: Android Unit Tests
+
+  - label: iOS Unit Tests
+    key: ios-unit-tests
+    plugins:
+      - *gb-mobile-docker-container
+      - *ci_toolkit_plugin
+      - *nvm_plugin
+      - *git-cache-plugin
+    command: |
+      echo "--- :npm: Install Node dependencies"
+      npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
+
+      echo "--- :node: Lint and Unit Tests"
+      CHECK_CORRECTNESS=false CHECK_TESTS=true TEST_RN_PLATFORM=ios ./bin/ci-checks-js.sh
     artifact_paths:
       - ./logs/*.log
       - ./reports/test-results/*.xml
@@ -82,7 +102,9 @@ steps:
           context: Lint and Unit Tests
 
   - label: "Build JS Bundles"
-    depends_on: "unit-tests"
+    depends_on:
+      - android-unit-tests
+      - ios-unit-tests
     key: "js-bundles"
     plugins:
       - *gb-mobile-docker-container
@@ -130,7 +152,7 @@ steps:
         fi
 
   - label: "Build Android RN Aztec & Publish to S3"
-    depends_on: unit-tests
+    depends_on: android-unit-tests
     key: "publish-react-native-aztec-android"
     plugins:
       - *git-cache-plugin

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,14 +44,7 @@ steps:
       echo "--- :docker: Additional Docker image setup"
       source /root/.bashrc
 
-      echo "--- :npm: Install Node dependencies"
-      npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
-
-      echo "--- :node: Lint"
-      CHECK_CORRECTNESS=true CHECK_TESTS=false ./bin/ci-checks-js.sh
-    agents:
-      queue: mac
-    env: *xcode_agent_env
+      .buildkite/commands/lint.sh
     notify:
       - github_commit_status:
           context: Lint
@@ -67,10 +60,7 @@ steps:
       echo "--- :docker: Additional Docker image setup"
       source /root/.bashrc
 
-      echo "--- :npm: Install Node dependencies"
-      npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
-
-      CHECK_CORRECTNESS=false CHECK_TESTS=true TEST_RN_PLATFORM=android ./bin/ci-checks-js.sh
+      .buildkite/commands/unit-tests-android.sh
     env:
       JEST_JUNIT_OUTPUT_FILE: reports/test-results/android-test-results.xml
     artifact_paths:
@@ -88,11 +78,10 @@ steps:
       - *nvm_plugin
       - *git-cache-plugin
     command: |
-      echo "--- :npm: Install Node dependencies"
-      npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
+      echo "--- :docker: Additional Docker image setup"
+      source /root/.bashrc
 
-      echo "--- :node: Lint and Unit Tests"
-      CHECK_CORRECTNESS=false CHECK_TESTS=true TEST_RN_PLATFORM=ios ./bin/ci-checks-js.sh
+      .buildkite/commands/unit-tests-ios.sh
     artifact_paths:
       - ./logs/*.log
       - ./reports/test-results/*.xml

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,26 +33,50 @@ x-common-params:
     build.branch != 'trunk' && build.branch !~ /^release.*/ && build.branch !~ /^dependabot\/submodules.*/
 
 steps:
-  - label: Lint and Unit Tests
-    key: unit-tests
+  - label: Lint
+    key: lint
     plugins:
       - *gb-mobile-docker-container
+      - *ci_toolkit_plugin
+      - *nvm_plugin
+      - *git-cache-plugin
     command: |
+      echo "--- :docker: Additional Docker image setup"
       source /root/.bashrc
-
-      echo "--- :node: Setup Node environment"
-      nvm install && nvm use
 
       echo "--- :npm: Install Node dependencies"
       npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 
-      echo "--- :node: Lint and Unit Tests"
-      ./bin/ci-checks-js.sh
+      echo "--- :node: Lint"
+      CHECK_CORRECTNESS=true CHECK_TESTS=false ./bin/ci-checks-js.sh
+    agents:
+      queue: mac
+    env: *xcode_agent_env
+    notify:
+      - github_commit_status:
+          context: Lint
+
+  - label: Unit Tests
+    key: unit-tests
+    plugins:
+      - *gb-mobile-docker-container
+      - *ci_toolkit_plugin
+      - *nvm_plugin
+      - *git-cache-plugin
+    command: |
+      echo "--- :docker: Additional Docker image setup"
+      source /root/.bashrc
+
+      echo "--- :npm: Install Node dependencies"
+      npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
+
+      CHECK_CORRECTNESS=false CHECK_TESTS=true ./bin/ci-checks-js.sh
     env:
       JEST_JUNIT_OUTPUT_FILE: reports/test-results/android-test-results.xml
     artifact_paths:
       - ./logs/*.log
       - ./reports/test-results/*.xml
+    # FIXME: Will need to update the GitHub setup again for the reporting and required checks
     notify:
       - github_commit_status:
           context: Lint and Unit Tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -85,10 +85,9 @@ steps:
     artifact_paths:
       - ./logs/*.log
       - ./reports/test-results/*.xml
-    # FIXME: Will need to update the GitHub setup again for the reporting and required checks
     notify:
       - github_commit_status:
-          context: Lint and Unit Tests
+          context: iOS Unit Tests
 
   - label: "Build JS Bundles"
     depends_on:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -92,6 +92,7 @@ steps:
 
   - label: "Build JS Bundles"
     depends_on:
+      - lint
       - android-unit-tests
       - ios-unit-tests
     key: "js-bundles"
@@ -141,7 +142,9 @@ steps:
         fi
 
   - label: "Build Android RN Aztec & Publish to S3"
-    depends_on: android-unit-tests
+    depends_on:
+      - lint
+      - android-unit-tests
     key: "publish-react-native-aztec-android"
     plugins:
       - *git-cache-plugin

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,6 +44,9 @@ steps:
       echo "--- :docker: Additional Docker image setup"
       source /root/.bashrc
 
+      echo "--- :docker::node: Setup Node environment"
+      nvm install && nvm use
+
       .buildkite/commands/lint.sh
     notify:
       - github_commit_status:
@@ -59,6 +62,9 @@ steps:
     command: |
       echo "--- :docker: Additional Docker image setup"
       source /root/.bashrc
+
+      echo "--- :docker::node: Setup Node environment"
+      nvm install && nvm use
 
       .buildkite/commands/unit-tests-android.sh
     env:
@@ -80,6 +86,9 @@ steps:
     command: |
       echo "--- :docker: Additional Docker image setup"
       source /root/.bashrc
+
+      echo "--- :docker::node: Setup Node environment"
+      nvm install && nvm use
 
       .buildkite/commands/unit-tests-ios.sh
     artifact_paths:

--- a/bin/ci-checks-js.sh
+++ b/bin/ci-checks-js.sh
@@ -14,13 +14,14 @@ function pFail() {
 
 function checkDiff() {
   set +e
-  diff=$(git diff)
+  LOCKFILE='package-lock.json'
+  diff=$(git diff -- "$LOCKFILE")
   set -e
   if [[ $? != 0 ]]; then
     pFail
   elif [[ $diff ]]; then
     echo "$diff"
-    pFail "package-lock.json has changed. Please run npm install and commit the diff"
+    pFail "$LOCKFILE has changed. Please run npm install and commit the diff"
   else
     pOk
   fi


### PR DESCRIPTION
Before, we had a 18-21 mins wait time on the lint + testing information:

<img width="1177" alt="image" src="https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/9ada037a-0b39-409f-9058-21ef7d9f2daa">

![image](https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/961edf2b-bebd-42f1-b057-e8956e8e9e31)

By running them in parallel on Docker we only wait ~10 minutes—_assuming all three steps start more or less at the same time_.

<img width="1184" alt="image" src="https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/d2f1c283-937f-44ff-81c2-b8f8ae8e92f2">

**Note:** If this is approved, we'll need to update the GitHub configuration to add new individual required checks.

### Testing

See CI builds

PR submission checklist:

- [x] I have considered adding unit tests where possible. – N.A.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary. – N.A.
