### PR TITLE
build: Fix failure when running npm command `i18n:update`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -133,12 +133,12 @@ steps:
         echo "--- :npm: Install Node dependencies"
         npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 
-        if [[ -z "$BUILDKITE_TAG" ]]; then
-          echo "--- :package: Skip bundle prep work"
-        else
+        # if [[ -z "$BUILDKITE_TAG" ]]; then
+          # echo "--- :package: Skip bundle prep work"
+        # else
           echo "--- :package: Run bundle prep work"
           npm run prebundle:js
-        fi
+        # fi
 
         echo "--- :android: Build Android bundle"
         npm run bundle:android

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -133,12 +133,12 @@ steps:
         echo "--- :npm: Install Node dependencies"
         npm ci --unsafe-perm --prefer-offline --no-audit --no-progress
 
-        # if [[ -z "$BUILDKITE_TAG" ]]; then
-          # echo "--- :package: Skip bundle prep work"
-        # else
+        if [[ -z "$BUILDKITE_TAG" ]]; then
+          echo "--- :package: Skip bundle prep work"
+        else
           echo "--- :package: Run bundle prep work"
           npm run prebundle:js
-        # fi
+        fi
 
         echo "--- :android: Build Android bundle"
         npm run bundle:android

--- a/bin/i18n-update.sh
+++ b/bin/i18n-update.sh
@@ -82,7 +82,13 @@ function fetch_translations() {
 
 # Set target path
 if [[ -n "${LOCAL_PATH:-}" ]]; then
-  TARGET_PATH=$LOCAL_PATH
+  # Ensure the target path is an absolute path
+  # Use greadlink on macOS, readlink on Linux
+  if [[ "$(uname)" == "Darwin" ]]; then
+      TARGET_PATH=$(greadlink -f "$LOCAL_PATH")
+  else
+      TARGET_PATH=$(readlink -f "$LOCAL_PATH")
+  fi
 else
   TARGET_PATH=$(mktemp -d)
   trap '{ rm -rf -- "$TARGET_PATH"; }' EXIT
@@ -138,7 +144,7 @@ for (( index=0; index<${#PLUGINS[@]}; index+=3 )); do
   PLUGINS_WITH_ADAPTED_PATHS+=( "$PLUGIN_NAME" "$PROJECT_SLUG" "$ADJUSTED_PLUGIN_FOLDER" )
 done
 pushd gutenberg/packages/react-native-editor > /dev/null
-METRO_CONFIG="../../../metro.config.js" node bin/extract-used-strings "../../../$USED_STRINGS_PATH" "${PLUGINS_WITH_ADAPTED_PATHS[@]}"
+METRO_CONFIG="../../../metro.config.js" node bin/extract-used-strings "$USED_STRINGS_PATH" "${PLUGINS_WITH_ADAPTED_PATHS[@]}"
 popd > /dev/null
 
 # Download translations of plugins (i.e. Jetpack)


### PR DESCRIPTION
This PR follows up https://github.com/wordpress-mobile/gutenberg-mobile/pull/6704 to address the issue outlined in https://github.com/wordpress-mobile/gutenberg-mobile/pull/6704#discussion_r1519649094. The solution applied is to ensure that both `TARGET_PATH` and `USED_STRINGS_PATH` variables point to an absolute path.

### To test

**`i18n:update` command:**
1. Run `npm run i18n:update`
1. Observe that the command succeeds. **NOTE:** It's likely that localization strings files get updated.

**`i18n:update:test` command:**
1. Run `i18n:update:test`.
1. Observe that the command succeeds and that the file `i18n-test/used-strings.json` is created.

**Build JS bundles CI job:**
1. Observe that the CI job in the commit https://github.com/wordpress-mobile/gutenberg-mobile/pull/6715/commits/6c69879adff2a06aaac3ee301994a29999ed3f35 succeeds.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.