### PR TITLE
Avoid including source map file in app's binary

### DIFF
--- a/ios-xcframework/XCFrameworkScaffold.xcodeproj/project.pbxproj
+++ b/ios-xcframework/XCFrameworkScaffold.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1D9EA4BE2B87A2570086B30F /* App.composed.js.map in Resources */ = {isa = PBXBuildFile; fileRef = 1D9EA4BD2B87A2470086B30F /* App.composed.js.map */; };
 		2F4F38292B86842C006EF573 /* external-style-overrides.css in Resources */ = {isa = PBXBuildFile; fileRef = 2F4F38282B86842C006EF573 /* external-style-overrides.css */; };
 		2F4F382B2B86844A006EF573 /* extra-localstorage-entries.js in Resources */ = {isa = PBXBuildFile; fileRef = 2F4F382A2B86844A006EF573 /* extra-localstorage-entries.js */; };
 		2F4F382D2B868457006EF573 /* remove-nux.js in Resources */ = {isa = PBXBuildFile; fileRef = 2F4F382C2B868457006EF573 /* remove-nux.js */; };
@@ -272,7 +271,6 @@
 				3F12364C29F6B21300AF54A4 /* wp-bar-override.css in Resources */,
 				3F12365029F6B23300AF54A4 /* supported-blocks.json in Resources */,
 				3FA0C5812A1C8C9700600A9A /* App.js in Resources */,
-				1D9EA4BE2B87A2570086B30F /* App.composed.js.map in Resources */,
 				2F4F38292B86842C006EF573 /* external-style-overrides.css in Resources */,
 				3F12364729F6B21300AF54A4 /* insert-block.js in Resources */,
 			);

--- a/ios-xcframework/build.sh
+++ b/ios-xcframework/build.sh
@@ -169,10 +169,17 @@ cp -r "$XCFRAMEWORKS_DIR/yoga.xcframework" "$ARCHIVE_FRAMEWORKS_PATH"
 # We don't want the Catalyst slice because 1) it's huge and 2) we don't need it at the moment
 rsync -a "$HERMES_XCFRAMEWORK" "$ARCHIVE_FRAMEWORKS_PATH" --exclude '*-maccatalyst'
 
+# Copy React Native bundle and source map for other uses in the host app
+RN_BUNDLE_SOURCE_MAP_DIR_NAME="react-native-bundle-source-map"
+mkdir -p "$XCFRAMEWORKS_DIR/$RN_BUNDLE_SOURCE_MAP_DIR_NAME"
+cp ../bundle/ios/App.js.map "$XCFRAMEWORKS_DIR/$RN_BUNDLE_SOURCE_MAP_DIR_NAME/main.jsbundle"
+cp ../bundle/ios/App.composed.js.map "$XCFRAMEWORKS_DIR/$RN_BUNDLE_SOURCE_MAP_DIR_NAME/main.jsbundle.map"
+
 ARCHIVE_PATH="$XCFRAMEWORKS_DIR/$MAIN_FRAMEWORK_NAME.tar.gz"
 
 tar -czf "$ARCHIVE_PATH" -C "$XCFRAMEWORKS_DIR" \
   "$ARCHIVE_FRAMEWORKS_DIR_NAME" \
-  "$DUMMY_FILE_NAME"
+  "$DUMMY_FILE_NAME" \
+  "$RN_BUNDLE_SOURCE_MAP_DIR_NAME"
 
 echo "Gutenberg XCFrameworks archive generated at $ARCHIVE_PATH"

--- a/ios-xcframework/build.sh
+++ b/ios-xcframework/build.sh
@@ -172,7 +172,7 @@ rsync -a "$HERMES_XCFRAMEWORK" "$ARCHIVE_FRAMEWORKS_PATH" --exclude '*-maccataly
 # Copy React Native bundle and source map for other uses in the host app
 RN_BUNDLE_SOURCE_MAP_DIR_NAME="react-native-bundle-source-map"
 mkdir -p "$XCFRAMEWORKS_DIR/$RN_BUNDLE_SOURCE_MAP_DIR_NAME"
-cp ../bundle/ios/App.js.map "$XCFRAMEWORKS_DIR/$RN_BUNDLE_SOURCE_MAP_DIR_NAME/main.jsbundle"
+cp ../bundle/ios/App.js "$XCFRAMEWORKS_DIR/$RN_BUNDLE_SOURCE_MAP_DIR_NAME/main.jsbundle"
 cp ../bundle/ios/App.composed.js.map "$XCFRAMEWORKS_DIR/$RN_BUNDLE_SOURCE_MAP_DIR_NAME/main.jsbundle.map"
 
 ARCHIVE_PATH="$XCFRAMEWORKS_DIR/$MAIN_FRAMEWORK_NAME.tar.gz"

--- a/ios-xcframework/podspec.erb
+++ b/ios-xcframework/podspec.erb
@@ -25,4 +25,6 @@ Pod::Spec.new do |s|
     'Frameworks/yoga.xcframework',
     'Frameworks/hermes.xcframework'
   ]
+
+  s.preserve_paths = 'react-native-bundle-source-map'
 end


### PR DESCRIPTION
**Related PRs:**
* https://github.com/wordpress-mobile/WordPress-iOS/pull/22874

_Internal ref:_  pcdRpT-5rI-p2#comment-9518

This PR updates the approach for including the React Native source map when publishing the GBM via the XCFramework. The goal is to avoid including it in the final app's binary. Instead of including the file as an asset in the Xcode project, we'll create a new folder to hold both the bundle and source map independent of the iOS frameworks.

The previous approach was introduced in https://github.com/wordpress-mobile/WordPress-iOS/pull/22862.

**To test:**
- Observe that the XCFramework artifact is generated properly.
- Follow testing instructions from WP-iOS PR.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.