### PR TITLE
Release 1.113.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,9 @@
 Unreleased
 ---
 
+1.113.0
+---
+
 1.112.0
 ---
 * [**] Fix crash occurring on large post on Android [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6575]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@ Unreleased
 
 1.113.0
 ---
+* No User facing changes *
 
 1.112.0
 ---

--- a/bundle/android/strings.xml
+++ b/bundle/android/strings.xml
@@ -312,6 +312,9 @@ translators: %s: Select control button label e.g. "Button width" -->
     <string name="gutenberg_native_replace_video" tools:ignore="UnusedResources">Replace video</string>
     <string name="gutenberg_native_retry" tools:ignore="UnusedResources">Retry</string>
     <string name="gutenberg_native_rich_text_editing" tools:ignore="UnusedResources">Rich text editing</string>
+    <!-- translators: Block name. %s: The localized block name
+translators: %s: Block name e.g. "Image block" -->
+    <string name="gutenberg_native_s_block" tools:ignore="UnusedResources">%s block</string>
     <!-- translators: displayed right after the classic block is converted to blocks. %s: The localized classic block name -->
     <string name="gutenberg_native_s_block_converted_to_blocks" tools:ignore="UnusedResources">\'%s\' block converted to blocks</string>
     <!-- translators: accessibility text for the media block empty state. %s: media type -->

--- a/bundle/ios/GutenbergNativeTranslations.swift
+++ b/bundle/ios/GutenbergNativeTranslations.swift
@@ -6,6 +6,7 @@ private func dummy() {
     _ = NSLocalizedString("%1$s transformed to %2$s", comment: "translators: 1: From block title, e.g. Paragraph. 2: To block title, e.g. Header.")
     _ = NSLocalizedString("%1$s. %2$s is %3$s %4$s.", comment: "translators: accessibility text. Inform about current value. %1$s: Control label %2$s: setting label (example: width), %3$s: Current value. %4$s: value measurement unit (example: pixels)")
     _ = NSLocalizedString("%1$s. Currently selected: %2$s", comment: "translators:  %1$s: Select control button label e.g. \"Button width\". %2$s: Select control option value e.g: \"Auto, 25%\".")
+    _ = NSLocalizedString("%s block", comment: "translators: Block name. %s: The localized block name\ntranslators: %s: Block name e.g. \"Image block\"")
     _ = NSLocalizedString("%s block options", comment: "translators: %s: block title e.g: \"Paragraph\".")
     _ = NSLocalizedString("%s block, newly available", comment: "translators: Newly available block name. %s: The localized block name")
     _ = NSLocalizedString("%s block. Empty", comment: "translators: accessibility text for the media block empty state. %s: media type")

--- a/ios-xcframework/Podfile.lock
+++ b/ios-xcframework/Podfile.lock
@@ -427,7 +427,7 @@ PODS:
     - React-RCTImage
   - RNSVG (13.9.0):
     - React-Core
-  - RNTAztecView (1.112.0):
+  - RNTAztecView (1.113.0):
     - React-Core
     - WordPress-Aztec-iOS (= 1.19.9)
   - SDWebImage (5.11.1):
@@ -662,7 +662,7 @@ SPEC CHECKSUMS:
   RNReanimated: 21e1e71d7f1ac9f2fa11df37c06a8ec52ed06232
   RNScreens: e3ffdd78ff5afe8ec82c2566ee2410857ed5ce75
   RNSVG: 29dd0ac32d83774d4b0953ae92a5cd8205a782d7
-  RNTAztecView: 74c676c87e4a9db79104fcdad9624c1e5c02fe15
+  RNTAztecView: e8a998a6928769cc4f9d903c5f6696bcd4265f58
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   WordPress-Aztec-iOS: fbebd569c61baa252b3f5058c0a2a9a6ada686bb

--- a/ios-xcframework/XCFrameworkScaffold.xcodeproj/project.pbxproj
+++ b/ios-xcframework/XCFrameworkScaffold.xcodeproj/project.pbxproj
@@ -358,11 +358,7 @@
 					"$(inherited)",
 					_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION,
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-Wl",
-					"-ld_classic",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../gutenberg/node_modules/react-native";
 			};
 			name = Debug;
@@ -377,11 +373,7 @@
 					"$(inherited)",
 					_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION,
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-Wl",
-					"-ld_classic",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../gutenberg/node_modules/react-native";
 			};
 			name = Release;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "gutenberg-mobile",
-	"version": "1.112.0",
+	"version": "1.113.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "gutenberg-mobile",
-			"version": "1.112.0",
+			"version": "1.113.0",
 			"hasInstallScript": true,
 			"devDependencies": {
 				"@babel/core": "^7.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg-mobile",
-	"version": "1.112.0",
+	"version": "1.113.0",
 	"private": true,
 	"config": {
 		"jsfiles": "./*.js src/*.js src/**/*.js src/**/**/*.js",


### PR DESCRIPTION
Release for Gutenberg Mobile 1.113.0

<!-- ## Related PRs

- https://github.com/WordPress/gutenberg/pull/59062

## Changes

 -->


<!-- To determine the changes you can check the RELEASE-NOTES.txt and gutenberg/packages/react-native-editor/CHANGELOG.md files and cross check with the list of commits that are part of the PR -->
## Test plan

Once the installable builds of the main apps are ready, perform a quick smoke test of the editor on both iOS and Android to verify it launches without crashing. We will perform additional testing after the main apps cut their releases.

## Release Submission Checklist

- [ ] Verify Items from test plan have been completed
- [ ] Check if `RELEASE-NOTES.txt` is updated with all the changes that made it to the release. Replace `Unreleased` section with the release version and create a new `Unreleased` section.
- [ ] Check if `gutenberg/packages/react-native-editor/CHANGELOG.md` is updated with all the changes that made it to the release. Replace `## Unreleased` with the release version and create a new `## Unreleased`.
- [ ] Bundle package of the release is updated.