### PR TITLE
Add workflows for creating releases

### DIFF
--- a/.github/workflows/integrate-release.yml
+++ b/.github/workflows/integrate-release.yml
@@ -8,8 +8,8 @@ on:
       platform:
         description: 'Platform target for integration'
         required: true
-      cli:
-        description: 'ClI version'
+      gbm-cli:
+        description: 'gbm-cli version'
         default: 'latest'
 
 jobs:
@@ -27,7 +27,7 @@ jobs:
           go-version: 1.21
 
       - name: Install CLI
-        run: go install github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/gbm-cli@${{ github.event.inputs.cli }}
+        run: go install github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/gbm-cli@${{ github.event.inputs.gbm-cli }}
 
 
       - name: Create PR

--- a/.github/workflows/integrate-release.yml
+++ b/.github/workflows/integrate-release.yml
@@ -1,0 +1,34 @@
+name: Integrate Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release'
+        required: true
+      platform:
+        description: 'Platform target for integration'
+        required: true
+      cli:
+        description: 'ClI version'
+        default: 'latest'
+
+jobs:
+  integrate_release:
+    runs-on: macos-latest
+    name: Integrate Gutenberg Release
+    env:
+      # Use the repo secret so we can access the main app repos
+      GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v4.1.0
+        with:
+          go-version: 1.21
+
+      - name: Install CLI
+        run: go install github.com/jhnstn/release-toolkit-gutenberg-mobile/gbm-cli@${{ github.event.inputs.cli }}
+
+
+      - name: Create PR
+        run: gbm-cli release integrate ${{ github.event.inputs.version }} --${{ github.event.inputs.platform}}

--- a/.github/workflows/integrate-release.yml
+++ b/.github/workflows/integrate-release.yml
@@ -27,7 +27,7 @@ jobs:
           go-version: 1.21
 
       - name: Install CLI
-        run: go install github.com/jhnstn/release-toolkit-gutenberg-mobile/gbm-cli@${{ github.event.inputs.cli }}
+        run: go install github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/gbm-cli@${{ github.event.inputs.cli }}
 
 
       - name: Create PR

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -24,7 +24,7 @@ jobs:
           go-version: 1.21
 
       - name: Install CLI
-        run: go install github.com/jhnstn/release-toolkit-gutenberg-mobile/gbm-cli@${{ github.event.inputs.cli }}
+        run: go install github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/gbm-cli@${{ github.event.inputs.cli }}
 
       - name: Create PR
         run: yes | gbm-cli release prepare gbm ${{ github.event.inputs.version }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -5,8 +5,8 @@ on:
       version:
         description: 'Version to release'
         required: true
-      cli:
-        description: 'ClI version'
+      gbm-cli:
+        description: 'gbm-cli version'
         default: 'latest'
 
 jobs:
@@ -24,7 +24,7 @@ jobs:
           go-version: 1.21
 
       - name: Install CLI
-        run: go install github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/gbm-cli@${{ github.event.inputs.cli }}
+        run: go install github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/gbm-cli@${{ github.event.inputs.gbm-cli }}
 
       - name: Create PR
         run: yes | gbm-cli release prepare gbm ${{ github.event.inputs.version }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,31 @@
+name: Prepare Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release'
+        required: true
+      cli:
+        description: 'ClI version'
+        default: 'latest'
+
+jobs:
+  prepare_release:
+    runs-on: macos-latest
+    name: Prepare Gutenberg Mobile release
+    env:
+      GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+      GITHUB_USER: ${{ github.actor }}
+
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v4.1.0
+        with:
+          go-version: 1.21
+
+      - name: Install CLI
+        run: go install github.com/jhnstn/release-toolkit-gutenberg-mobile/gbm-cli@${{ github.event.inputs.cli }}
+
+      - name: Create PR
+        run: yes | gbm-cli release prepare gbm ${{ github.event.inputs.version }}
+


### PR DESCRIPTION
This adds two Github workflows to create release PRs

`prepare-release.yml` will create a release PR on this repo, Gutenberg Mobile

`integrate-release.yml` will create an integration release on the specified platform

Both take a release version and the option to specify a `gbm-cli` version (this can be a tag or a commit on `release-toolkit-gutenberg-mobile` ) 

As-is we will need to generate an access token and add it to this repository. There is a `PAT_TOKEN` there now but I'm not sure if it's still valid. We need a secret named 'GH_ACCESS_TOKEN` that has access to this repo for the prepare commands. The token will have to work with the main app repos for the integration workflow to work.

To test:
Testing will get a bit noisy so it might be best to merge this branch into a fork of Gutenberg Mobile and add  `GBM_WPMOBILE_ORG` and `GBM_WORDPRESS_ORG:` to the workflow `env` sections like so:

```yml
...
     env:
         GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         GITHUB_USER: ${{ github.actor }}
         GBM_WPMOBILE_ORG: {your github user}
         GBM_WORDPRESS_ORG:  {your github user}
...
```
You will also need a [github PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) added to the fork as a repository secret named `GH_ACCESS_TOKEN`

Then run the prepare worklfow with a version associated with a test release pr on your forked Gutenberg repo

The integration will only work for android in this scenario since iOS will require pods for the release.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
