### PR TITLE
Try using `android` queue instead of `gb-mobile` Docker image

### DIFF
--- a/.buildkite/commands/unit-tests-android.sh
+++ b/.buildkite/commands/unit-tests-android.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -eu
 
+echo "--- Check Ruby test"
+which ruby
+
 echo "--- :npm: Install Node dependencies"
 npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 

--- a/.buildkite/commands/unit-tests-android.sh
+++ b/.buildkite/commands/unit-tests-android.sh
@@ -3,5 +3,33 @@
 echo "--- :npm: Install Node dependencies"
 npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 
-echo "--- :node: Lint and Unit Tests"
+SECTION='--- :node: Android Unit Tests'
+set +e
+echo "$SECTION"
 CHECK_CORRECTNESS=false CHECK_TESTS=true TEST_RN_PLATFORM=android ./bin/ci-checks-js.sh
+TESTS_EXIT_CODE=$?
+set -e
+
+REPORT_SECTION_NAME='🚦 Report Tests Status'
+if [[ $TESTS_EXIT_CODE -eq 0 ]]; then
+    echo "--- $REPORT_SECTION_NAME"
+    echo "Android tests passed. 🎉"
+else
+    echo "+++ $REPORT_SECTION_NAME"
+    echo "Android tests failed."
+
+    if ! command -v ruby ; then
+      echo 'Skipping test reporting because Ruby is not available on this machine.'
+      exit $TESTS_EXIT_CODE
+    fi
+
+    echo "For more details about the failed tests, check the Buildkite annotation, the logs under the '$SECTION' section and the tests results in the artifacts tab."
+
+    if [[ $BUILDKITE_BRANCH == trunk ]]; then
+        annotate_test_failures "$JEST_JUNIT_OUTPUT_FILE" --slack "build-and-ship"
+    else
+        annotate_test_failures "$JEST_JUNIT_OUTPUT_FILE"
+    fi
+
+    exit $TESTS_EXIT_CODE
+fi

--- a/.buildkite/commands/unit-tests-ios.sh
+++ b/.buildkite/commands/unit-tests-ios.sh
@@ -3,5 +3,33 @@
 echo "--- :npm: Install Node dependencies"
 npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 
-echo "--- :node: Lint and Unit Tests"
+SECTION='--- :node: iOS Unit Tests'
+set +e
+echo "$SECTION"
 CHECK_CORRECTNESS=false CHECK_TESTS=true TEST_RN_PLATFORM=ios ./bin/ci-checks-js.sh
+TESTS_EXIT_CODE=$?
+set -e
+
+REPORT_SECTION_NAME='🚦 Report Tests Status'
+if [[ $TESTS_EXIT_CODE -eq 0 ]]; then
+    echo "--- $REPORT_SECTION_NAME"
+    echo "iOS tests passed. 🎉"
+else
+    echo "+++ $REPORT_SECTION_NAME"
+    echo "iOS tests failed."
+
+    if ! command -v ruby ; then
+      echo 'Skipping test reporting because Ruby is not available on this machine.'
+      exit $TESTS_EXIT_CODE
+    fi
+
+    echo "For more details about the failed tests, check the Buildkite annotation, the logs under the '$SECTION' section and the tests results in the artifacts tab."
+
+    if [[ $BUILDKITE_BRANCH == trunk ]]; then
+        annotate_test_failures "$JEST_JUNIT_OUTPUT_FILE" --slack "build-and-ship"
+    else
+        annotate_test_failures "$JEST_JUNIT_OUTPUT_FILE"
+    fi
+
+    exit $TESTS_EXIT_CODE
+fi

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -74,6 +74,8 @@ steps:
     agents:
       queue: android
     command: .buildkite/commands/unit-tests-ios.sh
+    env:
+      JEST_JUNIT_OUTPUT_FILE: reports/test-results/ios-test-results.xml
     artifact_paths:
       - ./logs/*.log
       - ./reports/test-results/*.xml

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -43,7 +43,7 @@ steps:
       - *nvm_plugin
       - *git-cache-plugin
     agents:
-      queue: android
+      queue: default
     command: .buildkite/commands/lint.sh
     notify:
       - github_commit_status:
@@ -55,7 +55,7 @@ steps:
       - *nvm_plugin
       - *ci_toolkit_plugin
     agents:
-      queue: android
+      queue: default
     command: .buildkite/commands/unit-tests-android.sh
     env:
       JEST_JUNIT_OUTPUT_FILE: reports/test-results/android-test-results.xml
@@ -72,7 +72,7 @@ steps:
       - *nvm_plugin
       - *ci_toolkit_plugin
     agents:
-      queue: android
+      queue: default
     command: .buildkite/commands/unit-tests-ios.sh
     env:
       JEST_JUNIT_OUTPUT_FILE: reports/test-results/ios-test-results.xml

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -40,16 +40,11 @@ steps:
   - label: Lint
     key: lint
     plugins:
-      - *gb-mobile-docker-container
+      - *nvm_plugin
       - *git-cache-plugin
-    command: |
-      echo "--- :docker: Additional Docker image setup"
-      source /root/.bashrc
-
-      echo "--- :docker::node: Set up Node environment"
-      nvm install && nvm use
-
-      .buildkite/commands/lint.sh
+    agents:
+      queue: android
+    command: .buildkite/commands/lint.sh
     notify:
       - github_commit_status:
           context: Lint
@@ -57,16 +52,11 @@ steps:
   - label: Android Unit Tests
     key: android-unit-tests
     plugins:
-      - *gb-mobile-docker-container
+      - *nvm_plugin
       - *ci_toolkit_plugin
-    command: |
-      echo "--- :docker: Additional Docker image setup"
-      source /root/.bashrc
-
-      echo "--- :docker::node: Set up Node environment"
-      nvm install && nvm use
-
-      .buildkite/commands/unit-tests-android.sh
+    agents:
+      queue: android
+    command: .buildkite/commands/unit-tests-android.sh
     env:
       JEST_JUNIT_OUTPUT_FILE: reports/test-results/android-test-results.xml
     artifact_paths:
@@ -79,16 +69,11 @@ steps:
   - label: iOS Unit Tests
     key: ios-unit-tests
     plugins:
-      - *gb-mobile-docker-container
+      - *nvm_plugin
       - *ci_toolkit_plugin
-    command: |
-      echo "--- :docker: Additional Docker image setup"
-      source /root/.bashrc
-
-      echo "--- :docker::node: Set up Node environment"
-      nvm install && nvm use
-
-      .buildkite/commands/unit-tests-ios.sh
+    agents:
+      queue: android
+    command: .buildkite/commands/unit-tests-ios.sh
     artifact_paths:
       - ./logs/*.log
       - ./reports/test-results/*.xml
@@ -120,21 +105,17 @@ steps:
     agents:
       queue: android
 
-  - label: "Build JS Bundles"
+  - label: Build JS Bundles
     depends_on:
       - lint
       - android-unit-tests
       - ios-unit-tests
-    key: "js-bundles"
+    key: js-bundles
     plugins:
-      - *gb-mobile-docker-container
+      - *ci_toolkit_plugin # unused?
+      - *nvm_plugin
       - *git-cache-plugin
     command: |
-        source /root/.bashrc
-
-        echo "--- :node: Set up Node environment"
-        nvm install && nvm use
-
         echo "--- :npm: Install Node dependencies"
         npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 

--- a/src/test/paywall/edit.native.js
+++ b/src/test/paywall/edit.native.js
@@ -29,7 +29,7 @@ describe( 'Paywall block', () => {
 		} );
 
 		expect(
-			screen.getByText( 'Subscriber-only content below' )
+			screen.getByText( 'Subscriber-only content below HACKED TO EXPERIENCE FAILURE IN CI' )
 		).toBeVisible();
 	} );
 } );

--- a/src/test/videopress/edit.js
+++ b/src/test/videopress/edit.js
@@ -79,7 +79,7 @@ describe( 'VideoPress block', () => {
 		const videoPressBlock = await getBlock( screen, 'VideoPress' );
 		expect( videoPressBlock ).toBeVisible();
 
-		const expectedHtml = `<!-- wp:videopress/video /-->`;
+		const expectedHtml = `<!-- wp:videopress/video/hack/for/ci/failure /-->`;
 		expect( getEditorHtml() ).toBe( expectedHtml );
 	} );
 


### PR DESCRIPTION
Want to see if it works. If it does, then we could use it as a solution for the problem of reporting needing Ruby, see #6537.

Assuming it will work, one question to address would be performance. Is it faster to run on the `android` queue? If so, faster enough to justify an increase in cost, if any, and of how much? Finally, how would more load on that queue affect the other Android builds?