### PR TITLE
E2E Tests - Organize test device configuration

### DIFF
--- a/.buildkite/commands/build-ios.sh
+++ b/.buildkite/commands/build-ios.sh
@@ -10,7 +10,7 @@ export TEST_ENV=sauce
 CONFIG_FILE="$(pwd)/gutenberg/packages/react-native-editor/__device-tests__/helpers/device-config.json"
 # Uses the local deviceName since SauceLabs uses a different one.
 IOS_DEVICE_NAME=$(jq -r '.ios.local.deviceName' "$CONFIG_FILE")
-IOS_PLATFORM_VERSION=$(jq -r '.ios.server.platformVersion' "$CONFIG_FILE")
+IOS_PLATFORM_VERSION=$(jq -r '.ios.buildkite.platformVersion' "$CONFIG_FILE")
 # Set a destination different from the hardcoded one which only works in the
 # older Xcode-setup used by CircleCI
 export RN_EDITOR_E2E_IOS_DESTINATION="platform=iOS Simulator,name=$IOS_DEVICE_NAME,OS=$IOS_PLATFORM_VERSION"

--- a/.buildkite/commands/build-ios.sh
+++ b/.buildkite/commands/build-ios.sh
@@ -8,7 +8,8 @@ set -x
 export TEST_RN_PLATFORM=ios
 export TEST_ENV=sauce
 CONFIG_FILE="$(pwd)/gutenberg/packages/react-native-editor/__device-tests__/helpers/device-config.json"
-IOS_DEVICE_NAME=$(jq -r '.ios.server.deviceName' "$CONFIG_FILE")
+# Uses the local deviceName since SauceLabs uses a different one.
+IOS_DEVICE_NAME=$(jq -r '.ios.local.deviceName' "$CONFIG_FILE")
 IOS_PLATFORM_VERSION=$(jq -r '.ios.server.platformVersion' "$CONFIG_FILE")
 # Set a destination different from the hardcoded one which only works in the
 # older Xcode-setup used by CircleCI

--- a/.buildkite/commands/build-ios.sh
+++ b/.buildkite/commands/build-ios.sh
@@ -7,9 +7,12 @@ echo '--- :ios: Set env var for iOS E2E testing'
 set -x
 export TEST_RN_PLATFORM=ios
 export TEST_ENV=sauce
+CONFIG_FILE="$(pwd)/gutenberg/packages/react-native-editor/__device-tests__/helpers/device-config.json"
+IOS_DEVICE_NAME=$(jq -r '.ios.server.deviceName' "$CONFIG_FILE")
+IOS_PLATFORM_VERSION=$(jq -r '.ios.server.platformVersion' "$CONFIG_FILE")
 # Set a destination different from the hardcoded one which only works in the
 # older Xcode-setup used by CircleCI
-export RN_EDITOR_E2E_IOS_DESTINATION='platform=iOS Simulator,name=iPhone 14,OS=16.4'
+export RN_EDITOR_E2E_IOS_DESTINATION="platform=iOS Simulator,name=$IOS_DEVICE_NAME,OS=$IOS_PLATFORM_VERSION"
 set +x
 
 echo '--- :react: Build iOS app for E2E testing'

--- a/.buildkite/commands/test-ios.sh
+++ b/.buildkite/commands/test-ios.sh
@@ -28,9 +28,6 @@ set -x
 export TEST_RN_PLATFORM=ios
 export TEST_ENV=sauce
 export JEST_JUNIT_OUTPUT_FILE="reports/test-results/ios-test-results.xml"
-# Set a destination different from the hardcoded one which only works in the
-# older Xcode-setup used by CircleCI
-export RN_EDITOR_E2E_IOS_DESTINATION='platform=iOS Simulator,name=iPhone 13,OS=16.4'
 # This is a relic of the CircleCI setup.
 # It should be removed once the migration to Buildkite is completed.
 export CIRCLE_BRANCH=${BUILDKITE_BRANCH}


### PR DESCRIPTION
**Related PRs:**
- https://github.com/WordPress/gutenberg/pull/55701

This PR updates the build `build-ios.sh` script to pull the device configuration from the newly introduced `device-config.json` file.

To test CI checks should pass.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
