### PR TITLE
Classic block: Add option to convert to blocks

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 Unreleased
 ---
+* [*] Classic block: Add option to convert to blocks [https://github.com/WordPress/gutenberg/pull/55461]
 
 1.106.0
 * [*] Exit Preformatted and Verse blocks by triple pressing the Return key [https://github.com/WordPress/gutenberg/pull/53354]

--- a/bundle/android/strings.xml
+++ b/bundle/android/strings.xml
@@ -34,6 +34,7 @@
     <string name="gutenberg_native_add_video" tools:ignore="UnusedResources">Add video</string>
     <string name="gutenberg_native_address_settings" tools:ignore="UnusedResources">Address Settings</string>
     <string name="gutenberg_native_alt_text" tools:ignore="UnusedResources">Alt Text</string>
+    <string name="gutenberg_native_alternatively_you_can_convert_the_content_to_blocks" tools:ignore="UnusedResources">Alternatively, you can convert the content to blocks.</string>
     <string name="gutenberg_native_alternatively_you_can_detach_and_edit_these_blocks_separately_by" tools:ignore="UnusedResources">Alternatively, you can detach and edit these blocks separately by tapping “Detach patterns”.</string>
     <string name="gutenberg_native_alternatively_you_can_detach_and_edit_this_block_separately_by_ta" tools:ignore="UnusedResources">Alternatively, you can detach and edit this block separately by tapping “Detach pattern”.</string>
     <string name="gutenberg_native_an_unknown_error_occurred_please_try_again" tools:ignore="UnusedResources">An unknown error occurred. Please try again.</string>
@@ -179,7 +180,6 @@
     <string name="gutenberg_native_failed_to_save_files_please_tap_for_options" tools:ignore="UnusedResources">Failed to save files.\nPlease tap for options.</string>
     <string name="gutenberg_native_failed_to_upload_files_please_tap_for_options" tools:ignore="UnusedResources">Failed to upload files.\nPlease tap for options.</string>
     <string name="gutenberg_native_featured" tools:ignore="UnusedResources">Featured</string>
-    <string name="gutenberg_native_featured_image" tools:ignore="UnusedResources">Featured Image</string>
     <string name="gutenberg_native_file_block_settings" tools:ignore="UnusedResources">File block settings</string>
     <string name="gutenberg_native_file_name" tools:ignore="UnusedResources">File name</string>
     <string name="gutenberg_native_font_size" tools:ignore="UnusedResources">Font Size</string>
@@ -309,6 +309,8 @@ translators: %s: Select control button label e.g. "Button width" -->
     <!-- translators: %s: Block name e.g. "Image block"
 translators: Block name. %s: The localized block name -->
     <string name="gutenberg_native_s_block" tools:ignore="UnusedResources">%s block</string>
+    <!-- translators: displayed right after the classic block is converted to blocks. %s: The localized classic block name -->
+    <string name="gutenberg_native_s_block_converted_to_blocks" tools:ignore="UnusedResources">\'%s\' block converted to blocks</string>
     <!-- translators: accessibility text for the media block empty state. %s: media type -->
     <string name="gutenberg_native_s_block_empty" tools:ignore="UnusedResources">%s block. Empty</string>
     <!-- translators: Newly available block name. %s: The localized block name -->

--- a/bundle/ios/GutenbergNativeTranslations.swift
+++ b/bundle/ios/GutenbergNativeTranslations.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 private func dummy() {
+    _ = NSLocalizedString("'%s' block converted to blocks", comment: "translators: displayed right after the classic block is converted to blocks. %s: The localized classic block name")
     _ = NSLocalizedString("'%s' is not fully-supported", comment: "translators: Missing block alert title. %s: The localized block name")
     _ = NSLocalizedString("%1$s transformed to %2$s", comment: "translators: 1: From block title, e.g. Paragraph. 2: To block title, e.g. Header.")
     _ = NSLocalizedString("%1$s. %2$s is %3$s %4$s.", comment: "translators: accessibility text. Inform about current value. %1$s: Control label %2$s: setting label (example: width), %3$s: Current value. %4$s: value measurement unit (example: pixels)")
@@ -44,6 +45,7 @@ private func dummy() {
     _ = NSLocalizedString("Add video", comment: "")
     _ = NSLocalizedString("Address Settings", comment: "")
     _ = NSLocalizedString("Alt Text", comment: "")
+    _ = NSLocalizedString("Alternatively, you can convert the content to blocks.", comment: "")
     _ = NSLocalizedString("Alternatively, you can detach and edit these blocks separately by tapping “Detach patterns”.", comment: "")
     _ = NSLocalizedString("Alternatively, you can detach and edit this block separately by tapping “Detach pattern”.", comment: "")
     _ = NSLocalizedString("An unknown error occurred. Please try again.", comment: "")
@@ -165,7 +167,6 @@ private func dummy() {
     _ = NSLocalizedString("Failed to save files.\nPlease tap for options.", comment: "")
     _ = NSLocalizedString("Failed to upload files.\nPlease tap for options.", comment: "")
     _ = NSLocalizedString("Featured", comment: "")
-    _ = NSLocalizedString("Featured Image", comment: "")
     _ = NSLocalizedString("File block settings", comment: "")
     _ = NSLocalizedString("File name", comment: "")
     _ = NSLocalizedString("Font Size", comment: "")


### PR DESCRIPTION
**Related to** https://github.com/WordPress/gutenberg/pull/55461.

**To test:**
Follow testing instructions from https://github.com/WordPress/gutenberg/pull/55461.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
