### PR TITLE
Release 1.109.2

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,15 @@
 Unreleased
 ---
 
+1.109.2
+---
+* [**] Fix issue related to text color format and receiving in rare cases an undefined ref from `RichText` component [https://github.com/WordPress/gutenberg/pull/56686]
+* [**] Fixes a crash on pasting MS Word list markup [https://github.com/WordPress/gutenberg/pull/56653]
+* [**] Address rare cases where a null value is passed to a heading block, causing a crash [https://github.com/WordPress/gutenberg/pull/56757]
+* [**] Fixes a crash related to HTML to blocks conversion when no transformations are available [https://github.com/WordPress/gutenberg/pull/56723]
+* [**] Fixes a crash related to undefined attributes in `getFormatColors` function of `RichText` component [https://github.com/WordPress/gutenberg/pull/56684]
+* [**] Fixes an issue with custom color variables not being parsed when using global styles [https://github.com/WordPress/gutenberg/pull/56752]
+
 1.109.1
 ---
 * [***] Fix issue when backspacing in an empty Paragraph block [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6402]

--- a/ios-xcframework/Podfile.lock
+++ b/ios-xcframework/Podfile.lock
@@ -424,7 +424,7 @@ PODS:
     - React-RCTImage
   - RNSVG (13.9.0):
     - React-Core
-  - RNTAztecView (1.109.1):
+  - RNTAztecView (1.109.2):
     - React-Core
     - WordPress-Aztec-iOS (= 1.19.9)
   - SDWebImage (5.11.1):
@@ -659,7 +659,7 @@ SPEC CHECKSUMS:
   RNReanimated: 21e1e71d7f1ac9f2fa11df37c06a8ec52ed06232
   RNScreens: e3ffdd78ff5afe8ec82c2566ee2410857ed5ce75
   RNSVG: 29dd0ac32d83774d4b0953ae92a5cd8205a782d7
-  RNTAztecView: 8d9b3bd517873101ab1ea89948b45c601bcedea0
+  RNTAztecView: dc2635b4d33818f4c113717ff67071c1e367ed8c
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   WordPress-Aztec-iOS: fbebd569c61baa252b3f5058c0a2a9a6ada686bb

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "gutenberg-mobile",
-	"version": "1.109.1",
+	"version": "1.109.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "gutenberg-mobile",
-			"version": "1.109.1",
+			"version": "1.109.2",
 			"hasInstallScript": true,
 			"devDependencies": {
 				"@babel/core": "^7.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg-mobile",
-	"version": "1.109.1",
+	"version": "1.109.2",
 	"private": true,
 	"config": {
 		"jsfiles": "./*.js src/*.js src/**/*.js src/**/**/*.js",


### PR DESCRIPTION
Release for Gutenberg Mobile 1.109.2

## Related PRs

- https://github.com/WordPress/gutenberg/pull/56782
- https://github.com/wordpress-mobile/WordPress-Android/pull/19732
- https://github.com/wordpress-mobile/WordPress-iOS/pull/22149

## Changes
- https://github.com/WordPress/gutenberg/pull/56653
- https://github.com/WordPress/gutenberg/pull/56686
- https://github.com/WordPress/gutenberg/pull/56723
- https://github.com/WordPress/gutenberg/pull/56684
- https://github.com/WordPress/gutenberg/pull/56752
- https://github.com/WordPress/gutenberg/pull/56757

<!-- To determine the changes you can check the RELEASE-NOTES.txt and gutenberg/packages/react-native-editor/CHANGELOG.md files and cross check with the list of commits that are part of the PR -->
## Test plan

Once the installable builds of the main apps are ready, perform a quick smoke test of the editor on both iOS and Android to verify it launches without crashing. We will perform additional testing after the main apps cut their releases.

## Release Submission Checklist

- [x] Verify Items from test plan have been completed
- [x] Check if `RELEASE-NOTES.txt` is updated with all the changes that made it to the release. Replace `Unreleased` section with the release version and create a new `Unreleased` section.
- [x] Check if `gutenberg/packages/react-native-editor/CHANGELOG.md` is updated with all the changes that made it to the release. Replace `## Unreleased` with the release version and create a new `## Unreleased`.
- [x] Bundle package of the release is updated.