### PR TITLE
Improve List block onSplit to avoid hiding the keyboard on enter

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 Unreleased
 ---
+* [*] Prevent hiding the keyboard when creating new list items [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6922]
 
 1.120.0
 ---


### PR DESCRIPTION
**Related PRs:**
- https://github.com/WordPress/gutenberg/pull/62446
- https://github.com/wordpress-mobile/WordPress-Android/pull/20962
- https://github.com/wordpress-mobile/WordPress-iOS/pull/23336

To test check the Gutenberg PR description.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
