### PR TITLE
Remove `themes` from the allowed API endpoint list

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@ Unreleased
 * [*] Prevent hiding the keyboard when creating new list items [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6922]
 * [*] Fix issue when pasting HTML content [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6933]
 * [**] Add support prefix transforms [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6932]
+* [*] Remove themes from the allowed API endpoint list [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6967]
 
 1.120.1
 ---


### PR DESCRIPTION
**Related PRs:**
- https://github.com/WordPress/gutenberg/pull/63183
- https://github.com/wordpress-mobile/WordPress-Android/pull/21032

To test check the Gutenberg PR description.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
