### PR TITLE
Update/alt jp setup

### DIFF
--- a/bin/run-jetpack-command.sh
+++ b/bin/run-jetpack-command.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 local_run_script="${GBM_LOCAL_JP_RUN_SCRIPT:-./bin/run-jetpack-command.sh.local}"
 
-if [ -e "$local_run_script"]
+if [ -e "$local_run_script" ]
 then
   source "$local_run_script"
   exit 0

--- a/bin/run-jetpack-command.sh
+++ b/bin/run-jetpack-command.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-if [ -e ./bin/run-jetpack-command.sh.local ]
+local_run_script="${GBM_LOCAL_JP_RUN_SCRIPT:-./bin/run-jetpack-command.sh.local}"
+
+if [ -e "$local_run_script"]
 then
-  source ./bin/run-jetpack-command.sh.local
+  source "$local_run_script"
   exit 0
 fi
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/issues/157

This allow for adding the source of the alternate Jetpack setup script from an env in the shell.  

### Why?
This _should_ unblock the issue with the `gbm-cli` being able to prepare Gutenberg Mobile release prs without `nvm`.
The new cli tool clones Gutenberg Mobile into a temporary directory. In this situation `run-jetpack-command.sh.local` won't be in the bin directory. 
Instead we can place the path to the alternate run script in an env, `GBM_LOCAL_JP_RUN_SCRIPT` so when `./bin/run-jetpack-command.sh` is ran during the `gbm-cli` run, the alt script can be sourced.

It would look something like this:

```
GBM_LOCAL_JP_RUN_SCRIPT=~/your/path/to/gutenberg-mobile/bin/run-jetpack-command.sh.local gbm-cli release prepare all {version}
```

To test:

- Try running `npm install` with either an alternate setup or with nvm. 
- Verify no regressions 

If using an alternate setup:
- Move `run-jetpack-command.sh` out of the bin directory i.e. `~/run-jetpack-command.sh`
- Try running `npm install` with `GBM_LOCAL_JP_RUN_SCRIPT` set to the new path for `run-jetpack-command.sh` i.e. : 
```
GBM_LOCAL_JP_RUN_SCRIPT=~/run-jetpack-command.sh nvm install
```
If not using an alternate setup:
- run `echo 'echo "TESTING ALTERNATE RUN JP"' > ~/testing-alt-jp.sh  && chmod +x ~/testing-alt-jp.sh` 
- run `GBM_LOCAL_JP_RUN_SCRIPT=~/testing-alt-jp.sh  nvm install`
- Verify that the test message is echoed 

Testing `gbm-cli`

This is tricky. The script currently picks up evn variables just fine and I don't see why it wouldn't in this case. We'll have to merge this branch into forked repos and try from there. 



PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
