### PR TITLE
Remove the 'version' command from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,8 +104,7 @@
 		"lint": "eslint . --ext .js",
 		"lint:fix": "npm run lint -- --fix",
 		"xcframework:setup": "./bin/xcframework-setup",
-		"xcframework:build": "npm run xcframework:setup && pushd ./ios-xcframework && ./build.sh && popd",
-		"version": "npm run bundle && git add -A bundle"
+		"xcframework:build": "npm run xcframework:setup && pushd ./ios-xcframework && ./build.sh && popd"
 	},
 	"dependencies": {}
 }


### PR DESCRIPTION
The `version` command is running the bundle step which is no longer needed to create a release.
Also, using `npm version <newversion>` is the cleanest way to update the package version. 



To test:
N/A

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
