### PR TITLE
Fix broken appearance of video blocks that were first created on the web

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 Unreleased
 ---
--   [**] Fix broken appearance of video blocks that were first created on the web []
+-   [**] Fix broken appearance of video blocks that were first created on the web [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6371]
 
 1.108.0
 ---

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 Unreleased
 ---
+-   [**] Fix broken appearance of video blocks that were first created on the web []
 
 1.108.0
 ---


### PR DESCRIPTION
Fixes a problem in which video blocks that were first created on the web appear broken when viewed in the app.

For further information and to test, please refer to the central Jetpack PR available at https://github.com/Automattic/jetpack/pull/34073

<hr />

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
