### PR TITLE
Update Dependabot configuration to use patterns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,17 +9,31 @@
 version: 2
 updates:
   - package-ecosystem: "gitsubmodule" # See documentation for possible values
-    directory: "/gutenberg" # Location of package manifests
+    directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-      time: "12:00" # UTC time
+      time: "18:00" # UTC time
+    groups:
+      submodules:
+        patterns:
+        - "gutenberg"
+
   - package-ecosystem: "gitsubmodule"
-    directory: "/jetpack"
+    directory: "/"
     schedule:
       interval: "daily"
-      time: "14:00"
+      time: "20:00"
+    groups:
+      submodules:
+        patterns:
+        - "jetpack"
+
   - package-ecosystem: "gitsubmodule"
-    directory: "/block-experiments"
+    directory: "/"
     schedule:
       interval: "daily"
-      time: "16:00"
+      time: "22:00"
+    groups:
+      submodules:
+        patterns:
+        - "block-experiments"


### PR DESCRIPTION
This PR updates the Depentabot configuration to use [patterns](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/customizing-dependency-updates#example-2) instead of specific directories.

The current configuration is not [being triggered](https://github.com/wordpress-mobile/gutenberg-mobile/pulls?q=is%3Apr+is%3Aopen+label%3Adependencies), the Gutenberg PR should've been updated today at 14:00 UTC.

The only way to test this is to merge it into `trunk`.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
