### PR TITLE
docs: Link to React Native CLI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For a developer experience closer to the one the project maintainers currently h
 -   CocoaPods (`sudo gem install cocoapods`) needed to fetch React and third-party dependencies.
 -   [Carthage](https://github.com/Carthage/Carthage#installing-carthage) for Appium to be able run iOS UI tests
 
-Depending on your setup, there may be a few configurations needed in Android Studio and Xcode. Please refer to [React Native's documentation](https://reactnative.dev/docs/environment-setup) for the latest requirements for each development environment.
+Depending on your setup, there may be a few configurations needed in Android Studio and Xcode. Please refer to [React Native's documentation](https://reactnative.dev/docs/environment-setup?guide=native) for the latest requirements for each development environment.
 
 Note that the OS platform used by the maintainers is macOS but the tools and setup should be usable in other platforms too.
 


### PR DESCRIPTION
## Description

Avoid confusion that may be caused by linking to the default Expo
documentation found on the React Native website. Instead, link to the
React Native CLI variant, which is what the `gutenberg-mobile` project
utilizes.

## Testing Instructions

N/A, small documentation change.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
