### PR TITLE
Use `android` queue instead of `gb-mobile-...` Docker image

### DIFF
--- a/.buildkite/commands/unit-tests-android.sh
+++ b/.buildkite/commands/unit-tests-android.sh
@@ -3,5 +3,33 @@
 echo "--- :npm: Install Node dependencies"
 npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 
-echo "--- :node: Lint and Unit Tests"
+SECTION='--- :node: Android Unit Tests'
+set +e
+echo "$SECTION"
 CHECK_CORRECTNESS=false CHECK_TESTS=true TEST_RN_PLATFORM=android ./bin/ci-checks-js.sh
+TESTS_EXIT_CODE=$?
+set -e
+
+REPORT_SECTION_NAME='🚦 Report Tests Status'
+if [[ $TESTS_EXIT_CODE -eq 0 ]]; then
+    echo "--- $REPORT_SECTION_NAME"
+    echo "Android tests passed. 🎉"
+else
+    echo "+++ $REPORT_SECTION_NAME"
+    echo "Android tests failed."
+
+    if ! command -v ruby ; then
+      echo 'Skipping test reporting because Ruby is not available on this machine.'
+      exit $TESTS_EXIT_CODE
+    fi
+
+    echo "For more details about the failed tests, check the Buildkite annotation, the logs under the '$SECTION' section and the tests results in the artifacts tab."
+
+    if [[ $BUILDKITE_BRANCH == trunk ]]; then
+        annotate_test_failures "$JEST_JUNIT_OUTPUT_FILE" --slack "build-and-ship"
+    else
+        annotate_test_failures "$JEST_JUNIT_OUTPUT_FILE"
+    fi
+
+    exit $TESTS_EXIT_CODE
+fi

--- a/.buildkite/commands/unit-tests-ios.sh
+++ b/.buildkite/commands/unit-tests-ios.sh
@@ -3,5 +3,33 @@
 echo "--- :npm: Install Node dependencies"
 npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 
-echo "--- :node: Lint and Unit Tests"
+SECTION='--- :node: iOS Unit Tests'
+set +e
+echo "$SECTION"
 CHECK_CORRECTNESS=false CHECK_TESTS=true TEST_RN_PLATFORM=ios ./bin/ci-checks-js.sh
+TESTS_EXIT_CODE=$?
+set -e
+
+REPORT_SECTION_NAME='🚦 Report Tests Status'
+if [[ $TESTS_EXIT_CODE -eq 0 ]]; then
+    echo "--- $REPORT_SECTION_NAME"
+    echo "iOS tests passed. 🎉"
+else
+    echo "+++ $REPORT_SECTION_NAME"
+    echo "iOS tests failed."
+
+    if ! command -v ruby ; then
+      echo 'Skipping test reporting because Ruby is not available on this machine.'
+      exit $TESTS_EXIT_CODE
+    fi
+
+    echo "For more details about the failed tests, check the Buildkite annotation, the logs under the '$SECTION' section and the tests results in the artifacts tab."
+
+    if [[ $BUILDKITE_BRANCH == trunk ]]; then
+        annotate_test_failures "$JEST_JUNIT_OUTPUT_FILE" --slack "build-and-ship"
+    else
+        annotate_test_failures "$JEST_JUNIT_OUTPUT_FILE"
+    fi
+
+    exit $TESTS_EXIT_CODE
+fi

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -74,6 +74,8 @@ steps:
     agents:
       queue: android
     command: .buildkite/commands/unit-tests-ios.sh
+    env:
+      JEST_JUNIT_OUTPUT_FILE: reports/test-results/ios-test-results.xml
     artifact_paths:
       - ./logs/*.log
       - ./reports/test-results/*.xml

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -40,16 +40,11 @@ steps:
   - label: Lint
     key: lint
     plugins:
-      - *gb-mobile-docker-container
+      - *nvm_plugin
       - *git-cache-plugin
-    command: |
-      echo "--- :docker: Additional Docker image setup"
-      source /root/.bashrc
-
-      echo "--- :docker::node: Set up Node environment"
-      nvm install && nvm use
-
-      .buildkite/commands/lint.sh
+    agents:
+      queue: android
+    command: .buildkite/commands/lint.sh
     notify:
       - github_commit_status:
           context: Lint
@@ -57,16 +52,11 @@ steps:
   - label: Android Unit Tests
     key: android-unit-tests
     plugins:
-      - *gb-mobile-docker-container
+      - *nvm_plugin
       - *ci_toolkit_plugin
-    command: |
-      echo "--- :docker: Additional Docker image setup"
-      source /root/.bashrc
-
-      echo "--- :docker::node: Set up Node environment"
-      nvm install && nvm use
-
-      .buildkite/commands/unit-tests-android.sh
+    agents:
+      queue: android
+    command: .buildkite/commands/unit-tests-android.sh
     env:
       JEST_JUNIT_OUTPUT_FILE: reports/test-results/android-test-results.xml
     artifact_paths:
@@ -79,16 +69,11 @@ steps:
   - label: iOS Unit Tests
     key: ios-unit-tests
     plugins:
-      - *gb-mobile-docker-container
+      - *nvm_plugin
       - *ci_toolkit_plugin
-    command: |
-      echo "--- :docker: Additional Docker image setup"
-      source /root/.bashrc
-
-      echo "--- :docker::node: Set up Node environment"
-      nvm install && nvm use
-
-      .buildkite/commands/unit-tests-ios.sh
+    agents:
+      queue: android
+    command: .buildkite/commands/unit-tests-ios.sh
     artifact_paths:
       - ./logs/*.log
       - ./reports/test-results/*.xml
@@ -120,21 +105,17 @@ steps:
     agents:
       queue: android
 
-  - label: "Build JS Bundles"
+  - label: Build JS Bundles
     depends_on:
       - lint
       - android-unit-tests
       - ios-unit-tests
-    key: "js-bundles"
+    key: js-bundles
     plugins:
-      - *gb-mobile-docker-container
+      - *ci_toolkit_plugin # unused?
+      - *nvm_plugin
       - *git-cache-plugin
     command: |
-        source /root/.bashrc
-
-        echo "--- :node: Set up Node environment"
-        nvm install && nvm use
-
         echo "--- :npm: Install Node dependencies"
         npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 


### PR DESCRIPTION
With this switch, we gain support for unit test failure reporting, see [this example build](https://buildkite.com/automattic/gutenberg-mobile/builds/8285#018d15f0-ee5a-460c-813e-88247eb44ca5), and in the order of 1-2 minute faster execution for each of Lint and Unit Tests steps. All that with room for improvement in terms of adding caching layer to make `npm ci` faster.

![image](https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/6a7277c0-828a-48f9-90f0-6d5792b39d70)

To test: Verify CI is greed.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
