### PR TITLE
build: Capture core dependency updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
 		},
 		"gutenberg/packages/babel-plugin-import-jsx-pragma": {
 			"name": "@wordpress/babel-plugin-import-jsx-pragma",
-			"version": "4.34.0",
+			"version": "4.35.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -75,7 +75,7 @@
 		},
 		"gutenberg/packages/babel-preset-default": {
 			"name": "@wordpress/babel-preset-default",
-			"version": "7.35.0",
+			"version": "7.36.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -98,7 +98,7 @@
 		},
 		"gutenberg/packages/browserslist-config": {
 			"name": "@wordpress/browserslist-config",
-			"version": "5.34.0",
+			"version": "5.35.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -138,7 +138,7 @@
 		},
 		"gutenberg/packages/eslint-plugin": {
 			"name": "@wordpress/eslint-plugin",
-			"version": "17.8.0",
+			"version": "17.9.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -271,7 +271,7 @@
 		},
 		"gutenberg/packages/prettier-config": {
 			"name": "@wordpress/prettier-config",
-			"version": "3.8.0",
+			"version": "3.9.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -283,7 +283,7 @@
 		},
 		"gutenberg/packages/warning": {
 			"name": "@wordpress/warning",
-			"version": "2.51.0",
+			"version": "2.52.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {


### PR DESCRIPTION
These updates originate from the core Gutenberg repository.

https://github.com/WordPress/gutenberg/commit/f01fef6cf0b0bfab5752b3d2c648274d7150d739

To test: N/A, no user facing changes.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
