### PR TITLE
Release 1.119.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,8 @@
 Unreleased
 ---
+
+1.119.0
+---
 * [*] Cancel failed or in progress uploads if the media block is removed [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6841]
 * [internal] Upgrade target sdk version to Android API 34 [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6870]
 * [internal] Remove circular dependencies within the components package [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6874]

--- a/ios-xcframework/Podfile.lock
+++ b/ios-xcframework/Podfile.lock
@@ -1104,7 +1104,7 @@ PODS:
     - React-RCTImage
   - RNSVG (14.0.0):
     - React-Core
-  - RNTAztecView (1.118.0):
+  - RNTAztecView (1.119.0):
     - React-Core
     - WordPress-Aztec-iOS (= 1.19.11)
   - SDWebImage (5.11.1):
@@ -1399,7 +1399,7 @@ SPEC CHECKSUMS:
   RNReanimated: f705119af7f77c961122a09adbfdf3dd38ce6a60
   RNScreens: d07e03170921286b65f07e7b2a3aa8300f61f2ec
   RNSVG: eb0b170443191e4a1af53b9bd17d1f2fbd1ba152
-  RNTAztecView: caf0e76a80867970eaa182cf9bf2d5b3c89285c5
+  RNTAztecView: c0a124a24b01a96ceeac8c0dcdc461f2d06e13f2
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "gutenberg-mobile",
-	"version": "1.118.0",
+	"version": "1.119.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "gutenberg-mobile",
-			"version": "1.118.0",
+			"version": "1.119.0",
 			"hasInstallScript": true,
 			"devDependencies": {
 				"@babel/core": "^7.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg-mobile",
-	"version": "1.118.0",
+	"version": "1.119.0",
 	"private": true,
 	"config": {
 		"jsfiles": "./*.js src/*.js src/**/*.js src/**/**/*.js",


### PR DESCRIPTION
Release for Gutenberg Mobile 1.119.0

## Related PRs

- https://github.com/WordPress/gutenberg/pull/61910
- https://github.com/wordpress-mobile/WordPress-Android/pull/20869
- https://github.com/wordpress-mobile/WordPress-iOS/pull/23249

## Changes
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6874
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6870
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6861
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6842
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6841

<!-- To determine the changes you can check the RELEASE-NOTES.txt and gutenberg/packages/react-native-editor/CHANGELOG.md files and cross check with the list of commits that are part of the PR -->
## Test plan

Once the installable builds of the main apps are ready, perform a quick smoke test of the editor on both iOS and Android to verify it launches without crashing. We will perform additional testing after the main apps cut their releases.

## Release Submission Checklist

- [ ] Verify Items from test plan have been completed
- [x] Check if `RELEASE-NOTES.txt` is updated with all the changes that made it to the release. Replace `Unreleased` section with the release version and create a new `Unreleased` section.
- [x] Check if `gutenberg/packages/react-native-editor/CHANGELOG.md` is updated with all the changes that made it to the release. Replace `## Unreleased` with the release version and create a new `## Unreleased`.
- [x] Bundle package of the release is updated.