### PR TITLE
Update Dependabot config to use target-branch for one of the configurations.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,11 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/
 
-# We are using a configuration for each submodule so they run at a different time
+# We are using two configurations so they run at a different time
 # to avoid multiple PRs running CI and SauceLabs.
+# Currently, there's a limitation with GitHub and multiple combinations of
+# package-ecosystem, as a workaround one of them has a target-branch.
+# https://github.com/dependabot/dependabot-core/issues/1778
 
 version: 2
 updates:
@@ -12,28 +15,20 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-      time: "18:00" # UTC time
+      time: "19:00" # UTC time
     groups:
       submodules:
         patterns:
         - "gutenberg"
+    target-branch: trunk
 
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
       interval: "daily"
-      time: "20:00"
+      time: "21:00"
     groups:
       submodules:
         patterns:
         - "jetpack"
-
-  - package-ecosystem: "gitsubmodule"
-    directory: "/"
-    schedule:
-      interval: "daily"
-      time: "22:00"
-    groups:
-      submodules:
-        patterns:
         - "block-experiments"


### PR DESCRIPTION
This is a follow-up of https://github.com/wordpress-mobile/gutenberg-mobile/pull/6744

Unfortunately, [those changes failed](https://github.com/wordpress-mobile/gutenberg-mobile/runs/22795776877) with the following error:

```
Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'
```

After some investigation, I saw [there's an issue](https://github.com/dependabot/dependabot-core/issues/1778) related to this, where a [workaround is suggested](https://github.com/dependabot/dependabot-core/issues/1778#issuecomment-1988140219) and I'm trying out with this PR.

I've added `target-branch` to the Gutenberg config, which should bypass the error mentioned above.

Since this workaround only works for two configurations, I've merged the Jetpack and Block Experiments since the latter doesn't get too many updates lately so it should only trigger Jetpack updates daily.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
