### PR TITLE
Use https git urls in git submodules

### DIFF
--- a/.buildkite/commands/build-ios.sh
+++ b/.buildkite/commands/build-ios.sh
@@ -13,7 +13,7 @@ IOS_DEVICE_NAME=$(jq -r '.ios.local.deviceName' "$CONFIG_FILE")
 IOS_PLATFORM_VERSION=$(jq -r '.ios.buildkite.platformVersion' "$CONFIG_FILE")
 # Set a destination different from the hardcoded one which only works in the
 # older Xcode-setup used by CircleCI
-export RN_EDITOR_E2E_IOS_DESTINATION="platform=iOS Simulator,name=$IOS_DEVICE_NAME,OS=$IOS_PLATFORM_VERSION"
+export RN_EDITOR_E2E_IOS_DESTINATION="platform=iOS Simulator,name=iPhone 15,OS=17.2"
 set +x
 
 echo '--- :react: Build iOS app for E2E testing'

--- a/.buildkite/commands/build-ios.sh
+++ b/.buildkite/commands/build-ios.sh
@@ -7,12 +7,9 @@ echo '--- :ios: Set env var for iOS E2E testing'
 set -x
 export TEST_RN_PLATFORM=ios
 export TEST_ENV=sauce
-CONFIG_FILE="$(pwd)/gutenberg/packages/react-native-editor/__device-tests__/helpers/device-config.json"
-# Uses the local deviceName since SauceLabs uses a different one.
-IOS_DEVICE_NAME=$(jq -r '.ios.local.deviceName' "$CONFIG_FILE")
-IOS_PLATFORM_VERSION=$(jq -r '.ios.buildkite.platformVersion' "$CONFIG_FILE")
-# Set a destination different from the hardcoded one which only works in the
-# older Xcode-setup used by CircleCI
+# We must use a simulator that's available on the selected Xcode version
+# otherwsie Xcode fallbacks to "generic destination" which requires provision
+# profiles to built the Demo app.
 export RN_EDITOR_E2E_IOS_DESTINATION="platform=iOS Simulator,name=iPhone 15,OS=17.2"
 set +x
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,7 +30,7 @@ x-common-params:
   - &ci_toolkit_plugin
     automattic/a8c-ci-toolkit#2.18.2
   - &xcode_agent_env
-    IMAGE_ID: xcode-14.3.1
+    IMAGE_ID: xcode-15.1
   - &is_branch_for_full_ui_tests
     build.branch == 'trunk' || build.branch =~ /^release.*/ || build.branch =~ /^dependabot\/submodules.*/
   - &is_branch_for_quick_ui_tests

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "gutenberg"]
 	path = gutenberg
-	url = ../../WordPress/gutenberg.git
+	url = https://github.com/WordPress/gutenberg.git
 	shallow = true
 [submodule "jetpack"]
 	path = jetpack
-	url = ../../Automattic/jetpack.git
+	url = https://github.com/Automattic/jetpack.git
 	shallow = true
 [submodule "block-experiments"]
 	path = block-experiments
-	url = ../../Automattic/block-experiments.git
+	url = https://github.com/Automattic/block-experiments.git
 	shallow = true


### PR DESCRIPTION
## Issue

The git-mirror feature in buildkite-agent clones all git repository into a local directory. But it doesn't resolve a relative submodule url to a real git url (based on the "host" repository's URL) and fails to clone the submodule repositories.

## Fix

Changing the relative url to a https URL fixed the issue. I'll report the issue to buildkite too. If they resolve it in the buildkite-agent, we have the option of reverting the submodule url change if needed.

> [!Warning]
> Once this PR is merged and pulled into your local git checkout, you may need to run `git submodule sync` to update the submodule URLs in your work copy.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
