### PR TITLE
Update annotate_test_failures to only send Slack notification for trunk merges

### DIFF
--- a/.buildkite/commands/test-ios.sh
+++ b/.buildkite/commands/test-ios.sh
@@ -62,11 +62,11 @@ else
     echo "npm run $TESTS_CMD failed."
     echo "For more details about the failed tests, check the Buildkite annotation, the logs under the '$SECTION' section and the tests results in the artifacts tab."
 
-    exit $TESTS_EXIT_CODE
-fi
+    if [[ $BUILDKITE_BRANCH == trunk ]]; then
+        annotate_test_failures "$JEST_JUNIT_OUTPUT_FILE" --slack "build-and-ship"
+    else
+        annotate_test_failures "$JEST_JUNIT_OUTPUT_FILE"
+    fi
 
-if [[ $BUILDKITE_BRANCH == trunk ]] || [[ $BUILDKITE_BRANCH == send-slack-notification-only-trunk-failures ]]; then
-    annotate_test_failures "$JEST_JUNIT_OUTPUT_FILE" --slack "build-and-ship"
-else
-    annotate_test_failures "$JEST_JUNIT_OUTPUT_FILE"
+    exit $TESTS_EXIT_CODE
 fi

--- a/.buildkite/commands/test-ios.sh
+++ b/.buildkite/commands/test-ios.sh
@@ -62,6 +62,11 @@ else
     echo "npm run $TESTS_CMD failed."
     echo "For more details about the failed tests, check the Buildkite annotation, the logs under the '$SECTION' section and the tests results in the artifacts tab."
 
-    annotate_test_failures "$JEST_JUNIT_OUTPUT_FILE" --slack "build-and-ship"
+    if [[ $BUILDKITE_BRANCH == trunk ]]; then
+        annotate_test_failures "$JEST_JUNIT_OUTPUT_FILE" --slack "build-and-ship"
+    else
+        annotate_test_failures "$JEST_JUNIT_OUTPUT_FILE"
+    fi
+
     exit $TESTS_EXIT_CODE
 fi

--- a/.buildkite/commands/test-ios.sh
+++ b/.buildkite/commands/test-ios.sh
@@ -62,11 +62,11 @@ else
     echo "npm run $TESTS_CMD failed."
     echo "For more details about the failed tests, check the Buildkite annotation, the logs under the '$SECTION' section and the tests results in the artifacts tab."
 
-    if [[ $BUILDKITE_BRANCH == trunk ]] || [[ $BUILDKITE_BRANCH == send-slack-notification-only-trunk-failures ]]; then
-        annotate_test_failures "$JEST_JUNIT_OUTPUT_FILE" --slack "build-and-ship"
-    else
-        annotate_test_failures "$JEST_JUNIT_OUTPUT_FILE"
-    fi
-
     exit $TESTS_EXIT_CODE
+fi
+
+if [[ $BUILDKITE_BRANCH == trunk ]] || [[ $BUILDKITE_BRANCH == send-slack-notification-only-trunk-failures ]]; then
+    annotate_test_failures "$JEST_JUNIT_OUTPUT_FILE" --slack "build-and-ship"
+else
+    annotate_test_failures "$JEST_JUNIT_OUTPUT_FILE"
 fi

--- a/.buildkite/commands/test-ios.sh
+++ b/.buildkite/commands/test-ios.sh
@@ -62,7 +62,7 @@ else
     echo "npm run $TESTS_CMD failed."
     echo "For more details about the failed tests, check the Buildkite annotation, the logs under the '$SECTION' section and the tests results in the artifacts tab."
 
-    if [[ $BUILDKITE_BRANCH == trunk ]]; then
+    if [[ $BUILDKITE_BRANCH == trunk ]] || [[ $BUILDKITE_BRANCH == send-slack-notification-only-trunk-failures ]]; then
         annotate_test_failures "$JEST_JUNIT_OUTPUT_FILE" --slack "build-and-ship"
     else
         annotate_test_failures "$JEST_JUNIT_OUTPUT_FILE"


### PR DESCRIPTION
### Description
This PR updates the condition for the `annotate_test_failures` plugin, where it would now only send Slack notifications for failing tests on `trunk` merges.

This change should reduce the noise from development branches to the `#build-and-ship` channel.