### PR TITLE
Update dependabot configuration to check for updates for each submodule at a different time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,25 @@
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/
+
+# We are using a configuration for each submodule so they run at a different time
+# to avoid multiple PRs running CI and SauceLabs.
 
 version: 2
 updates:
   - package-ecosystem: "gitsubmodule" # See documentation for possible values
-    directory: "/" # Location of package manifests
+    directory: "/gutenberg" # Location of package manifests
     schedule:
       interval: "daily"
+      time: "12:00" # UTC time
+  - package-ecosystem: "gitsubmodule"
+    directory: "/jetpack"
+    schedule:
+      interval: "daily"
+      time: "14:00"
+  - package-ecosystem: "gitsubmodule"
+    directory: "/block-experiments"
+    schedule:
+      interval: "daily"
+      time: "16:00"


### PR DESCRIPTION
Currently, Dependabot's configuration for submodules is the same for all of them. The issue with that is that it triggers CI at the same time. Usually, it's just for `gutenberg` and `jetpack`, but in some cases, `block-experiments` is more active and it adds one more.

<kbd><img width="534" alt="Screenshot 2024-03-15 at 14 03 23" src="https://github.com/wordpress-mobile/gutenberg-mobile/assets/4885740/403564e2-63d4-44c8-81b9-aec31a956f4f"></kbd>

The main issue is SauceLabs, since we have a limit of 5 jobs to run at a time. So, tests usually fail due to exceeding retry times or getting the connection terminated.

With this proposal, there will be a 2-hour space between each submodule to avoid this problem.

To test CI checks should pass.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
