### PR TITLE
Change CI `checkout` approach for faster repo setup

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -43,6 +43,8 @@ steps:
       - *ci_toolkit_plugin
       - automattic/git-partial-clone#trunk
       - *nvm_plugin
+    env:
+      BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH: true
     agents:
       queue: android
     command: .buildkite/commands/lint.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -55,9 +55,9 @@ steps:
   - label: Android Unit Tests
     key: android-unit-tests
     plugins:
+      - automattic/git-partial-clone#mokagio/experiments
       - *nvm_plugin
       - *ci_toolkit_plugin
-      - *git-cache-plugin
     agents:
       queue: android
     command: .buildkite/commands/unit-tests-android.sh
@@ -75,7 +75,7 @@ steps:
     plugins:
       - *nvm_plugin
       - *ci_toolkit_plugin
-      - *git-cache-plugin
+      - automattic/git-partial-clone#mokagio/experiments
     agents:
       queue: android
     command: .buildkite/commands/unit-tests-ios.sh
@@ -97,7 +97,7 @@ steps:
       ./gradlew testDebug
     plugins:
       - *ci_toolkit_plugin
-      - *git-cache-plugin
+      - automattic/git-partial-clone#mokagio/experiments
       - *nvm_plugin
     agents:
       queue: android
@@ -111,7 +111,7 @@ steps:
       ./gradlew test
     plugins:
       - *ci_toolkit_plugin
-      - *git-cache-plugin
+      - automattic/git-partial-clone#mokagio/experiments
       - *nvm_plugin
     agents:
       queue: android
@@ -126,7 +126,7 @@ steps:
       - *gb-mobile-docker-container
       # - *ci_toolkit_plugin # unused?
       # - *nvm_plugin
-      - *git-cache-plugin
+      - automattic/git-partial-clone#mokagio/experiments
     command: |
         source /root/.bashrc
 
@@ -162,7 +162,7 @@ steps:
   - label: "Build Android RN Aztec & Publish to S3"
     key: "publish-react-native-aztec-android"
     plugins:
-      - *git-cache-plugin
+      - automattic/git-partial-clone#mokagio/experiments
       - *publish-android-artifacts-docker-container
     command: .buildkite/commands/publish-react-native-aztec-android-artifacts.sh
 
@@ -171,7 +171,7 @@ steps:
       - "js-bundles"
       - "publish-react-native-aztec-android"
     plugins:
-      - *git-cache-plugin
+      - automattic/git-partial-clone#mokagio/experiments
       - *publish-android-artifacts-docker-container
     command: .buildkite/commands/publish-react-native-bridge-android-artifacts.sh
 
@@ -222,7 +222,7 @@ steps:
     command: .buildkite/commands/build-android.sh
     plugins:
       - *ci_toolkit_plugin
-      - *git-cache-plugin
+      - automattic/git-partial-clone#mokagio/experiments
       - *nvm_plugin
     agents:
       queue: android
@@ -233,7 +233,7 @@ steps:
     plugins:
       - *ci_toolkit_plugin
       - *nvm_plugin
-      - *git-cache-plugin
+      - automattic/git-partial-clone#mokagio/experiments
     agents:
       queue: android
     artifact_paths:
@@ -328,7 +328,7 @@ steps:
     plugins:
       - *ci_toolkit_plugin
       - *nvm_plugin
-      - *git-cache-plugin
+      - automattic/git-partial-clone#mokagio/experiments
     agents:
       queue: android
     artifact_paths:
@@ -345,7 +345,7 @@ steps:
     plugins:
       - *ci_toolkit_plugin
       - *nvm_plugin
-      - *git-cache-plugin
+      - automattic/git-partial-clone#mokagio/experiments
     agents:
       queue: android
     artifact_paths:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -41,8 +41,8 @@ steps:
     key: lint
     plugins:
       - *ci_toolkit_plugin
+      - automattic/git-partial-clone#trunk
       - *nvm_plugin
-      - *git-cache-plugin
     agents:
       queue: android
     command: .buildkite/commands/lint.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -45,8 +45,6 @@ steps:
       - *ci_toolkit_plugin
       - *git-partial-clone-plugin
       - *nvm_plugin
-    env:
-      BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH: true
     agents:
       queue: android
     command: .buildkite/commands/lint.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,6 +14,8 @@ x-common-params:
       # Ensure these settings match what's defined in cache-builder.yml
       bucket: a8c-repo-mirrors
       repo: automattic/gutenberg-mobile/
+  - &git-partial-clone-plugin
+    automattic/git-partial-clone#trunk
   - &publish-android-artifacts-docker-container
     docker#v3.8.0:
       image: 'public.ecr.aws/automattic/android-build-image:v1.3.0'
@@ -41,7 +43,7 @@ steps:
     key: lint
     plugins:
       - *ci_toolkit_plugin
-      - automattic/git-partial-clone#mokagio/experiments
+      - *git-partial-clone-plugin
       - *nvm_plugin
     env:
       BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH: true
@@ -55,7 +57,7 @@ steps:
   - label: Android Unit Tests
     key: android-unit-tests
     plugins:
-      - automattic/git-partial-clone#mokagio/experiments
+      - *git-partial-clone-plugin
       - *nvm_plugin
       - *ci_toolkit_plugin
     agents:
@@ -75,7 +77,7 @@ steps:
     plugins:
       - *nvm_plugin
       - *ci_toolkit_plugin
-      - automattic/git-partial-clone#mokagio/experiments
+      - *git-partial-clone-plugin
     agents:
       queue: android
     command: .buildkite/commands/unit-tests-ios.sh
@@ -97,7 +99,7 @@ steps:
       ./gradlew testDebug
     plugins:
       - *ci_toolkit_plugin
-      - automattic/git-partial-clone#mokagio/experiments
+      - *git-partial-clone-plugin
       - *nvm_plugin
     agents:
       queue: android
@@ -111,7 +113,7 @@ steps:
       ./gradlew test
     plugins:
       - *ci_toolkit_plugin
-      - automattic/git-partial-clone#mokagio/experiments
+      - *git-partial-clone-plugin
       - *nvm_plugin
     agents:
       queue: android
@@ -126,7 +128,7 @@ steps:
       - *gb-mobile-docker-container
       # - *ci_toolkit_plugin # unused?
       # - *nvm_plugin
-      - automattic/git-partial-clone#mokagio/experiments
+      - *git-partial-clone-plugin
     command: |
         source /root/.bashrc
 
@@ -162,7 +164,7 @@ steps:
   - label: "Build Android RN Aztec & Publish to S3"
     key: "publish-react-native-aztec-android"
     plugins:
-      - automattic/git-partial-clone#mokagio/experiments
+      - *git-partial-clone-plugin
       - *publish-android-artifacts-docker-container
     command: .buildkite/commands/publish-react-native-aztec-android-artifacts.sh
 
@@ -171,7 +173,7 @@ steps:
       - "js-bundles"
       - "publish-react-native-aztec-android"
     plugins:
-      - automattic/git-partial-clone#mokagio/experiments
+      - *git-partial-clone-plugin
       - *publish-android-artifacts-docker-container
     command: .buildkite/commands/publish-react-native-bridge-android-artifacts.sh
 
@@ -222,7 +224,7 @@ steps:
     command: .buildkite/commands/build-android.sh
     plugins:
       - *ci_toolkit_plugin
-      - automattic/git-partial-clone#mokagio/experiments
+      - *git-partial-clone-plugin
       - *nvm_plugin
     agents:
       queue: android
@@ -233,7 +235,7 @@ steps:
     plugins:
       - *ci_toolkit_plugin
       - *nvm_plugin
-      - automattic/git-partial-clone#mokagio/experiments
+      - *git-partial-clone-plugin
     agents:
       queue: android
     artifact_paths:
@@ -328,7 +330,7 @@ steps:
     plugins:
       - *ci_toolkit_plugin
       - *nvm_plugin
-      - automattic/git-partial-clone#mokagio/experiments
+      - *git-partial-clone-plugin
     agents:
       queue: android
     artifact_paths:
@@ -345,7 +347,7 @@ steps:
     plugins:
       - *ci_toolkit_plugin
       - *nvm_plugin
-      - automattic/git-partial-clone#mokagio/experiments
+      - *git-partial-clone-plugin
     agents:
       queue: android
     artifact_paths:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -41,7 +41,7 @@ steps:
     key: lint
     plugins:
       - *ci_toolkit_plugin
-      - automattic/git-partial-clone#trunk
+      - automattic/git-partial-clone#mokagio/experiments
       - *nvm_plugin
     env:
       BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,7 +15,7 @@ x-common-params:
       bucket: a8c-repo-mirrors
       repo: automattic/gutenberg-mobile/
   - &git-partial-clone-plugin
-    automattic/git-partial-clone#trunk
+    automattic/git-partial-clone#0.1.0
   - &publish-android-artifacts-docker-container
     docker#v3.8.0:
       image: 'public.ecr.aws/automattic/android-build-image:v1.3.0'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,11 +9,6 @@ x-common-params:
         - 'WP_CLI_ALLOW_ROOT=true'
         # Increase max available memory for node
         - 'NODE_OPTIONS="--max-old-space-size=4096"'
-  - &git-cache-plugin
-    automattic/git-s3-cache#1.1.4:
-      # Ensure these settings match what's defined in cache-builder.yml
-      bucket: a8c-repo-mirrors
-      repo: automattic/gutenberg-mobile/
   - &git-partial-clone-plugin
     automattic/git-partial-clone#0.1.0
   - &publish-android-artifacts-docker-container
@@ -183,7 +178,6 @@ steps:
     plugins:
       - *ci_toolkit_plugin
       - *nvm_plugin
-      - *git-cache-plugin
     agents:
       queue: mac
     env: *xcode_agent_env
@@ -194,7 +188,6 @@ steps:
     plugins:
       - *ci_toolkit_plugin
       - *nvm_plugin
-      - *git-cache-plugin
     artifact_paths:
       - ./gutenberg/packages/react-native-editor/ios/GutenbergDemo.app.zip
     agents:
@@ -207,7 +200,6 @@ steps:
     plugins:
       - *ci_toolkit_plugin
       - *nvm_plugin
-      - *git-cache-plugin
     artifact_paths:
       - reports/test-results/ios-test-results.xml
     agents:
@@ -261,7 +253,6 @@ steps:
     plugins:
       - *ci_toolkit_plugin
       - *nvm_plugin
-      - *git-cache-plugin
     artifact_paths:
       - reports/test-results/ios-test-results.xml
     agents:
@@ -278,7 +269,6 @@ steps:
     plugins:
       - *ci_toolkit_plugin
       - *nvm_plugin
-      - *git-cache-plugin
     artifact_paths:
       - reports/test-results/ios-test-results.xml
     agents:
@@ -295,7 +285,6 @@ steps:
     plugins:
       - *ci_toolkit_plugin
       - *nvm_plugin
-      - *git-cache-plugin
     artifact_paths:
       - reports/test-results/ios-test-results.xml
     agents:
@@ -311,7 +300,6 @@ steps:
     plugins:
       - *ci_toolkit_plugin
       - *nvm_plugin
-      - *git-cache-plugin
     artifact_paths:
       - reports/test-results/ios-test-results.xml
     agents:


### PR DESCRIPTION
This experimental PR builds on top of a suggestion by @AliSoftware to add a `--filter` to the `git clone` command as explained [in this blog post by GitHub](https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/).

> **Treeless clones**
> In some repositories, the tree data might be a significant portion of the history. Using `--filter=tree:0`, a treeless clone downloads all reachable commits, then downloads trees and blobs on demand.
> [...]
> Treeless clones are really only helpful for automated builds when you want to quickly clone, compile a project, then throw away the repository. 

At first, I tried setting `--filter=tree:0` via the env var Buildkite offers. That worked well for checking out `gutenberg-mobile` but didn't improve the situation for its submodules. I tinkered with options but didn't get far. As far as I could tell, while one can customize some of the checkout behavior, Buildkite still adds certain parameters to the commands which interfered with the approach.

As such, I tried using [a custom checkout script](https://github.com/Automattic/git-partial-clone-buildkite-plugin/blob/77ac31a82ea20f8f6f5d2734db5dc162c97b39a9/hooks/checkout):

```sh
#!/usr/bin/env bash

# Hooks are sourced, so we need to set flags via `set`, not shebang.
set -eu

echo '[git-partial-clone-plugin] :git: Adding GitHub to known hosts'
ssh-keyscan -t rsa github.com >> "$HOME/.ssh/known_hosts"

# See https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/
#
# > Treeless clones are really only helpful for automated
# > builds when you want to quickly clone, compile a project,
# > then throw away the repository. In environments like
# > GitHub Actions using public runners, you want to minimize
# > your clone time so you can spend your machine time
# > actually building your software! Treeless clones might be
# > an excellent option for those environments.

echo '[git-partial-clone-plugin] :git: Cloning repo and submodules'
git clone --filter=tree:0 --recurse-submodules --also-filter-submodules "$BUILDKITE_REPO" "$BUILDKITE_BUILD_CHECKOUT_PATH"

cd "$BUILDKITE_BUILD_CHECKOUT_PATH"

git submodule foreach --recursive "git clean -ffxdq"
git clean -ffxdq

echo '[git-partial-clone-plugin] :git: Checking out commit'
git checkout -f "$BUILDKITE_COMMIT"

git submodule sync --recursive
git submodule update --init --recursive
```

The result was that **checking out the repo now takes ~30 seconds** where before it took ~5 minutes.

![image](https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/7d0b9bea-5c4b-43fe-9ef1-3f43859a68fb)

![image](https://github.com/wordpress-mobile/gutenberg-mobile/assets/1218433/3dff6d1f-2b21-4ae9-91cc-adcfa5074f42)

The improvement is so good and promising that I'm scared I'm missing something here. Like, why wouldn't Buildkite use this approach out of the box?

Still, I'm putting it out here for your feedback and consideration. Let me know what you think.

_Note:_ The iOS steps running on the `mac` queue don't use the plugin because the Apple Silicon CI optimization for Git @jkmassel built already delivers great speed.