### PR TITLE
build: XCFramework includes local resources

### DIFF
--- a/ios-xcframework/XCFrameworkScaffold.xcodeproj/project.pbxproj
+++ b/ios-xcframework/XCFrameworkScaffold.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2F4F38292B86842C006EF573 /* external-style-overrides.css in Resources */ = {isa = PBXBuildFile; fileRef = 2F4F38282B86842C006EF573 /* external-style-overrides.css */; };
+		2F4F382B2B86844A006EF573 /* extra-localstorage-entries.js in Resources */ = {isa = PBXBuildFile; fileRef = 2F4F382A2B86844A006EF573 /* extra-localstorage-entries.js */; };
+		2F4F382D2B868457006EF573 /* remove-nux.js in Resources */ = {isa = PBXBuildFile; fileRef = 2F4F382C2B868457006EF573 /* remove-nux.js */; };
 		3F1235FE29F680F900AF54A4 /* GutenbergBridgeDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1235FB29F680F900AF54A4 /* GutenbergBridgeDelegate.swift */; };
 		3F1235FF29F680F900AF54A4 /* GutenbergBridgeDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1235FC29F680F900AF54A4 /* GutenbergBridgeDataSource.swift */; };
 		3F12360029F680F900AF54A4 /* Gutenberg.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1235FD29F680F900AF54A4 /* Gutenberg.swift */; };
@@ -39,6 +42,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2F4F38282B86842C006EF573 /* external-style-overrides.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; name = "external-style-overrides.css"; path = "../../../resources/unsupported-block-editor/external-style-overrides.css"; sourceTree = "<group>"; };
+		2F4F382A2B86844A006EF573 /* extra-localstorage-entries.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = "extra-localstorage-entries.js"; path = "../../../resources/unsupported-block-editor/extra-localstorage-entries.js"; sourceTree = "<group>"; };
+		2F4F382C2B868457006EF573 /* remove-nux.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = "remove-nux.js"; path = "../../../resources/unsupported-block-editor/remove-nux.js"; sourceTree = "<group>"; };
 		3F1235FB29F680F900AF54A4 /* GutenbergBridgeDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GutenbergBridgeDelegate.swift; path = "../../gutenberg/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift"; sourceTree = "<group>"; };
 		3F1235FC29F680F900AF54A4 /* GutenbergBridgeDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GutenbergBridgeDataSource.swift; path = "../../gutenberg/packages/react-native-bridge/ios/GutenbergBridgeDataSource.swift"; sourceTree = "<group>"; };
 		3F1235FD29F680F900AF54A4 /* Gutenberg.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Gutenberg.swift; path = "../../gutenberg/packages/react-native-bridge/ios/Gutenberg.swift"; sourceTree = "<group>"; };
@@ -89,6 +95,9 @@
 		3F12363C29F6B1E900AF54A4 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				2F4F382C2B868457006EF573 /* remove-nux.js */,
+				2F4F382A2B86844A006EF573 /* extra-localstorage-entries.js */,
+				2F4F38282B86842C006EF573 /* external-style-overrides.css */,
 				3FA0C5802A1C8C9700600A9A /* App.js */,
 				3F12363F29F6B21300AF54A4 /* content-functions.js */,
 				3F12364429F6B21300AF54A4 /* editor-behavior-overrides.js */,
@@ -245,6 +254,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2F4F382D2B868457006EF573 /* remove-nux.js in Resources */,
+				2F4F382B2B86844A006EF573 /* extra-localstorage-entries.js in Resources */,
 				3F8D0D482A8CB297008A5891 /* assets in Resources */,
 				3FE06AD329F3F6DA00F752AD /* Project-Debug.xcconfig in Resources */,
 				3F12364E29F6B21300AF54A4 /* local-storage-overrides.json in Resources */,
@@ -262,6 +273,7 @@
 				3F12364C29F6B21300AF54A4 /* wp-bar-override.css in Resources */,
 				3F12365029F6B23300AF54A4 /* supported-blocks.json in Resources */,
 				3FA0C5812A1C8C9700600A9A /* App.js in Resources */,
+				2F4F38292B86842C006EF573 /* external-style-overrides.css in Resources */,
 				3F12364729F6B21300AF54A4 /* insert-block.js in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
## Description

These resource files were not included during the XCFramework build
phase. The absence resulted in a crash when the unsupported block 
editor (UBE) attempted to load the asset.

Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/21620.

## Testing Instructions

Clone [WordPress-iOS](https://github.com/wordpress-mobile/WordPress-iOS) and switch to the `trunk` branch. 

1. Launch Xcode. 
1. [Clear Xcode’s Derived Data](https://stackoverflow.com/a/39495772/378228) directory. 
1. Quit Xcode. 
1. In your WordPress-iOS clone…
    ```
    rm -rf build/
    rm -rf Pods/
    bundle exec pod install
    ```
1. Build the project with Xcode. 
1. Use the editor to open a post containing an unsupported block. 
1. Attempt to use the unsupported block editor to [modify](https://github.com/wordpress-mobile/test-cases/blob/698996af2bb0216fd95c5f65fea43d0f2075640a/test-cases/gutenberg/unsupported-block-editing.md#tc001) the block. 

Note the crash while loading the local asset. 

Modify `Gutenberg/config.yml` to point to the commit from this branch. 

<details><summary>Modification Diff</summary>

```diff
diff --git a/Gutenberg/config.yml b/Gutenberg/config.yml
index d7d70cc490..c8aefe3771 100644
--- a/Gutenberg/config.yml
+++ b/Gutenberg/config.yml
@@ -9,6 +9,7 @@
  #
  #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
 ref:
-  tag: v1.112.0
+  # tag: v1.112.0
+  commit: 24868f25b546527d70fbd3ec2a6c21edb264f775
 github_org: wordpress-mobile
 repo_name: gutenberg-mobile

```

</details>

Repeat the aforementioned steps. Note the crash no longer occurs. 

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
