### PR TITLE
Move "Android native tests" from Circle CI to Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -103,7 +103,7 @@ steps:
       - *git-cache-plugin
       - *nvm_plugin
     agents:
-      queue: android-staging
+      queue: android
 
   - label: React Native Bridge Android Tests
     command: |
@@ -114,7 +114,7 @@ steps:
       - *git-cache-plugin
       - *nvm_plugin
     agents:
-      queue: android-staging
+      queue: android
 
   - label: "Build JS Bundles"
     depends_on:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -96,7 +96,7 @@ steps:
 
   - label: React Native Editor Android Tests
     command: |
-      npm ci --prefer-offline --no-audit --no-progress
+      npm ci --prefix gutenberg --prefer-offline --no-audit --no-progress --ignore-scripts
       cd gutenberg/packages/react-native-editor/android
       ./gradlew testDebug
     plugins:
@@ -107,7 +107,7 @@ steps:
 
   - label: React Native Bridge Android Tests
     command: |
-      npm ci --prefer-offline --no-audit --no-progress
+      npm ci --prefix gutenberg --prefer-offline --no-audit --no-progress --ignore-scripts
       cd gutenberg/packages/react-native-bridge/android
       ./gradlew test
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -105,6 +105,17 @@ steps:
     agents:
       queue: android-staging
 
+  - label: React Native Bridge Android Tests
+    command: |
+      npm ci --prefer-offline --no-audit --no-progress
+      cd gutenberg/packages/react-native-bridge/android
+      ./gradlew test
+    plugins:
+      - *git-cache-plugin
+      - *nvm_plugin
+    agents:
+      queue: android-staging
+
   - label: "Build JS Bundles"
     depends_on:
       - lint

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -94,6 +94,17 @@ steps:
       - github_commit_status:
           context: iOS Unit Tests
 
+  - label: React Native Editor Android Tests
+    command: |
+      npm ci --prefer-offline --no-audit --no-progress
+      cd gutenberg/packages/react-native-editor/android
+      ./gradlew testDebug
+    plugins:
+      - *git-cache-plugin
+      - *nvm_plugin
+    agents:
+      queue: android-staging
+
   - label: "Build JS Bundles"
     depends_on:
       - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,9 +215,6 @@ jobs:
       - install-node-version
       - npm-install
       - run:
-          name: Run Android native-editor unit tests
-          command: cd gutenberg/packages/react-native-editor/android && ./gradlew testDebug
-      - run:
           name: Run Android native-bridge unit tests
           command: cd gutenberg/packages/react-native-bridge/android && ./gradlew test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,22 +201,6 @@ jobs:
             JEST_JUNIT_OUTPUT_FILE: "/home/circleci/test-results/android-test-results.xml"
       - store_test_results:
           path: /home/circleci/test-results
-  android-native-unit-tests:
-    parameters:
-      post-to-slack:
-        description: Post to Slack when tests fail. SLACK_WEBHOOK ENV variable must be set.
-        type: boolean
-        default: false
-    docker:
-    - image: << pipeline.parameters.android-docker-image >>
-    steps:
-      - checkout-shallow
-      - checkout-submodules
-      - install-node-version
-      - npm-install
-      - run:
-          name: Run Android native-bridge unit tests
-          command: cd gutenberg/packages/react-native-bridge/android && ./gradlew test
 
 workflows:
   gutenberg-mobile:
@@ -227,8 +211,6 @@ workflows:
           name: Test Android on Device - Canaries
           is-canary: "-canary"
           requires: [ "Android Native Unit Tests", "Android Build" ]
-      - android-native-unit-tests:
-          name: Android Native Unit Tests
       # For regular branches the full test suite is optional.
       - Optional UI Tests:
           type: approval


### PR DESCRIPTION
Move running the Android tests for the `react-native-editor` and `react-native-bridge` in Gutenberg submodule from Circle CI to Buildkite.

Things to note:

- `react-native-editor` doesn't seem to have any tests in the source, as such, I'm guessing CI only works as a safety check that the package build?
- There is another package that matches the `react-native-` pattern in the submodule, `react-native-aztec`. That one, too, has no tests
- The tests are running on the `android-staging` queue, https://github.com/Automattic/buildkite-ci/pull/281. See also the discussion here on things to keep in mind if we consider upgrading the main `android` queue to that configuration https://github.com/Automattic/buildkite-ci/pull/265#issuecomment-1749585960.

At this time, I am unclear on the value of these CI tasks, see also p9ugOq-47C-p2#comment-7715 . I think it's worth migrating them for consistency, but I would urge diving deep into establishing:

- Whether there's value in running these checks at all
- Whether this repo's CI is the appropriate one or they would be better running in the Gutenberg one

---

PR submission checklist:

- [x] I have considered adding unit tests where possible. – N.A.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary. – N.A.