### PR TITLE
Add visual screenshot reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Mobile Gutenberg
 
-This is the mobile version of [Gutenberg](https://github.com/WordPress/gutenberg), targeting Android and iOS. It's a React Native library bootstrapped by CRNA and now ejected.
+This repository represents the mobile version of the WordPress [Gutenberg](https://github.com/WordPress/gutenberg) project, targeting Android and iOS platforms using React Native.
+
+![Screenshot of the Mobile Gutenberg Editor, editing a post in WordPress](https://github.com/wordpress-mobile/gutenberg-mobile/assets/643285/db32a1b1-e149-4aab-aa81-01392f974aef)
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,10 @@ git submodule update
 
 ## Set up
 
-Before running the demo app, you need to download and install the project dependencies. This is done via the following command:
+Before running the demo app, download and install the project dependencies:
 
 ```
-nvm install
-npm install
+nvm install && npm install
 ```
 
 ## Run


### PR DESCRIPTION
Fixes:
* https://github.com/wordpress-mobile/gutenberg-mobile/issues/6362

To test:
View project [README](https://github.com/wordpress-mobile/gutenberg-mobile/blob/6696d7a715ab58ad262e6aa78204e89cfacf4cee/README.md).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.

<img width="1051" alt="Screenshot 2023-11-15 at 6 50 24 pm" src="https://github.com/wordpress-mobile/gutenberg-mobile/assets/643285/2da9699c-c24c-4471-8f5f-c8bd74dce794">

