### PR TITLE
Add missing CI reporting from Buildkite

### DIFF
--- a/.buildkite/commands/test-ios.sh
+++ b/.buildkite/commands/test-ios.sh
@@ -57,6 +57,12 @@ if [[ $TESTS_EXIT_CODE -eq 0 ]]; then
 else
     echo "+++ $REPORT_SECTION_NAME"
     echo "npm run $TESTS_CMD failed."
+
+    if ! command -v ruby ; then
+      echo 'Skipping test reporting because Ruby is not available on this machine.'
+      exit $TESTS_EXIT_CODE
+    fi
+
     echo "For more details about the failed tests, check the Buildkite annotation, the logs under the '$SECTION' section and the tests results in the artifacts tab."
 
     if [[ $BUILDKITE_BRANCH == trunk ]]; then

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -263,6 +263,9 @@ steps:
       - reports/test-results/android-test-results.xml
     env:
       JEST_JUNIT_OUTPUT_FILE: reports/test-results/android-test-results.xml
+    notify:
+      - github_commit_status:
+          context: Test Android on Device - Canaries
 
   - block: "Full UI Tests"
     # Show only in branches that run the quick UI tests suite, to optionally run the full suite


### PR DESCRIPTION
This PR was originally meant to restore _all_ the Slack and GitHub reporting that got lost in the move from CircleCI to Buildkite.

However, I discovered that our current Ruby-base approach is incompatible with the Docker images we use to run the unit tests, as they don't have Ruby.

So, I updated this PR to only add the missing named GitHub Check for the Android E2E tests and will followup about the rest later.

<details>
<summary>Original description, for reference.</summary>

A few things got lost in translation when moving from CircleCI to Buildkite. This PR restores them.

- Report for failed iOS unit tests (the ones run via `npm`)
- Report for failed Android unit tests (the ones run via `npm`)
- GitHub commit status reporting for Android E2E tests
- Align how test failures are reported in the CI logs

**Please let me know if I forgot others.**




</details>


---

PR submission checklist:

- [x] I have considered adding unit tests where possible. – N.A.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary. – N.A.
