### PR TITLE
Adopt an optimistic approach in CI to get faster feedback

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -110,10 +110,6 @@ steps:
       queue: android
 
   - label: Build JS Bundles
-    depends_on:
-      - lint
-      - android-unit-tests
-      - ios-unit-tests
     key: js-bundles
     agents:
       queue: android
@@ -157,9 +153,6 @@ steps:
         buildkite-agent artifact upload ios-assets.tar.gz
 
   - label: "Build Android RN Aztec & Publish to S3"
-    depends_on:
-      - lint
-      - android-unit-tests
     key: "publish-react-native-aztec-android"
     plugins:
       - *git-cache-plugin
@@ -190,9 +183,6 @@ steps:
 
   - label: iOS Build and Sauce Labs
     key: ios-build-and-saucelabs
-    depends_on:
-      - lint
-      - ios-unit-tests
     command: .buildkite/commands/build-ios.sh
     plugins:
       - *ci_toolkit_plugin
@@ -222,11 +212,6 @@ steps:
 
   - label: Android Build and Sauce Labs
     key: android-build-and-saucelabs
-    depends_on:
-      - lint
-      - android-unit-tests
-      - android-unit-tests-editor
-      - android-unit-tests-bridge
     command: .buildkite/commands/build-android.sh
     plugins:
       - *ci_toolkit_plugin

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -126,7 +126,7 @@ steps:
       - *git-cache-plugin
     command: |
         source /root/.bashrc
-        
+
         echo "--- :node: Set up Node environment"
         nvm install && nvm use
 


### PR DESCRIPTION
This removes non-required dependencies from CI steps in the interest of maximizing the chances for parallelization and receive feedback faster.

For example, we no longer wait for unit tests and linter to finish before building the JS bundle or running the E2E tests. Obviously, required dependencies such as building the JS bundle before building the XCFramework are still in place.

The assumption is that **faster feedback is more valuable than the cost of running unnecessary steps**.

If the unit tests fail, running the E2E tests is a waste because we know there's something wrong in the code. But the value we get in faster feedback on the whole build is higher than the compute dollars we waste on those steps.

Besides, running the E2E tests even when the UI tests fail might still be valuable. If the E2E pass, for example, we have a signal on a different degree of coverage, which is something worth investigating (but not necessarily, we don't want to replicate the fast, comprehensive coverage that unit tests offer in the slower and more cumbersome E2E layer).

If this approach is considered valuable, we might want to further refine it so that we maybe try to build (or whatever the equivalent in React Native land is of what iOS and Android call building) before attempting tests.  That is because if the code doesn't "build," then the problem is upstream of the tests runtime and we know for certain that all those steps will
fail.

### Before

<img width="1167" alt="image" src="https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/e1cc0add-a545-42b4-9c13-c685142d61cc">

### After

<img width="1182" alt="image" src="https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/3978a0a4-91d8-4663-8b15-d820161b3326">

<br/>

As can be seen in the images, none of the steps take the same time to run (+/– networking speed affecting resource downloads) but because we start various steps sooner, the whole pipeline **completes ~15 minutes earlier.**