### PR TITLE
build: Fix i18n test script path

### DIFF
--- a/bin/i18n-update.sh
+++ b/bin/i18n-update.sh
@@ -138,7 +138,7 @@ for (( index=0; index<${#PLUGINS[@]}; index+=3 )); do
   PLUGINS_WITH_ADAPTED_PATHS+=( "$PLUGIN_NAME" "$PROJECT_SLUG" "$ADJUSTED_PLUGIN_FOLDER" )
 done
 pushd gutenberg/packages/react-native-editor > /dev/null
-METRO_CONFIG="../../../metro.config.js" node bin/extract-used-strings "$USED_STRINGS_PATH" "${PLUGINS_WITH_ADAPTED_PATHS[@]}"
+METRO_CONFIG="../../../metro.config.js" node bin/extract-used-strings "../../../$USED_STRINGS_PATH" "${PLUGINS_WITH_ADAPTED_PATHS[@]}"
 popd > /dev/null
 
 # Download translations of plugins (i.e. Jetpack)


### PR DESCRIPTION
## Description 

Adjust an inability to load the used strings file path due to the script
now relying upon changing directories. Similar changes were made in
https://github.com/wordpress-mobile/gutenberg-mobile/pull/6700.

## Testing Instructions

Verify running `npm run i18n:update:test` succeeds in creating an VCS-ignored,
top-level `i18n-test` directory.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
