### PR TITLE
Release 1.109.1

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,10 @@
 Unreleased
 ---
 
+1.109.1
+---
+* [***] Fix issue when backspacing in an empty Paragraph block [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6402]
+
 1.109.0
 ---
 -   [*] Contact Info block: Improve legibility of typed text on various background colors [https://github.com/Automattic/jetpack/pull/33873]

--- a/ios-xcframework/Podfile.lock
+++ b/ios-xcframework/Podfile.lock
@@ -424,7 +424,7 @@ PODS:
     - React-RCTImage
   - RNSVG (13.9.0):
     - React-Core
-  - RNTAztecView (1.109.0):
+  - RNTAztecView (1.109.1):
     - React-Core
     - WordPress-Aztec-iOS (= 1.19.9)
   - SDWebImage (5.11.1):
@@ -659,7 +659,7 @@ SPEC CHECKSUMS:
   RNReanimated: 21e1e71d7f1ac9f2fa11df37c06a8ec52ed06232
   RNScreens: e3ffdd78ff5afe8ec82c2566ee2410857ed5ce75
   RNSVG: 29dd0ac32d83774d4b0953ae92a5cd8205a782d7
-  RNTAztecView: 8415d8e322e98d087b3f8fbba0669e84d6b235cb
+  RNTAztecView: 8d9b3bd517873101ab1ea89948b45c601bcedea0
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   WordPress-Aztec-iOS: fbebd569c61baa252b3f5058c0a2a9a6ada686bb

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "gutenberg-mobile",
-	"version": "1.109.0",
+	"version": "1.109.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "gutenberg-mobile",
-			"version": "1.109.0",
+			"version": "1.109.1",
 			"hasInstallScript": true,
 			"devDependencies": {
 				"@babel/core": "^7.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg-mobile",
-	"version": "1.109.0",
+	"version": "1.109.1",
 	"private": true,
 	"config": {
 		"jsfiles": "./*.js src/*.js src/**/*.js src/**/**/*.js",


### PR DESCRIPTION
Release for Gutenberg Mobile 1.109.1

## Related PRs
- https://github.com/WordPress/gutenberg/pull/56644
- https://github.com/wordpress-mobile/WordPress-iOS/pull/22122
- https://github.com/wordpress-mobile/WordPress-Android/pull/19691

## Changes

### Fix issue when backspacing in an empty Paragraph block 
**Issue:** https://github.com/WordPress/gutenberg/issues/56512
**PR:** https://github.com/WordPress/gutenberg/pull/56496 

<!-- To determine the changes you can check the RELEASE-NOTES.txt and gutenberg/packages/react-native-editor/CHANGELOG.md files and cross check with the list of commits that are part of the PR -->
## Test plan

Once the installable builds of the main apps are ready, perform a quick smoke test of the editor on both iOS and Android to verify it launches without crashing. We will perform additional testing after the main apps cut their releases.

## Release Submission Checklist

- [x] Verify Items from test plan have been completed
- [x] Check if `RELEASE-NOTES.txt` is updated with all the changes that made it to the release. Replace `Unreleased` section with the release version and create a new `Unreleased` section.
- [x] Check if `gutenberg/packages/react-native-editor/CHANGELOG.md` is updated with all the changes that made it to the release. Replace `## Unreleased` with the release version and create a new `## Unreleased`.
- [x] Bundle package of the release is updated.