### PR TITLE
[CI] Fix missing `php` command when building JS bundles for a GitHub tag

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -129,12 +129,8 @@ steps:
         echo "--- :npm: Install Node dependencies"
         npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 
-        if [[ -z "$BUILDKITE_TAG" ]]; then
-          echo "--- :package: Skip bundle prep work"
-        else
-          echo "--- :package: Run bundle prep work"
-          npm run prebundle:js
-        fi
+        echo "--- :package: Run bundle prep work"
+        npm run prebundle:js
 
         echo "--- :android: Build Android bundle"
         npm run bundle:android

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -108,10 +108,10 @@ steps:
       queue: android
 
   - label: Build JS Bundles
-    depends_on:
-      - lint
-      - android-unit-tests
-      - ios-unit-tests
+    # depends_on:
+    #   - lint
+    #   - android-unit-tests
+    #   - ios-unit-tests
     key: js-bundles
     plugins:
       # The following plugins are disabled temporarily until PHP is available.

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -108,10 +108,10 @@ steps:
       queue: android
 
   - label: Build JS Bundles
-    # depends_on:
-    #   - lint
-    #   - android-unit-tests
-    #   - ios-unit-tests
+    depends_on:
+      - lint
+      - android-unit-tests
+      - ios-unit-tests
     key: js-bundles
     plugins:
       # The following plugins are disabled temporarily until PHP is available.
@@ -126,13 +126,15 @@ steps:
         echo "--- :node: Set up Node environment"
         nvm install && nvm use
 
-        node -e 'console.log("Heap size limit:",v8.getHeapStatistics().heap_size_limit/(1024*1024))'
-
         echo "--- :npm: Install Node dependencies"
         npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 
-        echo "--- :package: Run bundle prep work"
-        npm run prebundle:js
+        if [[ -z "$BUILDKITE_TAG" ]]; then
+          echo "--- :package: Skip bundle prep work"
+        else
+          echo "--- :package: Run bundle prep work"
+          npm run prebundle:js
+        fi
 
         echo "--- :android: Build Android bundle"
         npm run bundle:android

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,14 @@
 x-common-params:
+  - &gb-mobile-docker-container
+    docker#v3.8.0:
+      image: 'public.ecr.aws/automattic/gb-mobile-image:latest'
+      environment:
+        - 'CI=true'
+        # Allow WP-CLI to be run as root, otherwise it throws an exception.
+        # Reference: https://git.io/J9q2S
+        - 'WP_CLI_ALLOW_ROOT=true'
+        # Increase max available memory for node
+        - 'NODE_OPTIONS="--max-old-space-size=4096"'
   - &git-cache-plugin
     automattic/git-s3-cache#1.1.4:
       # Ensure these settings match what's defined in cache-builder.yml
@@ -104,12 +114,18 @@ steps:
       - ios-unit-tests
     key: js-bundles
     plugins:
-      - *ci_toolkit_plugin # unused?
-      - *nvm_plugin
+      # The following plugins are disabled temporarily until PHP is available.
+      # In the meantime, we'll keep using the GB-mobile docker container.
+      - *gb-mobile-docker-container
+      # - *ci_toolkit_plugin # unused?
+      # - *nvm_plugin
       - *git-cache-plugin
-    env:
-      NODE_OPTIONS: "--max-old-space-size=4096"
     command: |
+        source /root/.bashrc
+        
+        echo "--- :node: Set up Node environment"
+        nvm install && nvm use
+
         echo "--- :npm: Install Node dependencies"
         npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -126,6 +126,8 @@ steps:
         echo "--- :node: Set up Node environment"
         nvm install && nvm use
 
+        node -e 'console.log("Heap size limit:",v8.getHeapStatistics().heap_size_limit/(1024*1024))'
+
         echo "--- :npm: Install Node dependencies"
         npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 


### PR DESCRIPTION
Following the changes from https://github.com/wordpress-mobile/gutenberg-mobile/pull/6579, this PR fixes an error in CI related to the missing `php` command during the bundle preparation step. The solution applied is reverting part of the changes introduced in https://github.com/wordpress-mobile/gutenberg-mobile/pull/6558, specifically, the usage of the GB-mobile docker container to build the JS bundles.

**To test:**
* Observe that the heap size limit is 4GB ([reference](https://buildkite.com/automattic/gutenberg-mobile/builds/8399#018d4590-bb30-435e-9630-3a3a2b693315/283-289)).
* Observe that the `WP-CLI` is installed and used ([reference](https://buildkite.com/automattic/gutenberg-mobile/builds/8399#018d4590-bb30-435e-9630-3a3a2b693315/617-878)).
* Observe that bundle preparation is completed ([reference](https://buildkite.com/automattic/gutenberg-mobile/builds/8399#018d4590-bb30-435e-9630-3a3a2b693315/617) - **note that the workflow was stopped after the preparation step finished to avoid waiting for all jobs to finish**)
* Observe that all CI jobs pass.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
