### PR TITLE
 Prevent deleting content when backspacing in the first Paragraph block

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 Unreleased
 ---
+* [*] Prevent deleting content when backspacing in the first Paragraph block [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6894]
 
 1.119.0
 ---


### PR DESCRIPTION
**Related PRs:**
- https://github.com/WordPress/gutenberg/pull/62069

To test:

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
