### PR TITLE
Include Block experiments classname package

### DIFF
--- a/bin/run-block-experiments-command.sh
+++ b/bin/run-block-experiments-command.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -Eeuo pipefail
 
+local_run_script="${GBM_LOCAL_BLOCK_EXPERIMENTS_RUN_SCRIPT:-./bin/run-block-experiments-command.sh.local}"
+
+if [ -e "$local_run_script" ]
+then
+  source "$local_run_script"
+  exit 0
+fi
+
 # Check if nvm is installed
 [ -z "$NVM_DIR" ] && NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"

--- a/bin/run-block-experiments-command.sh
+++ b/bin/run-block-experiments-command.sh
@@ -13,7 +13,7 @@ command -v nvm >/dev/null 2>&1 || {
 pushd block-experiments
 
 # Set up node requirement for block-experiments
-nvm use
+nvm install
 
 # Check if Yarn is installed
 if ! command -v yarn &> /dev/null

--- a/bin/run-block-experiments-command.sh
+++ b/bin/run-block-experiments-command.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+# Check if nvm is installed
+[ -z "$NVM_DIR" ] && NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+command -v nvm >/dev/null 2>&1 || {
+  echo "nvm is not installed or cannot be sourced from $NVM_DIR/nvm.sh. Please verify that "'$NVM_DIR'" points to the .nvm directory."
+  exit 1
+}
+
+pushd block-experiments
+
+# Set up node requirement for block-experiments
+nvm use
+
+# Check if Yarn is installed
+if ! command -v yarn &> /dev/null
+then
+    echo "Yarn is not installed. Setting up Yarn..."
+    # Set up Yarn using npx
+    npx --silent yarn set version latest
+    echo "Yarn has been set up."
+else
+    echo "Yarn is already installed."
+fi
+
+# Install only regular dependencies (excluding devDependencies)
+npx --silent yarn install --production

--- a/metro.config.js
+++ b/metro.config.js
@@ -18,7 +18,12 @@ const gutenbergMetroConfigCopy = {
 		sourceExts: [ 'js', 'cjs', 'jsx', 'json', 'scss', 'sass', 'ts', 'tsx' ],
 		extraNodeModules,
 		// Exclude `ios-xcframework` folder to avoid conflicts with packages contained in Pods.
-		blockList: [ /ios-xcframework\/.*/ ],
+		blockList: [
+			/ios-xcframework\/.*/,
+			// Exclude all modules in the "block-experiments" folder except for "classnames",
+			// this prevents issues with older references if we allow all packages.
+			/block-experiments\/node_modules\/(?!classnames)/,
+		],
 	},
 };
 

--- a/metro.config.js
+++ b/metro.config.js
@@ -20,9 +20,10 @@ const gutenbergMetroConfigCopy = {
 		// Exclude `ios-xcframework` folder to avoid conflicts with packages contained in Pods.
 		blockList: [
 			/ios-xcframework\/.*/,
-			// Exclude all modules in the "block-experiments" folder except for "classnames",
-			// this prevents issues with older references if we allow all packages.
-			/block-experiments\/node_modules\/(?!classnames)/,
+			// Exclude all @wordpress packages in the "block-experiments" folder,
+			// this prevents issues with older versions of native files.
+			// We are importing Gutenberg directly so all packages are already available.
+			/block-experiments\/node_modules\/@wordpress\/.*/,
 		],
 	},
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
 		},
 		"gutenberg/packages/babel-plugin-import-jsx-pragma": {
 			"name": "@wordpress/babel-plugin-import-jsx-pragma",
-			"version": "4.39.0",
+			"version": "4.40.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -75,7 +75,7 @@
 		},
 		"gutenberg/packages/babel-preset-default": {
 			"name": "@wordpress/babel-preset-default",
-			"version": "7.40.0",
+			"version": "7.41.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -98,7 +98,7 @@
 		},
 		"gutenberg/packages/browserslist-config": {
 			"name": "@wordpress/browserslist-config",
-			"version": "5.39.0",
+			"version": "5.40.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -138,7 +138,7 @@
 		},
 		"gutenberg/packages/eslint-plugin": {
 			"name": "@wordpress/eslint-plugin",
-			"version": "17.13.0",
+			"version": "18.0.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -271,7 +271,7 @@
 		},
 		"gutenberg/packages/prettier-config": {
 			"name": "@wordpress/prettier-config",
-			"version": "3.13.0",
+			"version": "3.14.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -283,7 +283,7 @@
 		},
 		"gutenberg/packages/warning": {
 			"name": "@wordpress/warning",
-			"version": "2.56.0",
+			"version": "2.57.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"webdriverio": "8.16.20"
 	},
 	"scripts": {
-		"postinstall": "patch-package && npm run clean:gutenberg:distclean && npm ci --prefix gutenberg && npm run i18n:check-cache && ./bin/run-jetpack-command.sh \"install --ignore-scripts\"",
+		"postinstall": "patch-package && npm run clean:gutenberg:distclean && npm ci --prefix gutenberg && ./bin/run-block-experiments-command.sh && npm run i18n:check-cache && ./bin/run-jetpack-command.sh \"install --ignore-scripts\"",
 		"start": "echo \"\\x1b[33mThe start command is not available in this project. It is strongly recommended to use \\x1b[1:33mstart:reset\\x1b[0m\\x1b[33m to perform some cleanup when starting the metro bundler.\nOr you may use \\x1b[1:33mstart:quick\\x1b[0m\\x1b[33m for a quicker startup, but this may lead to unexpected javascript errors when running the app.\\x1b[0m\"",
 		"start:reset": "npm run core clean:runtime && npm run start:quick -- --reset-cache",
 		"start:quick": "npm run core start:quick -- -- -- --config ../../../metro.config.js",


### PR DESCRIPTION
**Related PR:**
- https://github.com/WordPress/gutenberg/pull/61616

This PR adds a new step to install dependencies of the `block-experiments` submodule. Currently, we were relying on Gutenberg to have all needed dependencies for this submodule, but since the recent removal of the `classnames` package, it makes sense this submodule also installs its dependencies as we do it for Jetpack and Gutenberg.

It adds a new bash file to install the `block-experiments` dependencies, which will be called in the `postinstall` script in Gutenberg Mobile's `package.json`

A new item was added to Metro's block list, to not include files from the `@wordpress` package from its dependencies, the reason for this is to solve problems with bringing old references of older versions of the `native` files. This shouldn't affect anything as we are loading these packages from Gutenberg already.

To test CI checks should pass.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
