### PR TITLE
Remove the xip file in Trash to clear up some space

### DIFF
--- a/.buildkite/commands/build-ios.sh
+++ b/.buildkite/commands/build-ios.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -eu
 
+echo '--- :desktop_computer: Clear up some disk space'
+rm -rfv ~/.Trash/15.1.xip
+
 echo '--- :node: Setup Node depenendencies'
 npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 


### PR DESCRIPTION
This is a workaround to solve the issue where VM may run out of disk space.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
