### PR TITLE
Metro config - Exclude some `block-experiments` packages from metro's module resolution

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -18,7 +18,11 @@ const gutenbergMetroConfigCopy = {
 		sourceExts: [ 'js', 'cjs', 'jsx', 'json', 'scss', 'sass', 'ts', 'tsx' ],
 		extraNodeModules,
 		// Exclude `ios-xcframework` folder to avoid conflicts with packages contained in Pods.
-		blockList: [ /ios-xcframework\/.*/ ],
+		blockList: [
+			/ios-xcframework\/.*/,
+			// Prevents a resolution issue for these packages
+			/block-experiments\/node_modules\/@wordpress\/.*/,
+		],
 	},
 };
 


### PR DESCRIPTION

Fixes #

To test:

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
