### PR TITLE
Increase max available memory that `node` can use in CI jobs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,6 +7,8 @@ x-common-params:
         # Allow WP-CLI to be run as root, otherwise it throws an exception.
         # Reference: https://git.io/J9q2S
         - 'WP_CLI_ALLOW_ROOT=true'
+        # Increase max available memory for node
+        - 'NODE_OPTIONS="--max-old-space-size=4096"'
   - &git-cache-plugin
     automattic/git-s3-cache#1.1.4:
       # Ensure these settings match what's defined in cache-builder.yml

--- a/ios-xcframework/Podfile.lock
+++ b/ios-xcframework/Podfile.lock
@@ -424,7 +424,7 @@ PODS:
     - React-RCTImage
   - RNSVG (13.9.0):
     - React-Core
-  - RNTAztecView (1.109.3):
+  - RNTAztecView (1.110.0):
     - React-Core
     - WordPress-Aztec-iOS (= 1.19.9)
   - SDWebImage (5.11.1):
@@ -659,7 +659,7 @@ SPEC CHECKSUMS:
   RNReanimated: 21e1e71d7f1ac9f2fa11df37c06a8ec52ed06232
   RNScreens: e3ffdd78ff5afe8ec82c2566ee2410857ed5ce75
   RNSVG: 29dd0ac32d83774d4b0953ae92a5cd8205a782d7
-  RNTAztecView: fd32ea370f13d9edd7f43b65b6270ae499757d69
+  RNTAztecView: 75ea6f071cbdd0f0afe83de7b93c0691a2bebd21
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   WordPress-Aztec-iOS: fbebd569c61baa252b3f5058c0a2a9a6ada686bb


### PR DESCRIPTION
Fixes an issue in the CI job `lint` that we've recently encountered in PRs (https://github.com/wordpress-mobile/gutenberg-mobile/pull/6498/commits/325366dc1ec837a3ae682016d7fdd209f516a58c).

```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

**To test:**
* Check that all CI jobs pass.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.