### PR TITLE
[TEST] Revert "Add `git-cache-plugin` to CI steps that were missing it"

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -54,7 +54,6 @@ steps:
     plugins:
       - *nvm_plugin
       - *ci_toolkit_plugin
-      - *git-cache-plugin
     agents:
       queue: android
     command: .buildkite/commands/unit-tests-android.sh
@@ -72,7 +71,6 @@ steps:
     plugins:
       - *nvm_plugin
       - *ci_toolkit_plugin
-      - *git-cache-plugin
     agents:
       queue: android
     command: .buildkite/commands/unit-tests-ios.sh


### PR DESCRIPTION
Reverts wordpress-mobile/gutenberg-mobile#6638 to check if the CI failure `fatal: fetch-pack: invalid index-pack output%` is solved.