### PR TITLE
Run the "Build JS Bundles" step on the "android" queue

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -113,6 +113,8 @@ steps:
       - android-unit-tests
       - ios-unit-tests
     key: js-bundles
+    agents:
+      queue: android
     plugins:
       # The following plugins are disabled temporarily until PHP is available.
       # In the meantime, we'll keep using the GB-mobile docker container.


### PR DESCRIPTION
Use ci-android queue to speed up the "Build JS Bundles" step.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
