### PR TITLE
build: Fix i18n script paths causing `bundle` command not found errors

### DIFF
--- a/bin/i18n-update.sh
+++ b/bin/i18n-update.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 
+#
 # Handles the process of updating the i18n localizations of plugins, including Gutenberg.
 # The main goals of this command are:
 #
@@ -127,8 +127,19 @@ npm run build:gutenberg
 # - VideoPress package
 ./bin/run-jetpack-command.sh "-C projects/packages/videopress build"
 
-# Extract used strings for plugins
-METRO_CONFIG="metro.config.js" node gutenberg/packages/react-native-editor/bin/extract-used-strings "$USED_STRINGS_PATH" "${PLUGINS[@]}"
+# Extract used strings for plugins, adapt relative paths for changing directories
+PLUGINS_WITH_ADAPTED_PATHS=()
+for (( index=0; index<${#PLUGINS[@]}; index+=3 )); do
+  PLUGIN_NAME=${PLUGINS[index]}
+  PROJECT_SLUG=${PLUGINS[index+1]}
+  PLUGIN_FOLDER=${PLUGINS[index+2]}
+
+  ADJUSTED_PLUGIN_FOLDER="../../../$PLUGIN_FOLDER"
+  PLUGINS_WITH_ADAPTED_PATHS+=( "$PLUGIN_NAME" "$PROJECT_SLUG" "$ADJUSTED_PLUGIN_FOLDER" )
+done
+pushd gutenberg/packages/react-native-editor > /dev/null
+METRO_CONFIG="../../../metro.config.js" node bin/extract-used-strings "$USED_STRINGS_PATH" "${PLUGINS_WITH_ADAPTED_PATHS[@]}"
+popd > /dev/null
 
 # Download translations of plugins (i.e. Jetpack)
 for (( index=0; index<${#PLUGINS[@]}; index+=3 )); do


### PR DESCRIPTION
## Description

Certain React Native CLI commands were relocated when `cli-plugin-metro`
was moved to the React Native core repository.

https://github.com/react-native-community/cli/commit/80c84d019bc2d3b640c03856e7111a6459e62357

This resulted in an inability for `gutenberg-mobile` project scripts to
locate commands like `bundle`, as the `react-native` package is not
installed as direct dependency. Instead `gutenberg-mobile` relies upon
the version within the `gutenberg` Git submodule.

This change relies upon changing directories into the Git submodule so
that Node.js module resolution locates the React Native package.

Similar changes were applied to other React Native CLI commands during
the React Native 0.73 upgrade.

https://github.com/wordpress-mobile/gutenberg-mobile/commit/e2e5429805fe199f97df58f2dfc9872ac75297dc

## Testing Instructions

1. Run `npm run i18n:update`.
1. Verify it succeeds and expected files are generated.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
