### PR TITLE
Remove Gallery Block V1 and other experimental flags

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@ Unreleased
 * [*] Fix issue when pasting HTML content [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6933]
 * [**] Add support prefix transforms [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6932]
 * [*] Remove themes from the allowed API endpoint list [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6967]
+* [*] Remove Gallery Block V1 and other experimental flags  [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6973]
 
 1.120.1
 ---


### PR DESCRIPTION
**Related PRs:**
- https://github.com/WordPress/gutenberg/pull/63285

To test:

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes [more info](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/Release-notes.md) and have added them to [RELEASE-NOTES.txt](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/RELEASE-NOTES.txt) if necessary.
