### PR TITLE
Ensure text is always visible within Contact Info block

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 Unreleased
 ---
--   [*] Contact Info: Fix visibility of typed text when used with block based themes in dark mode [https://github.com/Automattic/jetpack/pull/33873]
+-   [*] Contact Info block: Improve legibility of typed text on various background colors [https://github.com/Automattic/jetpack/pull/33873]
 -   [*] Audio block: Improve legibility of audio file details on various background colors [https://github.com/WordPress/gutenberg/pull/55627]
 -   [**] Fix broken appearance of video blocks that were first created on the web [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6371]
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 Unreleased
 ---
+* [*] Contact Info: Fix visibility of typed text when used with block based themes in dark mode [https://github.com/Automattic/jetpack/pull/33873]
 
 1.107.0
 ---

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 Unreleased
 ---
-* [*] Contact Info: Fix visibility of typed text when used with block based themes in dark mode [https://github.com/Automattic/jetpack/pull/33873]
+-   [*] Contact Info: Fix visibility of typed text when used with block based themes in dark mode [https://github.com/Automattic/jetpack/pull/33873]
 -   [**] Fix broken appearance of video blocks that were first created on the web [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6371]
 
 1.108.0


### PR DESCRIPTION
Fixes an issue with the Contact Info block within the app, in which typed text can sometimes be invisible.

The issue occurs when a block based theme is active with a background colour that contrasts with the device's light/dark mode. For example, if a theme's background is light while the device has dark mode enabled, the text will be white on white.

To test, refer to Jetpack PR: https://github.com/Automattic/jetpack/pull/33873

<hr />

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
