### PR TITLE
Update second Gutenberg Mobile package reference in `package-lock.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "gutenberg-mobile",
-			"version": "1.105.0",
+			"version": "1.106.0",
 			"hasInstallScript": true,
 			"devDependencies": {
 				"@babel/core": "^7.20.0",


### PR DESCRIPTION
After running `npm install` against `trunk`, the second reference to Gutenberg Mobile's package version in `package-lock.json` was updated from `1.105.0` to `1.106.0`. 

I believe the structure of `package-lock.json` changed following the latest node/npm upgrades in https://github.com/WordPress/gutenberg/pull/53426, which may be why we don't currently account for this second reference as part of our release process. 

To test:

* With this branch checked out, run `npm install` to confirm no changes are suggested.

<hr />

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
