### PR TITLE
Dependabot config - Use "allow" option for filtering

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,10 +16,8 @@ updates:
     schedule:
       interval: "daily"
       time: "19:00" # UTC time
-    groups:
-      submodules:
-        patterns:
-        - "gutenberg"
+    allow:
+      - dependency-name: "gutenberg"
     target-branch: trunk
 
   - package-ecosystem: "gitsubmodule"
@@ -27,8 +25,6 @@ updates:
     schedule:
       interval: "daily"
       time: "21:00"
-    groups:
-      submodules:
-        patterns:
-        - "jetpack"
-        - "block-experiments"
+    allow:
+      - dependency-name: "jetpack"
+      - dependency-name: "block-experiments"


### PR DESCRIPTION
Follow-up of https://github.com/wordpress-mobile/gutenberg-mobile/pull/6745

The new config worked but using "groups" for filtering duplicated the PRs for each submodule due to having two configurations:

<kbd><img width="399" alt="Screenshot 2024-03-18 at 19 35 09" src="https://github.com/wordpress-mobile/gutenberg-mobile/assets/4885740/265d04a5-d874-470c-b4cd-8af8095016c4"></kbd>

This PR uses the [allow](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#allow) option to specify the submodules for each config.

To test:

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
