### PR TITLE
Update package-lock.json with the recent React upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
 		},
 		"gutenberg/packages/babel-plugin-import-jsx-pragma": {
 			"name": "@wordpress/babel-plugin-import-jsx-pragma",
-			"version": "4.35.0",
+			"version": "4.39.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -75,7 +75,7 @@
 		},
 		"gutenberg/packages/babel-preset-default": {
 			"name": "@wordpress/babel-preset-default",
-			"version": "7.36.0",
+			"version": "7.40.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -90,7 +90,7 @@
 				"@wordpress/warning": "file:../warning",
 				"browserslist": "^4.21.10",
 				"core-js": "^3.31.0",
-				"react": "^18.2.0"
+				"react": "^18.3.0"
 			},
 			"engines": {
 				"node": ">=14"
@@ -98,7 +98,7 @@
 		},
 		"gutenberg/packages/browserslist-config": {
 			"name": "@wordpress/browserslist-config",
-			"version": "5.35.0",
+			"version": "5.39.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -138,7 +138,7 @@
 		},
 		"gutenberg/packages/eslint-plugin": {
 			"name": "@wordpress/eslint-plugin",
-			"version": "17.9.0",
+			"version": "17.13.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -271,7 +271,7 @@
 		},
 		"gutenberg/packages/prettier-config": {
 			"name": "@wordpress/prettier-config",
-			"version": "3.9.0",
+			"version": "3.13.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -283,7 +283,7 @@
 		},
 		"gutenberg/packages/warning": {
 			"name": "@wordpress/warning",
-			"version": "2.52.0",
+			"version": "2.56.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -21308,9 +21308,9 @@
 			}
 		},
 		"node_modules/react": {
-			"version": "18.2.0",
-			"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-			"integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
 			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
@@ -31388,7 +31388,7 @@
 				"@wordpress/warning": "file:../warning",
 				"browserslist": "^4.21.10",
 				"core-js": "^3.31.0",
-				"react": "^18.2.0"
+				"react": "^18.3.0"
 			}
 		},
 		"@wordpress/browserslist-config": {
@@ -41383,9 +41383,9 @@
 			}
 		},
 		"react": {
-			"version": "18.2.0",
-			"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-			"integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
 			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0"

--- a/src/test/videopress/edit.js
+++ b/src/test/videopress/edit.js
@@ -209,7 +209,9 @@ describe( "Update VideoPress block's settings", () => {
 	 */
 	RATING_OPTIONS.forEach( ( option, index ) => {
 		// Skip the default setting, as it is already selected
-		if ( index === 0 ) return;
+		if ( index === 0 ) {
+			return;
+		}
 
 		it( `should update Privacy and Rating section's rating setting to ${ option }`, async () => {
 			await selectAndOpenBlockSettings( screen );
@@ -229,7 +231,9 @@ describe( "Update VideoPress block's settings", () => {
 	 */
 	PRIVACY_OPTIONS.forEach( ( option, index ) => {
 		// Skip the default setting, as it is already selected
-		if ( index === 0 ) return;
+		if ( index === 0 ) {
+			return;
+		}
 
 		it( `should update Privacy and Rating section's privacy setting to ${ option }`, async () => {
 			await selectAndOpenBlockSettings( screen );


### PR DESCRIPTION
This PR updates the `package-lock.json` file with the recent updates in https://github.com/WordPress/gutenberg/pull/61202

It also updates the VideoPress test with the recently enabled ESLint rule in https://github.com/WordPress/gutenberg/pull/61204

To test all CI checks should pass.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
