### PR TITLE
Use HTTP1.1 to download nodejs package

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,7 +22,9 @@ x-common-params:
         - 'AWS_ACCESS_KEY'
         - 'AWS_SECRET_KEY'
   - &nvm_plugin
-    automattic/nvm#0.2.1
+    automattic/nvm#0.3.0:
+      # This is an attempt to fix curl error (92) during installing nodejs.
+      curlrc: --http1.1
   - &ci_toolkit_plugin
     automattic/a8c-ci-toolkit#2.18.2
   - &xcode_agent_env


### PR DESCRIPTION
## Issue

Sometimes on CI, we got the following error (here is [an example](https://buildkite.com/automattic/gutenberg-mobile/builds/7737#018b8633-2b27-4ed4-8bee-875f26abad94/338-343)) from installing node:
> curl: (92) HTTP/2 stream 0 was not closed cleanly: INTERNAL_ERROR (err 2)

Even though the error is originated from nvm, but it doesn't appear to be an issue in nvm. [The same issue appears in n too](https://www.github.com/tj/n/issues/784#issue-1905460979), which is a similar tool as nvm. And, it's likely an issue in [the node.js package CDN (https://nodejs.org/dist)](https://www.github.com/tj/n/issues/784#issuecomment-1738813821).

## Changes

I have added a new `curlrc` option to the nvm plugin, so that we can pass extra curl arguments to the curl commands invoked by nvm. This PR set the new option to `--http1.1`, which should make nvm downloads nodejs packages using HTTP1.1 instead of HTTP2 protocol, which hopefully would resolve the aforementioned errors on CI.

## Test Instructions

This PR can be merged as long as CI jobs pass.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
