### PR TITLE
Release 1.117.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,11 @@ Unreleased
 
 1.117.0
 ---
+* [*] Add empty fallback option for the BottomSheetSelectControl component [https://github.com/WordPress/gutenberg/pull/60333]
+* [*] Fix Quote Block styles [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6790]
+* [*] Prevent passing potential false values to the onPress prop [https://github.com/WordPress/gutenberg/pull/60595]
+* [*] ColorPalette - Check for ScrollView reference [https://github.com/WordPress/gutenberg/pull/60562]
+* [*] Raw Handling - msListIgnore - Check attributes are valid [https://github.com/WordPress/gutenberg/pull/60375]
 * [*] Analytics - Add support to register block insertions from the clipboard [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6801]
 
 1.116.0

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,8 @@
 Unreleased
 ---
+
+1.117.0
+---
 * [*] Analytics - Add support to register block insertions from the clipboard [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6801]
 
 1.116.0

--- a/ios-xcframework/Podfile.lock
+++ b/ios-xcframework/Podfile.lock
@@ -1104,7 +1104,7 @@ PODS:
     - React-RCTImage
   - RNSVG (14.0.0):
     - React-Core
-  - RNTAztecView (1.116.0):
+  - RNTAztecView (1.117.0):
     - React-Core
     - WordPress-Aztec-iOS (= 1.19.11)
   - SDWebImage (5.11.1):
@@ -1399,7 +1399,7 @@ SPEC CHECKSUMS:
   RNReanimated: f705119af7f77c961122a09adbfdf3dd38ce6a60
   RNScreens: d07e03170921286b65f07e7b2a3aa8300f61f2ec
   RNSVG: eb0b170443191e4a1af53b9bd17d1f2fbd1ba152
-  RNTAztecView: 15c61330fdc47174997d858975d92e62891e5ba3
+  RNTAztecView: e161e7402f1e64e37d4fe1474a73845f0fc1efe9
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "gutenberg-mobile",
-	"version": "1.116.0",
+	"version": "1.117.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "gutenberg-mobile",
-			"version": "1.116.0",
+			"version": "1.117.0",
 			"hasInstallScript": true,
 			"devDependencies": {
 				"@babel/core": "^7.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg-mobile",
-	"version": "1.116.0",
+	"version": "1.117.0",
 	"private": true,
 	"config": {
 		"jsfiles": "./*.js src/*.js src/**/*.js src/**/**/*.js",


### PR DESCRIPTION
Release for Gutenberg Mobile 1.117.0

## Related PRs

- https://github.com/WordPress/gutenberg/pull/60698
- https://github.com/wordpress-mobile/WordPress-Android/pull/20629
- https://github.com/wordpress-mobile/WordPress-iOS/pull/23000

## Changes

- https://github.com/WordPress/gutenberg/pull/60333
- https://github.com/WordPress/gutenberg/pull/60375
- https://github.com/WordPress/gutenberg/pull/60476
- https://github.com/WordPress/gutenberg/pull/60562
- https://github.com/WordPress/gutenberg/pull/60595
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6801

## Test plan

Once the installable builds of the main apps are ready, perform a quick smoke test of the editor on both iOS and Android to verify it launches without crashing. We will perform additional testing after the main apps cut their releases.

## Release Submission Checklist

- [ ] Verify Items from test plan have been completed
- [x] Check if `RELEASE-NOTES.txt` is updated with all the changes that made it to the release. Replace `Unreleased` section with the release version and create a new `Unreleased` section.
- [x] Check if `gutenberg/packages/react-native-editor/CHANGELOG.md` is updated with all the changes that made it to the release. Replace `## Unreleased` with the release version and create a new `## Unreleased`.
- [x] Bundle package of the release is updated.