### PR TITLE
Update Gallery test to use the updated `closeMediaPicker` util

### DIFF
--- a/__device-tests__/gutenberg-editor-gallery-visual.test.js
+++ b/__device-tests__/gutenberg-editor-gallery-visual.test.js
@@ -8,7 +8,7 @@ describe( 'Gutenberg Editor Visual test for Gallery Block', () => {
 	it( 'should be able to render the placeholder correctly', async () => {
 		await editorPage.initializeEditor();
 		await editorPage.addNewBlock( blockNames.gallery );
-		await editorPage.closePicker();
+		await editorPage.closeMediaPicker();
 
 		// Visual test check
 		const screenshot = await takeScreenshot();


### PR DESCRIPTION
## Related PRs
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6276
- https://github.com/WordPress/gutenberg/pull/55166
- Part of https://github.com/WordPress/gutenberg/pull/55484

## What?
This PR updates the Gallery visual test.

## Why?
To use the new name for the `closePicker` util that is now changed to `closeMediaPicker`.

## How?
- Replaces `closePicker` to `closeMediaPicker`

## Testing Instructions
Canary tests should succeed in CI.

Local tests should pass by running the following command for both platforms:

**Android**
```
 TEST_RN_PLATFORM=android npm run device-tests:local gutenberg-editor-media-blocks-@canary.test
```

**iOS**
```
 TEST_RN_PLATFORM=ios npm run device-tests:local gutenberg-editor-media-blocks-@canary.test
```

I've also confirmed it runs on SauceLabs by triggering the test from a local command against the Appium 2 build

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
