### PR TITLE
chore: Enable offline media upload features

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 Unreleased
 ---
+* [**] Display a notice when a network connection unavailable [https://github.com/WordPress/gutenberg/pull/56934]
 
 1.110.0
 ---


### PR DESCRIPTION
## Related
- https://github.com/WordPress/gutenberg/pull/57731
- https://github.com/wordpress-mobile/WordPress-Android/pull/19914
- https://github.com/wordpress-mobile/WordPress-iOS/pull/22364

## Description
Remove `DEV` flags disabling offline media upload features.

## Testing Instructions
N/A, features were tested in individual PRs.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
