### PR TITLE
Add `git-cache-plugin` to CI steps that were missing it

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -54,6 +54,7 @@ steps:
     plugins:
       - *nvm_plugin
       - *ci_toolkit_plugin
+      - *git-cache-plugin
     agents:
       queue: android
     command: .buildkite/commands/unit-tests-android.sh
@@ -71,6 +72,7 @@ steps:
     plugins:
       - *nvm_plugin
       - *ci_toolkit_plugin
+      - *git-cache-plugin
     agents:
       queue: android
     command: .buildkite/commands/unit-tests-ios.sh


### PR DESCRIPTION
@geriux made me notice that not all the CI steps used the `git-s3-cache` plugin, thus missing out on using the cached version of the repo.

Unfortunately, the checkout times seem to be the same with or without the plugin available. I'm a bit rusty on how the plugin works exactly, but I think we ought to look at its internals and see if there's something more to do, or something that's not working out properly, maybe because of the submodules in this repo.

Still, this addition doesn't make things worse. And, assuming we can improve `git-s3-cache` efficacy, makes the whole pipeline ready to benefit from it.

---

PR submission checklist:

- [x] I have considered adding unit tests where possible. – N.A.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary. – N.A.
