### PR TITLE
Increase node max available memory in `Build JS Bundles` job

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -110,8 +110,6 @@ steps:
     env:
       NODE_OPTIONS: "--max-old-space-size=4096"
     command: |
-        node -e 'console.log("Heap size limit:",v8.getHeapStatistics().heap_size_limit/(1024*1024))'
-
         echo "--- :npm: Install Node dependencies"
         npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -117,6 +117,8 @@ steps:
       - *ci_toolkit_plugin # unused?
       - *nvm_plugin
       - *git-cache-plugin
+    env:
+      NODE_OPTIONS: "--max-old-space-size=4096"
     command: |
         echo "--- :npm: Install Node dependencies"
         npm ci --unsafe-perm --prefer-offline --no-audit --no-progress

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -110,6 +110,8 @@ steps:
     env:
       NODE_OPTIONS: "--max-old-space-size=4096"
     command: |
+        node -e 'console.log("Heap size limit:",v8.getHeapStatistics().heap_size_limit/(1024*1024))'
+
         echo "--- :npm: Install Node dependencies"
         npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,14 +1,4 @@
 x-common-params:
-  - &gb-mobile-docker-container
-    docker#v3.8.0:
-      image: 'public.ecr.aws/automattic/gb-mobile-image:latest'
-      environment:
-        - 'CI=true'
-        # Allow WP-CLI to be run as root, otherwise it throws an exception.
-        # Reference: https://git.io/J9q2S
-        - 'WP_CLI_ALLOW_ROOT=true'
-        # Increase max available memory for node
-        - 'NODE_OPTIONS="--max-old-space-size=4096"'
   - &git-cache-plugin
     automattic/git-s3-cache#1.1.4:
       # Ensure these settings match what's defined in cache-builder.yml


### PR DESCRIPTION
Increases the max available memory that `node` can use. This follows the same approach applied in https://github.com/wordpress-mobile/gutenberg-mobile/pull/6503 to avoid CI failures when building Gutenberg, which requires more memory than the default value (2GB).

**To test:**
* Observe that all CI checks pass.
* Observe in https://github.com/wordpress-mobile/gutenberg-mobile/pull/6579/commits/a1bc23ef70bd10097b10a3084b6fc2f09c8e4f1c that the heap size is set to 4G ([reference](https://buildkite.com/automattic/gutenberg-mobile/builds/8380#018d428c-5736-436f-aa24-4b67b3f02c5a/358-397)).

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
